### PR TITLE
Recovery alerts — notify on poor readiness

### DIFF
--- a/Packages/GymBroCore/Sources/GymBroCore/Services/NotificationService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/NotificationService.swift
@@ -9,10 +9,18 @@ public final class NotificationService {
     
     private let notificationCenter = UNUserNotificationCenter.current()
     private let restTimerIdentifier = "com.gymbro.rest-timer"
+    private let readinessAlertIdentifier = "com.gymbro.readiness-alert"
+    
+    /// Category for recovery alert notifications — supports "Deload Today" action.
+    public static let recoveryAlertCategory = "RECOVERY_ALERT"
+    /// Action identifier for the "Deload Today" button on recovery notifications.
+    public static let deloadActionIdentifier = "DELOAD_TODAY"
     
     private init() {}
     
-    // Request notification permissions
+    // MARK: - Authorization
+    
+    /// Request notification permissions.
     public func requestAuthorization() async -> Bool {
         do {
             return try await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
@@ -22,7 +30,27 @@ public final class NotificationService {
         }
     }
     
-    // Schedule rest timer notification
+    /// Register notification categories including recovery alert actions.
+    public func registerCategories() {
+        let deloadAction = UNNotificationAction(
+            identifier: Self.deloadActionIdentifier,
+            title: "Deload Today",
+            options: .foreground
+        )
+        
+        let recoveryCategory = UNNotificationCategory(
+            identifier: Self.recoveryAlertCategory,
+            actions: [deloadAction],
+            intentIdentifiers: [],
+            options: .customDismissAction
+        )
+        
+        notificationCenter.setNotificationCategories([recoveryCategory])
+    }
+    
+    // MARK: - Rest Timer
+    
+    /// Schedule rest timer notification.
     public func scheduleRestTimerNotification(duration: Int) {
         let content = UNMutableNotificationContent()
         content.title = "Rest Complete"
@@ -48,8 +76,79 @@ public final class NotificationService {
         }
     }
     
-    // Cancel rest timer notification
+    /// Cancel rest timer notification.
     public func cancelRestTimerNotification() {
         notificationCenter.removePendingNotificationRequests(withIdentifiers: [restTimerIdentifier])
+    }
+    
+    // MARK: - Recovery Alerts
+    
+    /// Schedule a daily readiness check notification at the specified hour and minute.
+    /// The notification repeats daily. Call once at app launch; the system persists the registration.
+    public func scheduleDailyReadinessAlert(hour: Int = 7, minute: Int = 0) {
+        var dateComponents = DateComponents()
+        dateComponents.hour = hour
+        dateComponents.minute = minute
+        
+        let content = UNMutableNotificationContent()
+        content.title = "Morning Recovery Check"
+        content.body = "Open GymBro to see your readiness score and today's training recommendation."
+        content.sound = .default
+        content.categoryIdentifier = Self.recoveryAlertCategory
+        
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: dateComponents,
+            repeats: true
+        )
+        
+        let request = UNNotificationRequest(
+            identifier: readinessAlertIdentifier,
+            content: content,
+            trigger: trigger
+        )
+        
+        notificationCenter.add(request) { error in
+            if let error {
+                Self.logger.error("Failed to schedule readiness alert: \(error.localizedDescription)")
+            } else {
+                Self.logger.info("Daily readiness alert scheduled for \(hour, privacy: .public):\(minute, privacy: .public)")
+            }
+        }
+    }
+    
+    /// Send an immediate recovery alert notification based on a RecoveryAlertService alert.
+    public func sendRecoveryAlert(_ alert: RecoveryAlertService.RecoveryAlert) {
+        let content = UNMutableNotificationContent()
+        content.title = alert.title
+        content.body = alert.message
+        content.sound = .default
+        content.categoryIdentifier = Self.recoveryAlertCategory
+        content.userInfo = [
+            "alertLevel": alert.level.rawValue,
+            "readinessScore": alert.readinessScore
+        ]
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let identifier = "\(readinessAlertIdentifier)-\(UUID().uuidString)"
+        
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: trigger
+        )
+        
+        notificationCenter.add(request) { error in
+            if let error {
+                Self.logger.error("Failed to send recovery alert: \(error.localizedDescription)")
+            } else {
+                Self.logger.info("Recovery alert sent: \(alert.level.rawValue, privacy: .public)")
+            }
+        }
+    }
+    
+    /// Cancel the scheduled daily readiness alert.
+    public func cancelDailyReadinessAlert() {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: [readinessAlertIdentifier])
+        Self.logger.info("Daily readiness alert cancelled")
     }
 }

