### PR TITLE
Apple Watch companion — basic set logging from wrist

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -119,3 +119,15 @@
 **Testing Pattern:**
 - 11 test cases using in-memory SwiftData container. Tests cover: find/discard/cleanup service methods, ViewModel isActive lifecycle, cancel flow, set preservation on recovery, exercises ordering, and empty-state nil return.
 - PR #57 opened, closes #53.
+
+### 2026-04-07: Apple Watch Companion — Basic Set Logging (Issue #12)
+**Implementation highlights:**
+- **WatchConnectivityService** in GymBroCore: Bidirectional iPhone↔Watch communication via `WCSession`. Uses `updateApplicationContext` for latest-state delivery (workout state), `sendMessage` for real-time data (rest timer), and `transferUserInfo` for offline queuing (set completions).
+- **Lightweight transfer types**: `WatchWorkoutState`, `WatchSetCompletion`, `WatchRestTimerState` — all Codable/Sendable structs, no SwiftData dependency on Watch side.
+- **WatchWorkoutViewModel**: @Observable ViewModel with Digital Crown weight adjustment (`digitalCrownRotation` modifier with snap-to-step logic at 2.5kg increments), rest timer countdown via Task-based async, WKInterfaceDevice haptics.
+- **ActiveSetView**: Large touch targets (44pt minimum), high-contrast text, +/- buttons for weight/reps, Crown integration for hands-free weight adjustment.
+- **RestTimerWatchView**: Circular progress indicator with color transitions (blue→orange→red). Auto-switches tab when timer starts.
+- **WorkoutSummaryWatchView**: Post-workout stats display.
+- **Complications**: WidgetKit-based with circular and rectangular families. 30s refresh during active workout.
+- **Architecture**: GymBroCore Package.swift updated to support `.watchOS(.v10)`. Watch source files in `GymBroWatch/` — requires manual Xcode target setup.
+- **Pattern: Offline-resilient messaging** — Set completions use `transferUserInfo` when phone is unreachable.

