### PR TITLE
AI coach: exponential backoff retry for transient errors

### DIFF
--- a/Packages/GymBroCore/Sources/GymBroCore/Services/AI/AzureOpenAICoachService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/AI/AzureOpenAICoachService.swift
@@ -137,7 +137,9 @@ public final class AzureOpenAICoachService: AICoachService {
         switch http.statusCode {
         case 200...299:
             return
-        case 401:
+        case 400:
+            throw AICoachError.invalidConfiguration("Bad request (HTTP 400)")
+        case 401, 403:
             throw AICoachError.authenticationFailed
         case 429:
             throw AICoachError.rateLimited
@@ -224,6 +226,7 @@ public enum AICoachError: LocalizedError {
     case serverError(Int)
     case emptyResponse
     case offlineUnavailable
+    case retriesExhausted(lastError: Error)
 
     public var errorDescription: String? {
         switch self {
@@ -234,6 +237,67 @@ public enum AICoachError: LocalizedError {
         case .serverError(let code): return "Server error (HTTP \(code)). Try again later."
         case .emptyResponse: return "AI returned an empty response."
         case .offlineUnavailable: return "This feature requires an internet connection."
+        case .retriesExhausted: return "Unable to reach AI coach after multiple attempts. Using offline mode."
         }
     }
+
+    /// Whether this error is transient and worth retrying.
+    public var isTransient: Bool {
+        switch self {
+        case .rateLimited, .emptyResponse:
+            return true
+        case .serverError(let code):
+            return [500, 502, 503].contains(code)
+        case .networkError:
+            return true
+        case .authenticationFailed, .invalidConfiguration,
+             .offlineUnavailable, .retriesExhausted:
+            return false
+        }
+    }
+
+    /// Classify any `Error` as transient for retry decisions.
+    /// Handles both `AICoachError` and Foundation `URLError` cases.
+    public static func isTransientError(_ error: Error) -> Bool {
+        if let coachError = error as? AICoachError {
+            return coachError.isTransient
+        }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut, .networkConnectionLost, .notConnectedToInternet,
+                 .cannotConnectToHost, .dnsLookupFailed:
+                return true
+            default:
+                return false
+            }
+        }
+        return false
+    }
+}
+
+// MARK: - Retry Policy
+
+/// Configures exponential backoff retry behavior for transient AI coach errors.
+public struct RetryPolicy: Sendable {
+    public let maxAttempts: Int
+    public let delays: [Duration]
+
+    public init(
+        maxAttempts: Int = 3,
+        delays: [Duration] = [.milliseconds(100), .seconds(1), .seconds(5)]
+    ) {
+        self.maxAttempts = maxAttempts
+        self.delays = delays
+    }
+
+    /// Returns the backoff delay for the given attempt (0-indexed).
+    public func delay(forAttempt attempt: Int) -> Duration {
+        guard attempt < delays.count else {
+            return delays.last ?? .seconds(5)
+        }
+        return delays[attempt]
+    }
+
+    /// Default policy: 100ms → 1s → 5s, 3 attempts max.
+    public static let `default` = RetryPolicy()
 }

--- a/Packages/GymBroCore/Sources/GymBroCore/Services/AI/RetryingAICoachService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/AI/RetryingAICoachService.swift
@@ -1,0 +1,133 @@
+import Foundation
+import os
+
+/// Decorator that wraps an `AICoachService` with exponential backoff retry logic.
+///
+/// On transient errors (network timeout, 429, 500, 502, 503), retries up to
+/// `RetryPolicy.maxAttempts` times with configurable backoff delays.
+/// Falls back to `DeterministicCoachFallback` after all retries are exhausted.
+/// Non-transient errors (401, 403, 400) fail immediately without retry.
+public final class RetryingAICoachService: AICoachService {
+
+    private let primary: AICoachService
+    private let fallback: AICoachService
+    private let retryPolicy: RetryPolicy
+    private let logger = Logger(
+        subsystem: "com.gymbro.core",
+        category: "RetryingAICoachService"
+    )
+
+    public init(
+        primary: AICoachService,
+        fallback: AICoachService = DeterministicCoachFallback(),
+        retryPolicy: RetryPolicy = .default
+    ) {
+        self.primary = primary
+        self.fallback = fallback
+        self.retryPolicy = retryPolicy
+    }
+
+    // MARK: - AICoachService
+
+    public func sendMessage(_ message: String, context: CoachContext) async throws -> String {
+        var lastError: Error?
+
+        for attempt in 0..<retryPolicy.maxAttempts {
+            do {
+                try Task.checkCancellation()
+                return try await primary.sendMessage(message, context: context)
+            } catch {
+                lastError = error
+
+                guard AICoachError.isTransientError(error) else {
+                    throw error
+                }
+
+                logger.warning(
+                    "Transient error on attempt \(attempt + 1)/\(self.retryPolicy.maxAttempts): \(error.localizedDescription)"
+                )
+
+                // Don't sleep after the last failed attempt
+                if attempt < retryPolicy.maxAttempts - 1 {
+                    let delay = retryPolicy.delay(forAttempt: attempt)
+                    try await Task.sleep(for: delay)
+                }
+            }
+        }
+
+        // All retries exhausted — fall back to offline rule engine
+        logger.error("All \(self.retryPolicy.maxAttempts) retries exhausted. Falling back to offline coach.")
+        return try await fallback.sendMessage(message, context: context)
+    }
+
+    public func streamMessage(_ message: String, context: CoachContext) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                var lastError: Error?
+
+                for attempt in 0..<self.retryPolicy.maxAttempts {
+                    do {
+                        try Task.checkCancellation()
+
+                        let stream = self.primary.streamMessage(message, context: context)
+                        var receivedContent = false
+
+                        for try await token in stream {
+                            receivedContent = true
+                            continuation.yield(token)
+                        }
+
+                        if receivedContent {
+                            continuation.finish()
+                            return
+                        }
+                    } catch {
+                        lastError = error
+
+                        guard AICoachError.isTransientError(error) else {
+                            continuation.finish(throwing: error)
+                            return
+                        }
+
+                        self.logger.warning(
+                            "Stream transient error on attempt \(attempt + 1)/\(self.retryPolicy.maxAttempts): \(error.localizedDescription)"
+                        )
+
+                        if attempt < self.retryPolicy.maxAttempts - 1 {
+                            // Signal reconnection status to the user
+                            continuation.yield("\n⟳ Reconnecting...\n")
+
+                            let delay = self.retryPolicy.delay(forAttempt: attempt)
+                            do {
+                                try await Task.sleep(for: delay)
+                            } catch {
+                                continuation.finish(throwing: error)
+                                return
+                            }
+                        }
+                    }
+                }
+
+                // All retries exhausted — stream from offline fallback
+                self.logger.error(
+                    "All \(self.retryPolicy.maxAttempts) stream retries exhausted. Falling back to offline coach."
+                )
+
+                continuation.yield("\n📡 Switching to offline mode...\n")
+                let fallbackStream = self.fallback.streamMessage(message, context: context)
+                do {
+                    for try await token in fallbackStream {
+                        continuation.yield(token)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+}

--- a/Packages/GymBroCore/Tests/GymBroCoreTests/AICoachErrorAndRateLimiterTests.swift
+++ b/Packages/GymBroCore/Tests/GymBroCoreTests/AICoachErrorAndRateLimiterTests.swift
@@ -165,4 +165,223 @@ final class AICoachErrorAndRateLimiterTests: XCTestCase {
         XCTAssertEqual(snap.weekNumber, 3)
         XCTAssertEqual(snap.frequencyPerWeek, 4)
     }
+
+    // MARK: - AICoachError Transient Classification
+
+    func testTransientErrors_areClassifiedCorrectly() {
+        XCTAssertTrue(AICoachError.rateLimited.isTransient)
+        XCTAssertTrue(AICoachError.emptyResponse.isTransient)
+        XCTAssertTrue(AICoachError.serverError(500).isTransient)
+        XCTAssertTrue(AICoachError.serverError(502).isTransient)
+        XCTAssertTrue(AICoachError.serverError(503).isTransient)
+        XCTAssertTrue(AICoachError.networkError("timeout").isTransient)
+    }
+
+    func testNonTransientErrors_areClassifiedCorrectly() {
+        XCTAssertFalse(AICoachError.authenticationFailed.isTransient)
+        XCTAssertFalse(AICoachError.invalidConfiguration("bad").isTransient)
+        XCTAssertFalse(AICoachError.offlineUnavailable.isTransient)
+        XCTAssertFalse(AICoachError.serverError(401).isTransient)
+        XCTAssertFalse(AICoachError.serverError(403).isTransient)
+        XCTAssertFalse(AICoachError.serverError(400).isTransient)
+    }
+
+    func testRetriesExhausted_description() {
+        let inner = AICoachError.serverError(503)
+        let error = AICoachError.retriesExhausted(lastError: inner)
+        XCTAssertTrue(error.localizedDescription.contains("multiple attempts"))
+        XCTAssertFalse(error.isTransient)
+    }
+
+    func testIsTransientError_handlesURLError() {
+        let timeout = URLError(.timedOut)
+        XCTAssertTrue(AICoachError.isTransientError(timeout))
+
+        let connectionLost = URLError(.networkConnectionLost)
+        XCTAssertTrue(AICoachError.isTransientError(connectionLost))
+
+        let cancelled = URLError(.cancelled)
+        XCTAssertFalse(AICoachError.isTransientError(cancelled))
+    }
+
+    // MARK: - RetryPolicy
+
+    func testRetryPolicy_defaultValues() {
+        let policy = RetryPolicy.default
+        XCTAssertEqual(policy.maxAttempts, 3)
+        XCTAssertEqual(policy.delays.count, 3)
+    }
+
+    func testRetryPolicy_delayForAttempt() {
+        let policy = RetryPolicy.default
+        XCTAssertEqual(policy.delay(forAttempt: 0), .milliseconds(100))
+        XCTAssertEqual(policy.delay(forAttempt: 1), .seconds(1))
+        XCTAssertEqual(policy.delay(forAttempt: 2), .seconds(5))
+        // Out of bounds clamps to last
+        XCTAssertEqual(policy.delay(forAttempt: 99), .seconds(5))
+    }
+
+    func testRetryPolicy_customValues() {
+        let policy = RetryPolicy(maxAttempts: 2, delays: [.milliseconds(50), .milliseconds(200)])
+        XCTAssertEqual(policy.maxAttempts, 2)
+        XCTAssertEqual(policy.delay(forAttempt: 0), .milliseconds(50))
+        XCTAssertEqual(policy.delay(forAttempt: 1), .milliseconds(200))
+    }
+
+    // MARK: - RetryingAICoachService
+
+    func testRetry_succeedsAfterTransientFailure() async throws {
+        let mock = MockAICoachService(
+            responses: [
+                .failure(AICoachError.serverError(503)),
+                .success("recovered response")
+            ]
+        )
+        let retrying = RetryingAICoachService(
+            primary: mock,
+            retryPolicy: RetryPolicy(maxAttempts: 3, delays: [.milliseconds(10), .milliseconds(10), .milliseconds(10)])
+        )
+
+        let result = try await retrying.sendMessage("test", context: CoachContext())
+        XCTAssertEqual(result, "recovered response")
+        XCTAssertEqual(mock.callCount, 2)
+    }
+
+    func testRetry_failsImmediatelyOnAuthError() async {
+        let mock = MockAICoachService(
+            responses: [.failure(AICoachError.authenticationFailed)]
+        )
+        let retrying = RetryingAICoachService(
+            primary: mock,
+            retryPolicy: RetryPolicy(maxAttempts: 3, delays: [.milliseconds(10), .milliseconds(10), .milliseconds(10)])
+        )
+
+        do {
+            _ = try await retrying.sendMessage("test", context: CoachContext())
+            XCTFail("Should have thrown immediately")
+        } catch let error as AICoachError {
+            if case .authenticationFailed = error {
+                // Expected — no retry
+            } else {
+                XCTFail("Expected .authenticationFailed, got \(error)")
+            }
+        }
+        XCTAssertEqual(mock.callCount, 1, "Auth errors must not be retried")
+    }
+
+    func testRetry_fallsBackAfterAllRetriesExhausted() async throws {
+        let mock = MockAICoachService(
+            responses: [
+                .failure(AICoachError.serverError(502)),
+                .failure(AICoachError.serverError(502)),
+                .failure(AICoachError.serverError(502))
+            ]
+        )
+        let retrying = RetryingAICoachService(
+            primary: mock,
+            retryPolicy: RetryPolicy(maxAttempts: 3, delays: [.milliseconds(10), .milliseconds(10), .milliseconds(10)])
+        )
+
+        let result = try await retrying.sendMessage("rest time", context: CoachContext())
+        // DeterministicCoachFallback responds with rest time advice
+        XCTAssertTrue(result.contains("Rest") || result.contains("offline") || result.contains("Offline"))
+        XCTAssertEqual(mock.callCount, 3)
+    }
+
+    func testRetry_stream_succeedsAfterTransientFailure() async throws {
+        let mock = MockStreamingAICoachService(
+            streamResults: [
+                .failure(AICoachError.networkError("timeout")),
+                .success(["Hello", " world"])
+            ]
+        )
+        let retrying = RetryingAICoachService(
+            primary: mock,
+            retryPolicy: RetryPolicy(maxAttempts: 3, delays: [.milliseconds(10), .milliseconds(10), .milliseconds(10)])
+        )
+
+        var tokens: [String] = []
+        let stream = retrying.streamMessage("test", context: CoachContext())
+        for try await token in stream {
+            tokens.append(token)
+        }
+        XCTAssertTrue(tokens.contains("Hello"))
+        XCTAssertTrue(tokens.contains(" world"))
+    }
+
+    func testRetry_stream_failsImmediatelyOnNonTransient() async {
+        let mock = MockStreamingAICoachService(
+            streamResults: [.failure(AICoachError.authenticationFailed)]
+        )
+        let retrying = RetryingAICoachService(
+            primary: mock,
+            retryPolicy: RetryPolicy(maxAttempts: 3, delays: [.milliseconds(10), .milliseconds(10), .milliseconds(10)])
+        )
+
+        var caughtError: Error?
+        let stream = retrying.streamMessage("test", context: CoachContext())
+        do {
+            for try await _ in stream { }
+        } catch {
+            caughtError = error
+        }
+        XCTAssertNotNil(caughtError)
+        XCTAssertTrue(caughtError is AICoachError)
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Mock that returns pre-configured responses in order for sendMessage.
+private final class MockAICoachService: AICoachService {
+    private let responses: [Result<String, Error>]
+    private(set) var callCount = 0
+
+    init(responses: [Result<String, Error>]) {
+        self.responses = responses
+    }
+
+    func sendMessage(_ message: String, context: CoachContext) async throws -> String {
+        let index = min(callCount, responses.count - 1)
+        callCount += 1
+        return try responses[index].get()
+    }
+
+    func streamMessage(_ message: String, context: CoachContext) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+}
+
+/// Mock that returns pre-configured stream results in order for streamMessage.
+private final class MockStreamingAICoachService: AICoachService {
+    private let streamResults: [Result<[String], Error>]
+    private var streamCallCount = 0
+
+    init(streamResults: [Result<[String], Error>]) {
+        self.streamResults = streamResults
+    }
+
+    func sendMessage(_ message: String, context: CoachContext) async throws -> String {
+        "mock"
+    }
+
+    func streamMessage(_ message: String, context: CoachContext) -> AsyncThrowingStream<String, Error> {
+        let index = min(streamCallCount, streamResults.count - 1)
+        streamCallCount += 1
+        let result = streamResults[index]
+
+        return AsyncThrowingStream { continuation in
+            Task {
+                switch result {
+                case .success(let tokens):
+                    for token in tokens {
+                        continuation.yield(token)
+                    }
+                    continuation.finish()
+                case .failure(let error):
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds retry logic with exponential backoff to the AI coach streaming client, ensuring users don't see 'AI coach unavailable' on temporary network glitches.

### Changes

- **\RetryingAICoachService\** — Decorator wrapping any \AICoachService\ with configurable retry policy
- **Backoff schedule:** 100ms → 1s → 5s (3 attempts max)
- **Transient-only retries:** network timeout, 429, 500, 502, 503 + \URLError\ (timedOut, connectionLost, etc.)
- **Fail-fast on permanent errors:** 401, 403, 400 — no retry wasted
- **User feedback:** Yields \⟳ Reconnecting...\ during stream retries
- **Graceful fallback:** Falls back to \DeterministicCoachFallback\ (offline rule engine) after all retries exhausted
- **HTTP mapping fix:** 400 → \invalidConfiguration\, 403 → \uthenticationFailed\ (non-retryable)

### Tests Added

- Transient/non-transient error classification
- \RetryPolicy\ defaults and custom values
- Retry succeeds after transient failure
- Auth errors fail immediately (no retry)
- Fallback triggers after all retries exhausted
- Stream retry + stream fail-fast scenarios
- \URLError\ transient classification

Closes #52