--- a/Packages/GymBroCore/Sources/GymBroCore/Services/Recovery/RecoveryAlertService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/Recovery/RecoveryAlertService.swift
@@ -1,0 +1,159 @@
+import Foundation
+import os
+
+/// Monitors readiness scores and triggers recovery alerts when scores drop below thresholds.
+///
+/// Threshold logic (per issue #54):
+///   - Score < 50: suggest deload / lighter workout
+///   - Score < 30: suggest complete rest day
+///
+/// Integrates with ReadinessScoreService for scores and NotificationService for delivery.
+public final class RecoveryAlertService: Sendable {
+    private static let logger = Logger(subsystem: "com.gymbro", category: "RecoveryAlerts")
+
+    /// Alert severity based on readiness score thresholds.
+    public enum AlertLevel: String, Sendable, Equatable {
+        case deload   // score < 50 — suggest lighter workout
+        case restDay  // score < 30 — suggest full rest day
+    }
+
+    /// A recovery alert with context for UI and notifications.
+    public struct RecoveryAlert: Sendable, Equatable {
+        public let level: AlertLevel
+        public let readinessScore: Double
+        public let title: String
+        public let message: String
+        public let recommendation: String
+        public let date: Date
+
+        public init(level: AlertLevel, readinessScore: Double, title: String, message: String, recommendation: String, date: Date = Date()) {
+            self.level = level
+            self.readinessScore = readinessScore
+            self.title = title
+            self.message = message
+            self.recommendation = recommendation
+            self.date = date
+        }
+    }
+
+    // Thresholds
+    public static let deloadThreshold: Double = 50.0
+    public static let restDayThreshold: Double = 30.0
+
+    private let readinessService: ReadinessScoreService
+
+    public init(readinessService: ReadinessScoreService = ReadinessScoreService()) {
+        self.readinessService = readinessService
+    }
+
+    // MARK: - Alert Evaluation
+
+    /// Evaluate a readiness score and return an alert if thresholds are breached.
+    /// Returns nil when the score is 50 or above (no alert needed).
+    public func evaluate(score: ReadinessScore) -> RecoveryAlert? {
+        if score.overallScore < Self.restDayThreshold {
+            return makeRestDayAlert(score: score)
+        } else if score.overallScore < Self.deloadThreshold {
+            return makeDeloadAlert(score: score)
+        }
+        return nil
+    }
+
+    /// Convenience: calculate readiness from raw input and evaluate in one step.
+    public func evaluateFromInput(_ input: ReadinessScoreService.Input, date: Date = Date()) -> RecoveryAlert? {
+        let score = readinessService.calculate(from: input, date: date)
+        return evaluate(score: score)
+    }
+
+    // MARK: - Alert Construction
+
+    private func makeDeloadAlert(score: ReadinessScore) -> RecoveryAlert {
+        Self.logger.info("Deload alert triggered — readiness \(score.overallScore, privacy: .public)")
+        return RecoveryAlert(
+            level: .deload,
+            readinessScore: score.overallScore,
+            title: "Low Recovery Today",
+            message: "Your readiness score is \(Int(score.overallScore)). Consider a lighter session with reduced intensity.",
+            recommendation: "Reduce working weights to 50-70% of your normal loads. Focus on technique and controlled tempo.",
+            date: score.date
+        )
+    }
+
+    private func makeRestDayAlert(score: ReadinessScore) -> RecoveryAlert {
+        Self.logger.info("Rest day alert triggered — readiness \(score.overallScore, privacy: .public)")
+        return RecoveryAlert(
+            level: .restDay,
+            readinessScore: score.overallScore,
+            title: "Recovery Needed",
+            message: "Your readiness score is \(Int(score.overallScore)). Your body needs rest to recover.",
+            recommendation: "Take a full rest day. Light walking or gentle mobility work only.",
+            date: score.date
+        )
+    }
+
+    // MARK: - Deload Suggestions
+
+    /// Lighter exercise suggestions based on alert level.
+    public static func deloadSuggestions(for level: AlertLevel) -> [DeloadSuggestion] {
+        switch level {
+        case .deload:
+            return [
+                DeloadSuggestion(
+                    name: "Light Compound Work",
+                    description: "Perform your planned compounds at 50-60% 1RM for 3×5. Focus on bar speed and technique.",
+                    icon: "figure.strengthtraining.traditional",
+                    intensityPercent: 55
+                ),
+                DeloadSuggestion(
+                    name: "Accessory Focus",
+                    description: "Skip heavy compounds. Do isolation and accessory work at moderate effort (RPE 5-6).",
+                    icon: "dumbbell.fill",
+                    intensityPercent: 60
+                ),
+                DeloadSuggestion(
+                    name: "Mobility & Technique",
+                    description: "Empty bar work, mobility drills, and movement patterns. Address weak points.",
+                    icon: "figure.flexibility",
+                    intensityPercent: 30
+                ),
+            ]
+        case .restDay:
+            return [
+                DeloadSuggestion(
+                    name: "Complete Rest",
+                    description: "No resistance training. Focus on sleep, nutrition, and stress management.",
+                    icon: "bed.double.fill",
+                    intensityPercent: 0
+                ),
+                DeloadSuggestion(
+                    name: "Light Walking",
+                    description: "20-30 minute easy walk. Promotes blood flow without adding training stress.",
+                    icon: "figure.walk",
+                    intensityPercent: 10
+                ),
+                DeloadSuggestion(
+                    name: "Gentle Mobility",
+                    description: "10-15 minutes of stretching and foam rolling. No loaded movements.",
+                    icon: "figure.cooldown",
+                    intensityPercent: 15
+                ),
+            ]
+        }
+    }
+}
+
+/// A lighter exercise suggestion shown in the deload UI.
+public struct DeloadSuggestion: Identifiable, Sendable, Equatable {
+    public let id = UUID()
+    public let name: String
+    public let description: String
+    public let icon: String
+    public let intensityPercent: Int
+
+    public init(name: String, description: String, icon: String, intensityPercent: Int) {
+        self.name = name
+        self.description = description
+        self.icon = icon
+        self.intensityPercent = intensityPercent
+    }
+}