--- a/GymBroWatch/Complications/WorkoutComplicationProvider.swift
+++ b/GymBroWatch/Complications/WorkoutComplicationProvider.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+import WidgetKit
+import GymBroCore
+
+/// WidgetKit complication definitions for GymBro on Apple Watch.
+/// Provides: active workout status and rest timer countdown.
+///
+/// NOTE: Requires WidgetKit extension target in Xcode project.
+/// This file defines the timeline provider and entry types
+/// for Watch complications.
+
+// MARK: - Timeline Entry
+
+struct WorkoutComplicationEntry: TimelineEntry {
+    let date: Date
+    let isWorkoutActive: Bool
+    let exerciseName: String?
+    let setNumber: Int?
+    let restTimerRemaining: Int?
+    let totalSetsCompleted: Int?
+
+    static var placeholder: WorkoutComplicationEntry {
+        WorkoutComplicationEntry(
+            date: Date(),
+            isWorkoutActive: true,
+            exerciseName: "Bench Press",
+            setNumber: 3,
+            restTimerRemaining: nil,
+            totalSetsCompleted: 8
+        )
+    }
+
+    static var empty: WorkoutComplicationEntry {
+        WorkoutComplicationEntry(
+            date: Date(),
+            isWorkoutActive: false,
+            exerciseName: nil,
+            setNumber: nil,
+            restTimerRemaining: nil,
+            totalSetsCompleted: nil
+        )
+    }
+}
+
+// MARK: - Timeline Provider
+
+struct WorkoutComplicationProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WorkoutComplicationEntry {
+        .placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (WorkoutComplicationEntry) -> Void) {
+        completion(currentEntry())
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WorkoutComplicationEntry>) -> Void) {
+        let entry = currentEntry()
+        // Refresh every 30 seconds during active workout, otherwise every 15 minutes
+        let refreshInterval: TimeInterval = entry.isWorkoutActive ? 30 : 900
+        let nextUpdate = Date().addingTimeInterval(refreshInterval)
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+
+    private func currentEntry() -> WorkoutComplicationEntry {
+        let state = WatchConnectivityService.shared.currentWorkoutState
+        let timerState = WatchConnectivityService.shared.currentRestTimerState
+
+        guard let state, state.isActive else {
+            return .empty
+        }
+
+        return WorkoutComplicationEntry(
+            date: Date(),
+            isWorkoutActive: true,
+            exerciseName: state.exerciseName,
+            setNumber: state.setNumber,
+            restTimerRemaining: timerState?.isActive == true ? timerState?.remainingSeconds : nil,
+            totalSetsCompleted: state.totalSetsCompleted
+        )
+    }
+}
+
+// MARK: - Complication Views
+
+/// Circular complication: shows workout status icon or rest timer countdown.
+struct WorkoutCircularComplication: View {
+    let entry: WorkoutComplicationEntry
+
+    var body: some View {
+        if entry.isWorkoutActive {
+            if let remaining = entry.restTimerRemaining {
+                // Rest timer mode
+                ZStack {
+                    AccessoryWidgetBackground()
+                    VStack(spacing: 0) {
+                        Image(systemName: "timer")
+                            .font(.system(size: 10))
+                        Text("\(remaining)s")
+                            .font(.system(size: 14, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                    }
+                }
+            } else {
+                // Active workout mode
+                ZStack {
+                    AccessoryWidgetBackground()
+                    VStack(spacing: 0) {
+                        Image(systemName: "dumbbell.fill")
+                            .font(.system(size: 12))
+                        if let sets = entry.totalSetsCompleted {
+                            Text("\(sets)")
+                                .font(.system(size: 14, weight: .bold, design: .rounded))
+                        }
+                    }
+                }
+            }
+        } else {
+            // No active workout
+            ZStack {
+                AccessoryWidgetBackground()
+                Image(systemName: "dumbbell")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+/// Rectangular complication: shows exercise name, set number, and status.
+struct WorkoutRectangularComplication: View {
+    let entry: WorkoutComplicationEntry
+
+    var body: some View {
+        if entry.isWorkoutActive {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Image(systemName: "dumbbell.fill")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.green)
+                    Text("GymBro")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+
+                if let name = entry.exerciseName {
+                    Text(name)
+                        .font(.system(size: 12, weight: .bold, design: .rounded))
+                        .lineLimit(1)
+                }
+
+                HStack(spacing: 8) {
+                    if let setNum = entry.setNumber {
+                        Text("Set \(setNum)")
+                            .font(.system(size: 10))
+                    }
+                    if let remaining = entry.restTimerRemaining {
+                        Text("Rest: \(remaining)s")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+        } else {
+            HStack(spacing: 6) {
+                Image(systemName: "dumbbell")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                Text("No Active Workout")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Widget Bundle
+
+struct GymBroWatchWidgets: WidgetBundle {
+    var body: some Widget {
+        WorkoutStatusWidget()
+    }
+}
+
+struct WorkoutStatusWidget: Widget {
+    let kind = "com.gymbro.workout-status"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(
+            kind: kind,
+            provider: WorkoutComplicationProvider()
+        ) { entry in
+            WorkoutCircularComplication(entry: entry)
+        }
+        .configurationDisplayName("Workout Status")
+        .description("Shows your active workout status and rest timer.")
+        .supportedFamilies([
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline
+        ])
+    }
+}

--- a/GymBroWatch/GymBroWatchApp.swift
+++ b/GymBroWatch/GymBroWatchApp.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import WatchConnectivity
+import GymBroCore
+
+@main
+struct GymBroWatchApp: App {
+    @State private var connectivityService = WatchConnectivityService.shared
+
+    var body: some Scene {
+        WindowGroup {
+            WatchContentView()
+                .task {
+                    connectivityService.activate()
+                }
+        }
+    }
+}
+
+/// Root view: shows active workout UI when a workout is in progress,
+/// otherwise shows a waiting state.
+struct WatchContentView: View {
+    @State private var connectivityService = WatchConnectivityService.shared
+
+    var body: some View {
+        Group {
+            if let workoutState = connectivityService.currentWorkoutState,
+               workoutState.isActive {
+                WatchWorkoutContainerView(initialState: workoutState)
+            } else if connectivityService.workoutDidEnd {
+                WatchWorkoutEndedView()
+            } else {
+                WatchIdleView()
+            }
+        }
+    }
+}
+
+// MARK: - Idle State
+
+struct WatchIdleView: View {
+    @State private var connectivityService = WatchConnectivityService.shared
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "dumbbell.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.blue)
+                .accessibilityHidden(true)
+
+            Text("GymBro")
+                .font(.headline)
+
+            Text("Start a workout\non your iPhone")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if connectivityService.isReachable {
+                Label("iPhone Connected", systemImage: "iphone")
+                    .font(.caption2)
+                    .foregroundStyle(.green)
+            } else {
+                Label("iPhone Not Reachable", systemImage: "iphone.slash")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+}
+
+// MARK: - Workout Ended
+
+struct WatchWorkoutEndedView: View {
+    @State private var connectivityService = WatchConnectivityService.shared
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 40))
+                .foregroundStyle(.green)
+                .accessibilityHidden(true)
+
+            Text("Workout Complete")
+                .font(.headline)
+
+            Text("Great session! 💪")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("Dismiss") {
+                connectivityService.clearWorkoutEnded()
+            }
+            .font(.caption)
+        }
+    }
+}
+
+// MARK: - Workout Container (TabView for set logging / rest timer)
+
+struct WatchWorkoutContainerView: View {
+    let initialState: WatchWorkoutState
+
+    @State private var viewModel: WatchWorkoutViewModel
+    @State private var selectedTab: WatchTab = .activeSet
+
+    enum WatchTab: Hashable {
+        case activeSet
+        case restTimer
+    }
+
+    init(initialState: WatchWorkoutState) {
+        self.initialState = initialState
+        self._viewModel = State(initialValue: WatchWorkoutViewModel(state: initialState))
+    }
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            ActiveSetView(viewModel: viewModel)
+                .tag(WatchTab.activeSet)
+
+            RestTimerWatchView(viewModel: viewModel)
+                .tag(WatchTab.restTimer)
+        }
+        .tabViewStyle(.verticalPage)
+        .onChange(of: viewModel.isRestTimerActive) { _, isActive in
+            if isActive {
+                selectedTab = .restTimer
+            }
+        }
+    }
+}

--- a/GymBroWatch/ViewModels/WatchWorkoutViewModel.swift
+++ b/GymBroWatch/ViewModels/WatchWorkoutViewModel.swift
@@ -1,0 +1,219 @@
+import Foundation
+import WatchKit
+import Observation
+import GymBroCore
+
+/// ViewModel for the Watch workout experience.
+/// Manages set logging state, Digital Crown weight adjustment,
+/// rest timer countdown, and haptic feedback.
+@MainActor
+@Observable
+final class WatchWorkoutViewModel {
+    // MARK: - Workout State
+
+    private(set) var workoutId: String
+    private(set) var exerciseName: String
+    private(set) var exerciseCategory: String
+    private(set) var setNumber: Int
+    var weight: Double
+    var reps: Int
+    private(set) var totalSetsCompleted: Int
+    private(set) var totalVolume: Double
+    private(set) var workoutStartTime: Date
+
+    // MARK: - Rest Timer
+
+    private(set) var isRestTimerActive: Bool = false
+    private(set) var restTimerRemaining: Int = 0
+    private(set) var restTimerTotal: Int = 0
+
+    // MARK: - UI State
+
+    private(set) var lastCompletedWeight: Double?
+    private(set) var lastCompletedReps: Int?
+
+    /// Digital Crown delta accumulator for weight adjustment.
+    var crownDelta: Double = 0
+
+    private var restTimerTask: Task<Void, Never>?
+    private let connectivityService = WatchConnectivityService.shared
+
+    // Weight step size (kg)
+    private let weightStep: Double = 2.5
+
+    // MARK: - Init
+
+    init(state: WatchWorkoutState) {
+        self.workoutId = state.workoutId
+        self.exerciseName = state.exerciseName
+        self.exerciseCategory = state.exerciseCategory
+        self.setNumber = state.setNumber
+        self.weight = state.targetWeight
+        self.reps = state.targetReps
+        self.totalSetsCompleted = state.totalSetsCompleted
+        self.totalVolume = state.totalVolume
+        self.workoutStartTime = state.workoutStartTime
+
+        observeConnectivityUpdates()
+    }
+
+    // MARK: - Actions
+
+    func completeSet() {
+        let completion = WatchSetCompletion(
+            workoutId: workoutId,
+            weightKg: weight,
+            reps: reps
+        )
+
+        connectivityService.sendSetCompletion(completion)
+
+        // Haptic confirmation
+        WKInterfaceDevice.current().play(.success)
+
+        lastCompletedWeight = weight
+        lastCompletedReps = reps
+
+        totalSetsCompleted += 1
+        totalVolume += weight * Double(reps)
+        setNumber += 1
+
+        startRestTimer()
+    }
+
+    func incrementWeight() {
+        weight = min(999, weight + weightStep)
+        WKInterfaceDevice.current().play(.click)
+    }
+
+    func decrementWeight() {
+        weight = max(0, weight - weightStep)
+        WKInterfaceDevice.current().play(.click)
+    }
+
+    func incrementReps() {
+        reps = min(999, reps + 1)
+        WKInterfaceDevice.current().play(.click)
+    }
+
+    func decrementReps() {
+        reps = max(0, reps - 1)
+        WKInterfaceDevice.current().play(.click)
+    }
+
+    /// Apply Digital Crown rotation to weight.
+    func applyCrownRotation(_ delta: Double) {
+        crownDelta += delta
+        // Snap to weight steps
+        if abs(crownDelta) >= 1.0 {
+            let steps = Int(crownDelta)
+            weight = max(0, min(999, weight + Double(steps) * weightStep))
+            crownDelta -= Double(steps)
+            WKInterfaceDevice.current().play(.click)
+        }
+    }
+
+    // MARK: - Rest Timer
+
+    func startRestTimer() {
+        let duration = defaultRestDuration()
+        restTimerTotal = duration
+        restTimerRemaining = duration
+        isRestTimerActive = true
+
+        restTimerTask?.cancel()
+        restTimerTask = Task { @MainActor in
+            while restTimerRemaining > 0 && !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                restTimerRemaining -= 1
+
+                if restTimerRemaining == 10 {
+                    WKInterfaceDevice.current().play(.notification)
+                }
+            }
+
+            if !Task.isCancelled {
+                // Timer complete — strong haptic
+                WKInterfaceDevice.current().play(.success)
+                WKInterfaceDevice.current().play(.success)
+                isRestTimerActive = false
+            }
+        }
+    }
+
+    func skipRestTimer() {
+        restTimerTask?.cancel()
+        restTimerTask = nil
+        isRestTimerActive = false
+        restTimerRemaining = 0
+    }
+
+    // MARK: - Helpers
+
+    var workoutDuration: TimeInterval {
+        Date().timeIntervalSince(workoutStartTime)
+    }
+
+    var formattedDuration: String {
+        let total = Int(workoutDuration)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    var restTimerProgress: Double {
+        guard restTimerTotal > 0 else { return 0 }
+        return Double(restTimerTotal - restTimerRemaining) / Double(restTimerTotal)
+    }
+
+    var formattedRestTime: String {
+        let minutes = restTimerRemaining / 60
+        let seconds = restTimerRemaining % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private func defaultRestDuration() -> Int {
+        switch exerciseCategory {
+        case "compound": return 180
+        case "isolation": return 90
+        case "accessory": return 60
+        default: return 120
+        }
+    }
+
+    // MARK: - Connectivity Observation
+
+    private func observeConnectivityUpdates() {
+        Task { @MainActor in
+            // Poll for state updates from connectivity service
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+
+                if let state = connectivityService.currentWorkoutState,
+                   state.workoutId == workoutId {
+                    exerciseName = state.exerciseName
+                    exerciseCategory = state.exerciseCategory
+                    if state.setNumber != setNumber {
+                        setNumber = state.setNumber
+                        weight = state.targetWeight
+                        reps = state.targetReps
+                    }
+                }
+
+                if let timerState = connectivityService.currentRestTimerState {
+                    if timerState.isActive && !isRestTimerActive {
+                        restTimerTotal = timerState.totalSeconds
+                        restTimerRemaining = timerState.remainingSeconds
+                        isRestTimerActive = true
+                    } else if !timerState.isActive && isRestTimerActive {
+                        skipRestTimer()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/GymBroWatch/Views/ActiveSetView.swift
+++ b/GymBroWatch/Views/ActiveSetView.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+import WatchKit
+
+/// Primary Watch view: shows current exercise, weight/reps adjusters,
+/// and a large "Complete Set" button optimized for sweaty-finger tapping.
+struct ActiveSetView: View {
+    @Bindable var viewModel: WatchWorkoutViewModel
+    @State private var showingConfirmation = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 8) {
+                // Exercise name & set number
+                exerciseHeader
+
+                // Weight adjuster with Digital Crown
+                weightSection
+
+                // Reps adjuster
+                repsSection
+
+                // Complete Set button — large, centered, minimum 44pt
+                completeButton
+
+                // Last set confirmation
+                if let lastWeight = viewModel.lastCompletedWeight,
+                   let lastReps = viewModel.lastCompletedReps {
+                    lastSetBanner(weight: lastWeight, reps: lastReps)
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+        .focusable()
+        .digitalCrownRotation(
+            $viewModel.crownDelta,
+            from: -100,
+            through: 100,
+            sensitivity: .medium,
+            isContinuous: true,
+            isHapticFeedbackEnabled: true
+        )
+        .onChange(of: viewModel.crownDelta) { _, newValue in
+            viewModel.applyCrownRotation(newValue)
+            viewModel.crownDelta = 0
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var exerciseHeader: some View {
+        VStack(spacing: 2) {
+            Text(viewModel.exerciseName)
+                .font(.system(.headline, design: .rounded))
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .minimumScaleFactor(0.7)
+
+            Text("Set \(viewModel.setNumber)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var weightSection: some View {
+        VStack(spacing: 4) {
+            Text("WEIGHT")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .tracking(1)
+
+            HStack(spacing: 12) {
+                Button {
+                    viewModel.decrementWeight()
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.blue)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Decrease weight")
+                .frame(minWidth: 44, minHeight: 44)
+
+                Text(String(format: "%.1f", viewModel.weight))
+                    .font(.system(.title2, design: .rounded, weight: .bold))
+                    .monospacedDigit()
+                    .frame(minWidth: 60)
+                    .multilineTextAlignment(.center)
+
+                Button {
+                    viewModel.incrementWeight()
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.blue)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Increase weight")
+                .frame(minWidth: 44, minHeight: 44)
+            }
+
+            Text("kg · Crown to adjust")
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var repsSection: some View {
+        VStack(spacing: 4) {
+            Text("REPS")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .tracking(1)
+
+            HStack(spacing: 12) {
+                Button {
+                    viewModel.decrementReps()
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.blue)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Decrease reps")
+                .frame(minWidth: 44, minHeight: 44)
+
+                Text("\(viewModel.reps)")
+                    .font(.system(.title2, design: .rounded, weight: .bold))
+                    .monospacedDigit()
+                    .frame(minWidth: 40)
+                    .multilineTextAlignment(.center)
+
+                Button {
+                    viewModel.incrementReps()
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.blue)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Increase reps")
+                .frame(minWidth: 44, minHeight: 44)
+            }
+        }
+    }
+
+    private var completeButton: some View {
+        Button {
+            viewModel.completeSet()
+            showingConfirmation = true
+            Task {
+                try? await Task.sleep(for: .seconds(1.5))
+                showingConfirmation = false
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.title3)
+                Text("Complete Set")
+                    .font(.system(.headline, design: .rounded))
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: 50)
+            .background(showingConfirmation ? Color.blue : Color.green)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 4)
+        .accessibilityHint("Logs the current set and starts rest timer")
+    }
+
+    private func lastSetBanner(weight: Double, reps: Int) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "checkmark")
+                .foregroundStyle(.green)
+                .font(.caption2)
+            Text("\(String(format: "%.1f", weight))kg × \(reps)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .transition(.opacity)
+        .animation(.easeInOut, value: viewModel.lastCompletedWeight)
+    }
+}

--- a/GymBroWatch/Views/RestTimerWatchView.swift
+++ b/GymBroWatch/Views/RestTimerWatchView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import WatchKit
+
+/// Watch rest timer view with circular countdown, skip action,
+/// and haptic alerts at 10s and completion.
+struct RestTimerWatchView: View {
+    @Bindable var viewModel: WatchWorkoutViewModel
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if viewModel.isRestTimerActive {
+                activeTimerContent
+            } else {
+                inactiveTimerContent
+            }
+        }
+    }
+
+    // MARK: - Active Timer
+
+    private var activeTimerContent: some View {
+        VStack(spacing: 6) {
+            Text("REST")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .tracking(1)
+
+            // Circular progress
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 6)
+
+                Circle()
+                    .trim(from: 0, to: 1 - viewModel.restTimerProgress)
+                    .stroke(timerColor, style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 1), value: viewModel.restTimerProgress)
+
+                VStack(spacing: 2) {
+                    Text(viewModel.formattedRestTime)
+                        .font(.system(.title, design: .rounded, weight: .bold))
+                        .monospacedDigit()
+
+                    Text("remaining")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 110, height: 110)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Rest timer \(viewModel.formattedRestTime) remaining")
+
+            // Skip button
+            Button {
+                viewModel.skipRestTimer()
+                WKInterfaceDevice.current().play(.click)
+            } label: {
+                Text("Skip Rest")
+                    .font(.system(.caption, design: .rounded, weight: .semibold))
+                    .foregroundStyle(.blue)
+            }
+            .buttonStyle(.plain)
+            .frame(minWidth: 44, minHeight: 44)
+        }
+    }
+
+    // MARK: - Inactive (workout stats)
+
+    private var inactiveTimerContent: some View {
+        VStack(spacing: 12) {
+            Text("WORKOUT")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .tracking(1)
+
+            VStack(spacing: 8) {
+                statRow(label: "Duration", value: viewModel.formattedDuration)
+                statRow(label: "Sets", value: "\(viewModel.totalSetsCompleted)")
+                statRow(
+                    label: "Volume",
+                    value: String(format: "%.0f kg", viewModel.totalVolume)
+                )
+            }
+            .padding(.horizontal, 8)
+
+            Text("Scroll down for next set")
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private func statRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(.caption, design: .rounded, weight: .bold))
+                .monospacedDigit()
+        }
+    }
+
+    // MARK: - Timer Color
+
+    private var timerColor: Color {
+        if viewModel.restTimerRemaining <= 10 {
+            return .red
+        } else if viewModel.restTimerRemaining <= 30 {
+            return .orange
+        }
+        return .blue
+    }
+}

--- a/GymBroWatch/Views/WorkoutSummaryWatchView.swift
+++ b/GymBroWatch/Views/WorkoutSummaryWatchView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import WatchKit
+
+/// Post-workout summary shown on the Watch after a workout ends.
+struct WorkoutSummaryWatchView: View {
+    let setsCompleted: Int
+    let totalVolume: Double
+    let duration: String
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                Image(systemName: "trophy.fill")
+                    .font(.system(size: 32))
+                    .foregroundStyle(.yellow)
+                    .accessibilityHidden(true)
+
+                Text("Workout Complete")
+                    .font(.system(.headline, design: .rounded))
+
+                Divider()
+
+                VStack(spacing: 8) {
+                    summaryRow(
+                        icon: "clock",
+                        label: "Duration",
+                        value: duration
+                    )
+                    summaryRow(
+                        icon: "number",
+                        label: "Sets",
+                        value: "\(setsCompleted)"
+                    )
+                    summaryRow(
+                        icon: "scalemass",
+                        label: "Volume",
+                        value: String(format: "%.0f kg", totalVolume)
+                    )
+                }
+                .padding(.horizontal, 4)
+
+                Text("Great work! 💪")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    private func summaryRow(icon: String, label: String, value: String) -> some View {
+        HStack {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(.blue)
+                .frame(width: 20)
+                .accessibilityHidden(true)
+
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Text(value)
+                .font(.system(.caption, design: .rounded, weight: .bold))
+                .monospacedDigit()
+        }
+    }
+}

--- a/Packages/GymBroCore/Package.swift
+++ b/Packages/GymBroCore/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "GymBroCore",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v17),
+        .watchOS(.v10)
     ],
     products: [
         .library(

--- a/Packages/GymBroCore/Sources/GymBroCore/Services/WatchConnectivityService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/WatchConnectivityService.swift
@@ -1,0 +1,314 @@
+import Foundation
+import WatchConnectivity
+import os
+
+// MARK: - Watch ↔ Phone Data Transfer Types
+
+/// Lightweight workout state transferred from iPhone to Watch.
+/// Uses only Codable primitives — no SwiftData dependency on Watch side.
+public struct WatchWorkoutState: Codable, Equatable, Sendable {
+    public let workoutId: String
+    public let exerciseName: String
+    public let exerciseCategory: String
+    public let setNumber: Int
+    public let targetWeight: Double
+    public let targetReps: Int
+    public let totalSetsCompleted: Int
+    public let totalVolume: Double
+    public let workoutStartTime: Date
+    public let isActive: Bool
+
+    public init(
+        workoutId: String,
+        exerciseName: String,
+        exerciseCategory: String,
+        setNumber: Int,
+        targetWeight: Double,
+        targetReps: Int,
+        totalSetsCompleted: Int,
+        totalVolume: Double,
+        workoutStartTime: Date,
+        isActive: Bool
+    ) {
+        self.workoutId = workoutId
+        self.exerciseName = exerciseName
+        self.exerciseCategory = exerciseCategory
+        self.setNumber = setNumber
+        self.targetWeight = targetWeight
+        self.targetReps = targetReps
+        self.totalSetsCompleted = totalSetsCompleted
+        self.totalVolume = totalVolume
+        self.workoutStartTime = workoutStartTime
+        self.isActive = isActive
+    }
+}
+
+/// Set completion sent from Watch back to iPhone.
+public struct WatchSetCompletion: Codable, Equatable, Sendable {
+    public let workoutId: String
+    public let weightKg: Double
+    public let reps: Int
+    public let completedAt: Date
+
+    public init(workoutId: String, weightKg: Double, reps: Int, completedAt: Date = Date()) {
+        self.workoutId = workoutId
+        self.weightKg = weightKg
+        self.reps = reps
+        self.completedAt = completedAt
+    }
+}
+
+/// Rest timer state synced between devices.
+public struct WatchRestTimerState: Codable, Equatable, Sendable {
+    public let isActive: Bool
+    public let remainingSeconds: Int
+    public let totalSeconds: Int
+
+    public init(isActive: Bool, remainingSeconds: Int, totalSeconds: Int) {
+        self.isActive = isActive
+        self.remainingSeconds = remainingSeconds
+        self.totalSeconds = totalSeconds
+    }
+}
+
+// MARK: - Message Keys
+
+public enum WatchMessageKey {
+    public static let workoutState = "workoutState"
+    public static let setCompletion = "setCompletion"
+    public static let restTimerState = "restTimerState"
+    public static let workoutEnded = "workoutEnded"
+}
+
+// MARK: - WatchConnectivityService
+
+/// Bidirectional communication layer between iPhone and Apple Watch.
+/// Runs on both iPhone and Watch — each side registers as delegate.
+@Observable
+@MainActor
+public final class WatchConnectivityService: NSObject {
+    private static let logger = Logger(subsystem: "com.gymbro", category: "WatchConnectivity")
+
+    public static let shared = WatchConnectivityService()
+
+    // MARK: - Published State
+
+    /// Current workout state (populated on Watch from iPhone messages).
+    public private(set) var currentWorkoutState: WatchWorkoutState?
+
+    /// Current rest timer state.
+    public private(set) var currentRestTimerState: WatchRestTimerState?
+
+    /// Whether the counterpart device is reachable.
+    public private(set) var isReachable: Bool = false
+
+    /// Pending set completions received (consumed by iPhone side).
+    public private(set) var pendingSetCompletions: [WatchSetCompletion] = []
+
+    /// Whether a workout just ended (signaled from phone).
+    public private(set) var workoutDidEnd: Bool = false
+
+    private var session: WCSession?
+
+    private override init() {
+        super.init()
+    }
+
+    // MARK: - Activation
+
+    public func activate() {
+        guard WCSession.isSupported() else {
+            Self.logger.info("WCSession not supported on this device")
+            return
+        }
+        let session = WCSession.default
+        session.delegate = self
+        session.activate()
+        self.session = session
+        Self.logger.info("WCSession activation requested")
+    }
+
+    // MARK: - Sending (iPhone → Watch)
+
+    /// Send workout state update to the Watch. Uses `updateApplicationContext`
+    /// so the Watch always gets the latest state even if not reachable.
+    public func sendWorkoutState(_ state: WatchWorkoutState) {
+        guard let session, session.activationState == .activated else { return }
+
+        do {
+            let data = try JSONEncoder().encode(state)
+            let context: [String: Any] = [WatchMessageKey.workoutState: data]
+            try session.updateApplicationContext(context)
+            Self.logger.debug("Sent workout state to Watch")
+        } catch {
+            Self.logger.error("Failed to send workout state: \(error.localizedDescription)")
+        }
+    }
+
+    /// Send rest timer state to the Watch via message (real-time).
+    public func sendRestTimerState(_ state: WatchRestTimerState) {
+        guard let session, session.isReachable else { return }
+
+        do {
+            let data = try JSONEncoder().encode(state)
+            session.sendMessage(
+                [WatchMessageKey.restTimerState: data],
+                replyHandler: nil
+            ) { error in
+                Self.logger.error("Failed to send rest timer state: \(error.localizedDescription)")
+            }
+        } catch {
+            Self.logger.error("Failed to encode rest timer state: \(error.localizedDescription)")
+        }
+    }
+
+    /// Signal to Watch that the workout has ended.
+    public func sendWorkoutEnded() {
+        guard let session, session.activationState == .activated else { return }
+
+        do {
+            try session.updateApplicationContext([WatchMessageKey.workoutEnded: true])
+            Self.logger.debug("Sent workout ended to Watch")
+        } catch {
+            Self.logger.error("Failed to send workout ended: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Sending (Watch → iPhone)
+
+    /// Send a completed set from Watch to iPhone.
+    public func sendSetCompletion(_ completion: WatchSetCompletion) {
+        guard let session, session.activationState == .activated else { return }
+
+        do {
+            let data = try JSONEncoder().encode(completion)
+            if session.isReachable {
+                session.sendMessage(
+                    [WatchMessageKey.setCompletion: data],
+                    replyHandler: nil
+                ) { error in
+                    Self.logger.error("Failed to send set completion: \(error.localizedDescription)")
+                }
+            } else {
+                // Queue for delivery when phone becomes reachable
+                session.transferUserInfo([WatchMessageKey.setCompletion: data])
+            }
+            Self.logger.debug("Sent set completion to iPhone")
+        } catch {
+            Self.logger.error("Failed to encode set completion: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Consuming
+
+    /// Consume and clear pending set completions (called by iPhone after processing).
+    public func consumeSetCompletions() -> [WatchSetCompletion] {
+        let completions = pendingSetCompletions
+        pendingSetCompletions.removeAll()
+        return completions
+    }
+
+    /// Reset workout ended flag.
+    public func clearWorkoutEnded() {
+        workoutDidEnd = false
+    }
+}
+
+// MARK: - WCSessionDelegate
+
+extension WatchConnectivityService: WCSessionDelegate {
+    nonisolated public func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        Task { @MainActor in
+            isReachable = session.isReachable
+            if let error {
+                Self.logger.error("WCSession activation failed: \(error.localizedDescription)")
+            } else {
+                Self.logger.info("WCSession activated: \(activationState.rawValue)")
+            }
+        }
+    }
+
+    #if os(iOS)
+    nonisolated public func sessionDidBecomeInactive(_ session: WCSession) {
+        Self.logger.info("WCSession became inactive")
+    }
+
+    nonisolated public func sessionDidDeactivate(_ session: WCSession) {
+        Self.logger.info("WCSession deactivated — reactivating")
+        session.activate()
+    }
+    #endif
+
+    nonisolated public func sessionReachabilityDidChange(_ session: WCSession) {
+        Task { @MainActor in
+            isReachable = session.isReachable
+        }
+    }
+
+    // Application context (latest-state delivery)
+    nonisolated public func session(
+        _ session: WCSession,
+        didReceiveApplicationContext applicationContext: [String: Any]
+    ) {
+        Task { @MainActor in
+            processIncoming(applicationContext)
+        }
+    }
+
+    // Real-time messages
+    nonisolated public func session(
+        _ session: WCSession,
+        didReceiveMessage message: [String: Any]
+    ) {
+        Task { @MainActor in
+            processIncoming(message)
+        }
+    }
+
+    // Queued user info (offline transfers)
+    nonisolated public func session(
+        _ session: WCSession,
+        didReceiveUserInfo userInfo: [String: Any] = [:]
+    ) {
+        Task { @MainActor in
+            processIncoming(userInfo)
+        }
+    }
+
+    // MARK: - Private
+
+    @MainActor
+    private func processIncoming(_ payload: [String: Any]) {
+        let decoder = JSONDecoder()
+
+        if let data = payload[WatchMessageKey.workoutState] as? Data,
+           let state = try? decoder.decode(WatchWorkoutState.self, from: data) {
+            currentWorkoutState = state
+            workoutDidEnd = false
+            Self.logger.debug("Received workout state: \(state.exerciseName)")
+        }
+
+        if let data = payload[WatchMessageKey.setCompletion] as? Data,
+           let completion = try? decoder.decode(WatchSetCompletion.self, from: data) {
+            pendingSetCompletions.append(completion)
+            Self.logger.debug("Received set completion: \(completion.weightKg)kg x \(completion.reps)")
+        }
+
+        if let data = payload[WatchMessageKey.restTimerState] as? Data,
+           let state = try? decoder.decode(WatchRestTimerState.self, from: data) {
+            currentRestTimerState = state
+            Self.logger.debug("Received rest timer state: \(state.remainingSeconds)s")
+        }
+
+        if let ended = payload[WatchMessageKey.workoutEnded] as? Bool, ended {
+            workoutDidEnd = true
+            currentWorkoutState = nil
+            currentRestTimerState = nil
+            Self.logger.debug("Received workout ended signal")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds Apple Watch companion app for simplified set logging during workouts.

### What's included
- **WatchConnectivityService** (GymBroCore): Bidirectional iPhone↔Watch communication via WCSession
- **WatchWorkoutViewModel**: Digital Crown weight adjustment, haptic feedback (WKInterfaceDevice), rest timer countdown
- **ActiveSetView**: Large touch targets (44pt+), weight/reps adjusters, high-contrast UI for gym lighting
- **RestTimerWatchView**: Circular progress countdown with color transitions (blue→orange→red)
- **WorkoutSummaryWatchView**: Post-workout stats display
- **Complications**: WidgetKit-based workout status + rest timer countdown
- **Offline-resilient**: Set completions queued via transferUserInfo when iPhone is unreachable

### Architecture
- Lightweight Codable transfer types (WatchWorkoutState, WatchSetCompletion, WatchRestTimerState) — no SwiftData on Watch
- GymBroCore Package.swift updated to support .watchOS(.v10)
- Watch source files in GymBroWatch/ — requires manual Xcode target setup

### Note
Since Xcode targets can't be created via CLI, the GymBroWatch/ directory contains all Swift source files. Manual Xcode project integration needed to add the watchOS target and link GymBroCore.

Closes #12