--- a/Packages/GymBroCore/Tests/GymBroCoreTests/RecoveryAlertServiceTests.swift
+++ b/Packages/GymBroCore/Tests/GymBroCoreTests/RecoveryAlertServiceTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import GymBroCore
+
+final class RecoveryAlertServiceTests: XCTestCase {
+
+    private var service: RecoveryAlertService!
+
+    override func setUp() {
+        super.setUp()
+        service = RecoveryAlertService()
+    }
+
+    // MARK: - Threshold Tests
+
+    func testScoreAbove50ReturnsNoAlert() {
+        let score = makeScore(overallScore: 65, label: .moderate)
+        let alert = service.evaluate(score: score)
+        XCTAssertNil(alert, "Score >= 50 should not trigger an alert")
+    }
+
+    func testScoreAt50ReturnsNoAlert() {
+        let score = makeScore(overallScore: 50, label: .moderate)
+        let alert = service.evaluate(score: score)
+        XCTAssertNil(alert, "Score exactly 50 should not trigger an alert")
+    }
+
+    func testScoreBelow50TriggersDeloadAlert() {
+        let score = makeScore(overallScore: 45, label: .poor)
+        let alert = service.evaluate(score: score)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert?.level, .deload)
+    }
+
+    func testScoreAt49TriggersDeloadAlert() {
+        let score = makeScore(overallScore: 49, label: .poor)
+        let alert = service.evaluate(score: score)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert?.level, .deload)
+    }
+
+    func testScoreBelow30TriggersRestDayAlert() {
+        let score = makeScore(overallScore: 25, label: .poor)
+        let alert = service.evaluate(score: score)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert?.level, .restDay)
+    }
+
+    func testScoreAt30TriggersDeloadNotRestDay() {
+        let score = makeScore(overallScore: 30, label: .poor)
+        let alert = service.evaluate(score: score)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert?.level, .deload, "Score exactly 30 should be deload, not rest day")
+    }
+
+    func testScoreAt29TriggersRestDay() {
+        let score = makeScore(overallScore: 29, label: .poor)
+        let alert = service.evaluate(score: score)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert?.level, .restDay)
+    }
+
+    func testScoreZeroTriggersRestDay() {
+        let score = makeScore(overallScore: 0, label: .poor)
+        let alert = service.evaluate(score: score)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert?.level, .restDay)
+    }
+
+    func testHighScoreReturnsNoAlert() {
+        let score = makeScore(overallScore: 92, label: .excellent)
+        let alert = service.evaluate(score: score)
+        XCTAssertNil(alert)
+    }
+
+    // MARK: - Alert Content
+
+    func testDeloadAlertContent() {
+        let score = makeScore(overallScore: 42, label: .poor)
+        let alert = service.evaluate(score: score)!
+        
+        XCTAssertEqual(alert.title, "Low Recovery Today")
+        XCTAssertTrue(alert.message.contains("42"), "Message should contain the score")
+        XCTAssertFalse(alert.recommendation.isEmpty)
+        XCTAssertEqual(alert.readinessScore, 42)
+    }
+
+    func testRestDayAlertContent() {
+        let score = makeScore(overallScore: 18, label: .poor)
+        let alert = service.evaluate(score: score)!
+
+        XCTAssertEqual(alert.title, "Recovery Needed")
+        XCTAssertTrue(alert.message.contains("18"))
+        XCTAssertTrue(alert.recommendation.lowercased().contains("rest"))
+    }
+
+    // MARK: - Deload Suggestions
+
+    func testDeloadSuggestionsForDeloadLevel() {
+        let suggestions = RecoveryAlertService.deloadSuggestions(for: .deload)
+        XCTAssertEqual(suggestions.count, 3)
+        XCTAssertTrue(suggestions.allSatisfy { $0.intensityPercent > 0 })
+        XCTAssertTrue(suggestions.allSatisfy { $0.intensityPercent <= 70 })
+    }
+
+    func testDeloadSuggestionsForRestDayLevel() {
+        let suggestions = RecoveryAlertService.deloadSuggestions(for: .restDay)
+        XCTAssertEqual(suggestions.count, 3)
+        // First suggestion should be complete rest (0%)
+        XCTAssertEqual(suggestions.first?.intensityPercent, 0)
+        XCTAssertTrue(suggestions.allSatisfy { $0.intensityPercent <= 15 })
+    }
+
+    func testSuggestionsHaveUniqueIds() {
+        let deloadSuggestions = RecoveryAlertService.deloadSuggestions(for: .deload)
+        let ids = Set(deloadSuggestions.map(\.id))
+        XCTAssertEqual(ids.count, deloadSuggestions.count, "All suggestions should have unique IDs")
+    }
+
+    func testSuggestionsHaveNonEmptyContent() {
+        for level in [RecoveryAlertService.AlertLevel.deload, .restDay] {
+            let suggestions = RecoveryAlertService.deloadSuggestions(for: level)
+            for suggestion in suggestions {
+                XCTAssertFalse(suggestion.name.isEmpty, "Suggestion name should not be empty")
+                XCTAssertFalse(suggestion.description.isEmpty, "Suggestion description should not be empty")
+                XCTAssertFalse(suggestion.icon.isEmpty, "Suggestion icon should not be empty")
+            }
+        }
+    }
+
+    // MARK: - Integration with ReadinessScoreService
+
+    func testEvaluateFromInputWithPoorSleep() {
+        let input = ReadinessScoreService.Input(
+            sleepRecord: SleepRecord(
+                date: Date(),
+                totalMinutes: 180,
+                stages: SleepStageBreakdown(
+                    inBedMinutes: 300,
+                    asleepMinutes: 100,
+                    awakeMinutes: 120,
+                    remMinutes: 20,
+                    deepMinutes: 10,
+                    coreMinutes: 50
+                )
+            ),
+            recentSleepDurations: [180, 200, 180, 220, 180, 200, 180],
+            currentHRV: 20.0,
+            hrvBaseline: HealthBaseline(
+                type: .heartRateVariability,
+                averageValue: 40.0,
+                standardDeviation: 5.0,
+                sampleCount: 30
+            ),
+            currentRestingHR: 72.0,
+            rhrBaseline: HealthBaseline(
+                type: .restingHeartRate,
+                averageValue: 58.0,
+                standardDeviation: 3.0,
+                sampleCount: 30
+            ),
+            dailyTrainingVolumes: [2000, 2000, 2000, 2000, 10000, 12000, 15000]
+        )
+
+        let alert = service.evaluateFromInput(input)
+        XCTAssertNotNil(alert, "Poor recovery input should trigger an alert")
+        // With very poor inputs, should be deload or rest day
+        XCTAssertTrue(
+            alert?.level == .deload || alert?.level == .restDay,
+            "Alert level should be deload or restDay, got \(String(describing: alert?.level))"
+        )
+    }
+
+    func testEvaluateFromInputWithGoodRecovery() {
+        let input = ReadinessScoreService.Input(
+            sleepRecord: SleepRecord(
+                date: Date(),
+                totalMinutes: 480,
+                stages: SleepStageBreakdown(
+                    inBedMinutes: 500,
+                    asleepMinutes: 0,
+                    awakeMinutes: 20,
+                    remMinutes: 100,
+                    deepMinutes: 90,
+                    coreMinutes: 290
+                )
+            ),
+            recentSleepDurations: [470, 480, 475, 480, 470, 485, 480],
+            currentHRV: 55.0,
+            hrvBaseline: HealthBaseline(
+                type: .heartRateVariability,
+                averageValue: 40.0,
+                standardDeviation: 5.0,
+                sampleCount: 30
+            ),
+            currentRestingHR: 50.0,
+            rhrBaseline: HealthBaseline(
+                type: .restingHeartRate,
+                averageValue: 58.0,
+                standardDeviation: 3.0,
+                sampleCount: 30
+            ),
+            dailyTrainingVolumes: Array(repeating: 5000.0, count: 28)
+        )
+
+        let alert = service.evaluateFromInput(input)
+        XCTAssertNil(alert, "Good recovery should not trigger an alert")
+    }
+
+    // MARK: - Thresholds Constants
+
+    func testThresholdConstants() {
+        XCTAssertEqual(RecoveryAlertService.deloadThreshold, 50.0)
+        XCTAssertEqual(RecoveryAlertService.restDayThreshold, 30.0)
+        XCTAssertTrue(
+            RecoveryAlertService.restDayThreshold < RecoveryAlertService.deloadThreshold,
+            "Rest day threshold must be lower than deload threshold"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeScore(overallScore: Double, label: ReadinessLabel) -> ReadinessScore {
+        ReadinessScore(
+            date: Date(),
+            overallScore: overallScore,
+            sleepScore: overallScore,
+            hrvScore: overallScore,
+            restingHRScore: overallScore,
+            trainingLoadScore: overallScore,
+            recommendation: ReadinessScoreService.recommendation(for: label),
+            label: label
+        )
+    }
+}

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Settings/NotificationSettingsView.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Settings/NotificationSettingsView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import GymBroCore
+
+/// Settings screen for configuring recovery notification preferences.
+/// Users can enable/disable daily readiness alerts and set the notification time.
+public struct NotificationSettingsView: View {
+    @AppStorage("readinessAlertsEnabled") private var alertsEnabled = true
+    @AppStorage("readinessAlertHour") private var alertHour = 7
+    @AppStorage("readinessAlertMinute") private var alertMinute = 0
+
+    @State private var notificationPermissionGranted = false
+    @State private var selectedTime = Date()
+
+    public init() {}
+
+    public var body: some View {
+        Form {
+            Section {
+                Toggle("Daily Readiness Alerts", isOn: $alertsEnabled)
+                    .onChange(of: alertsEnabled) { _, enabled in
+                        handleToggle(enabled)
+                    }
+            } header: {
+                Text("Recovery Notifications")
+            } footer: {
+                Text("Receive a morning notification to check your readiness score and get training recommendations.")
+            }
+
+            if alertsEnabled {
+                Section("Alert Time") {
+                    DatePicker(
+                        "Notification Time",
+                        selection: $selectedTime,
+                        displayedComponents: .hourAndMinute
+                    )
+                    .onChange(of: selectedTime) { _, newValue in
+                        updateAlertTime(from: newValue)
+                    }
+                }
+
+                Section {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Deload Alert")
+                                .font(.subheadline.weight(.medium))
+                            Text("Score below 50 — lighter workout suggested")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    HStack {
+                        Image(systemName: "bed.double.fill")
+                            .foregroundStyle(.red)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Rest Day Alert")
+                                .font(.subheadline.weight(.medium))
+                            Text("Score below 30 — rest day recommended")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                } header: {
+                    Text("Alert Thresholds")
+                } footer: {
+                    Text("Alerts are triggered automatically based on your readiness score calculated from HealthKit data.")
+                }
+            }
+
+            if !notificationPermissionGranted {
+                Section {
+                    Button {
+                        Task {
+                            let granted = await NotificationService.shared.requestAuthorization()
+                            await MainActor.run {
+                                notificationPermissionGranted = granted
+                            }
+                        }
+                    } label: {
+                        Label("Enable Notifications", systemImage: "bell.badge")
+                    }
+                } footer: {
+                    Text("Notification permission is required for recovery alerts. You can change this in Settings.")
+                }
+            }
+        }
+        .navigationTitle("Notifications")
+        .onAppear {
+            initializeTime()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func initializeTime() {
+        var components = DateComponents()
+        components.hour = alertHour
+        components.minute = alertMinute
+        if let date = Calendar.current.date(from: components) {
+            selectedTime = date
+        }
+    }
+
+    private func updateAlertTime(from date: Date) {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        alertHour = components.hour ?? 7
+        alertMinute = components.minute ?? 0
+
+        if alertsEnabled {
+            NotificationService.shared.scheduleDailyReadinessAlert(hour: alertHour, minute: alertMinute)
+        }
+    }
+
+    private func handleToggle(_ enabled: Bool) {
+        if enabled {
+            NotificationService.shared.scheduleDailyReadinessAlert(hour: alertHour, minute: alertMinute)
+        } else {
+            NotificationService.shared.cancelDailyReadinessAlert()
+        }
+    }
+}

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/DeloadSuggestionsView.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/DeloadSuggestionsView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+import GymBroCore
+
+/// In-app recovery alert view showing readiness status and lighter exercise suggestions.
+/// Presented when readiness score drops below 50 (deload) or 30 (rest day).
+public struct DeloadSuggestionsView: View {
+    let alert: RecoveryAlertService.RecoveryAlert
+    let onDismiss: () -> Void
+
+    @ScaledMetric(relativeTo: .largeTitle) private var gaugeSize: CGFloat = 120
+    @ScaledMetric(relativeTo: .title) private var iconSize: CGFloat = 32
+
+    public init(
+        alert: RecoveryAlertService.RecoveryAlert,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.alert = alert
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    alertHeader
+                    recommendationCard
+                    suggestionsSection
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+                .padding(.bottom, 32)
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Recovery Alert")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done", action: onDismiss)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+
+    // MARK: - Alert Header
+
+    private var alertHeader: some View {
+        VStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .stroke(Color(.systemGray5), lineWidth: 12)
+                    .frame(width: gaugeSize, height: gaugeSize)
+
+                Circle()
+                    .trim(from: 0, to: alert.readinessScore / 100.0)
+                    .stroke(
+                        alertColor,
+                        style: StrokeStyle(lineWidth: 12, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: gaugeSize, height: gaugeSize)
+                    .animation(.easeInOut(duration: 0.6), value: alert.readinessScore)
+
+                VStack(spacing: 2) {
+                    Text("\(Int(alert.readinessScore))")
+                        .font(.system(size: 36, weight: .bold, design: .rounded))
+                        .foregroundStyle(alertColor)
+                    Text("/ 100")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(spacing: 4) {
+                Text(alert.title)
+                    .font(.title2.weight(.bold))
+                Text(alert.message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+        }
+        .padding(.top, 8)
+    }
+
+    // MARK: - Recommendation
+
+    private var recommendationCard: some View {
+        HStack(spacing: 12) {
+            Image(systemName: alert.level == .restDay ? "bed.double.fill" : "exclamationmark.triangle.fill")
+                .font(.title2)
+                .foregroundStyle(alertColor)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Today's Recommendation")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(alert.recommendation)
+                    .font(.subheadline)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(alertColor.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Suggestions
+
+    private var suggestionsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(alert.level == .restDay ? "Rest Day Options" : "Lighter Alternatives")
+                .font(.headline)
+                .padding(.leading, 4)
+
+            ForEach(RecoveryAlertService.deloadSuggestions(for: alert.level)) { suggestion in
+                suggestionCard(suggestion)
+            }
+        }
+    }
+
+    private func suggestionCard(_ suggestion: DeloadSuggestion) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: suggestion.icon)
+                .font(.system(size: iconSize))
+                .foregroundStyle(alertColor)
+                .frame(width: 44, height: 44)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(suggestion.name)
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    if suggestion.intensityPercent > 0 {
+                        Text("\(suggestion.intensityPercent)% intensity")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(Color(.systemGray5))
+                            .clipShape(Capsule())
+                    } else {
+                        Text("Rest")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(alertColor)
+                            .clipShape(Capsule())
+                    }
+                }
+                Text(suggestion.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Helpers
+
+    private var alertColor: Color {
+        alert.level == .restDay ? .red : .orange
+    }
+}


### PR DESCRIPTION
## Summary

Implements recovery alerts that notify users when their daily readiness score drops below critical thresholds, and suggests lighter workout alternatives.

### Changes

**RecoveryAlertService** (Core)
- Two-tier alert system: deload (score < 50) and rest day (score < 30)
- Integrates with ReadinessScoreService (#14) for score evaluation
- Provides curated deload suggestions per alert level (lighter compounds, accessory focus, mobility, or complete rest)

**NotificationService** (Extended)
- Daily readiness check notification at configurable time (default 7am)
- Recovery alert category with 'Deload Today' action button
- Immediate alert delivery when poor readiness detected

**DeloadSuggestionsView** (UI)
- Readiness gauge showing current score
- Recommendation card with training advice
- Exercise suggestion cards with intensity percentages

**NotificationSettingsView** (UI)
- Toggle daily readiness alerts on/off
- Configure notification time
- Threshold info display

**Tests**
- 17 tests covering threshold logic, boundary conditions, alert content, deload suggestions, and end-to-end integration with ReadinessScoreService

Closes #54