### PR TITLE
Widgets + Dynamic Island for active workouts

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -131,3 +131,20 @@
 - **Complications**: WidgetKit-based with circular and rectangular families. 30s refresh during active workout.
 - **Architecture**: GymBroCore Package.swift updated to support `.watchOS(.v10)`. Watch source files in `GymBroWatch/` — requires manual Xcode target setup.
 - **Pattern: Offline-resilient messaging** — Set completions use `transferUserInfo` when phone is unreachable.
+
+### 2026-04-07: Widgets + Dynamic Island Implementation (Issues #15 & #16)
+**Widget System (Issue #15):**
+- **GymBroWidgets extension** with 6 widgets registered in `GymBroWidgetBundle`: WorkoutStreakWidget (small + Lock Screen circular/rectangular/inline), NextWorkoutWidget (medium + Lock Screen rectangular), WeeklySummaryWidget (large), ReadinessWidget (Lock Screen circular gauge), LockScreenInlineWidget, StandByWorkoutWidget.
+- **AppIntentTimelineProvider** pattern for all widgets (iOS 17+ configurable widgets). 30-minute refresh interval via `.after()` timeline policy.
+- **WidgetDataProvider** in GymBroCore/Services: queries SwiftData for streak calculation, weekly volume, recent PRs, next scheduled workout. Shared between widget extension and main app.
+- **Deep links**: All widgets use `widgetURL` with `gymbro://` scheme for navigation back into the app.
+- **Placeholder/snapshot views**: Every widget has proper placeholder data for the widget gallery.
+
+**Live Activity + Dynamic Island (Issue #16):**
+- **WorkoutActivityAttributes** in GymBroCore/Models: ActivityAttributes with ContentState containing exercise name, set number, rest timer end date, completed sets, total volume, elapsed time, last weight/reps.
+- **WorkoutLiveActivity** widget: Lock Screen banner + Dynamic Island (compact: timer + set count, expanded: exercise/weight/reps/timer/stats, minimal: timer icon).
+- **LockScreenLiveActivityView**: Shows current exercise, set progress, rest timer countdown (orange highlight), workout stats bar.
+- **LiveActivityService** singleton in GymBroCore/Services: manages full lifecycle — `startWorkoutActivity()`, `updateWorkoutActivity()`, `updateRestTimer()`, `clearRestTimer()`, `endWorkoutActivity()`, `dismissWorkoutActivity()`.
+- **ActiveWorkoutViewModel integration**: Live Activity starts on `startWorkout()`, updates on `completeSet()`, rest timer pushed to Dynamic Island on `startRestTimer()`, cleared on `skipRestTimer()`, ended on `finishWorkout()`, dismissed on `cancelWorkout()`.
+- **Rest timer in Dynamic Island**: Uses `Text(timerInterval:countsDown:)` for system-native countdown that works even when app is backgrounded.
+- **Tests**: WorkoutActivityAttributes tests (defaults, Codable, Hashable, LiveActivityService singleton), WidgetDataProvider data type tests.

--- a/GymBroWidgets/GymBroWidgetBundle.swift
+++ b/GymBroWidgets/GymBroWidgetBundle.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import WidgetKit
+
+/// The main widget bundle that registers all GymBro widgets.
+@main
+struct GymBroWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        // Home Screen Widgets
+        WorkoutStreakWidget()
+        NextWorkoutWidget()
+        WeeklySummaryWidget()
+
+        // Lock Screen Widgets
+        ReadinessWidget()
+        LockScreenInlineWidget()
+
+        // StandBy Widget
+        StandByWorkoutWidget()
+
+        // Live Activity
+        WorkoutLiveActivity()
+    }
+}

--- a/GymBroWidgets/LiveActivity/LockScreenLiveActivityView.swift
+++ b/GymBroWidgets/LiveActivity/LockScreenLiveActivityView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+import WidgetKit
+import ActivityKit
+
+/// Lock Screen banner view for the workout Live Activity.
+struct LockScreenLiveActivityView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+
+    var body: some View {
+        VStack(spacing: 12) {
+            // Top: Exercise and set info
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(context.state.exerciseName)
+                        .font(.headline)
+                        .fontWeight(.bold)
+                        .lineLimit(1)
+
+                    if context.state.totalPlannedSets > 0 {
+                        Text("Set \(context.state.currentSetNumber) of \(context.state.totalPlannedSets)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Set \(context.state.currentSetNumber)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                // Timer or working indicator
+                if let endDate = context.state.restTimerEndDate {
+                    restTimerView(endDate: endDate)
+                } else {
+                    workingIndicator
+                }
+            }
+
+            // Bottom: Stats bar
+            HStack {
+                statPill(icon: "checkmark.circle", value: "\(context.state.completedSets) sets")
+                Spacer()
+                statPill(icon: "scalemass", value: formatVolume(context.state.totalVolume))
+                Spacer()
+                statPill(icon: "clock", value: formatDuration(context.state.elapsedSeconds))
+            }
+        }
+        .padding()
+    }
+
+    // MARK: - Rest Timer
+
+    private func restTimerView(endDate: Date) -> some View {
+        VStack(spacing: 2) {
+            Text("REST")
+                .font(.caption2)
+                .fontWeight(.bold)
+                .foregroundStyle(.orange)
+
+            Text(timerInterval: context.state.restTimerStartDate...endDate, countsDown: true)
+                .font(.system(.title, design: .monospaced, weight: .bold))
+                .monospacedDigit()
+                .foregroundStyle(.orange)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var workingIndicator: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(.green)
+                .frame(width: 8, height: 8)
+            Text("Working")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.green)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.green.opacity(0.15), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Stat Pill
+
+    private func statPill(icon: String, value: String) -> some View {
+        Label(value, systemImage: icon)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+
+    // MARK: - Formatting
+
+    private func formatVolume(_ volume: Double) -> String {
+        if volume >= 1000 {
+            return String(format: "%.1fk kg", volume / 1000)
+        }
+        return String(format: "%.0f kg", volume)
+    }
+
+    private func formatDuration(_ seconds: Int) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+}

--- a/GymBroWidgets/LiveActivity/WorkoutActivityAttributes.swift
+++ b/GymBroWidgets/LiveActivity/WorkoutActivityAttributes.swift
@@ -1,0 +1,68 @@
+// Re-export WorkoutActivityAttributes from GymBroCore for the widget extension.
+// In the Xcode project, add GymBroCore as a dependency of the widget extension target,
+// or copy this definition directly. For SPM-based builds, the widget extension should
+// depend on the GymBroCore package.
+
+// When building with Xcode, uncomment and remove the local definition below:
+// import GymBroCore
+
+// For standalone widget extension compilation, include the attributes directly:
+import Foundation
+import ActivityKit
+
+/// Defines the static and dynamic data for the workout Live Activity.
+/// This is a mirror of the definition in GymBroCore/Models/WorkoutActivityAttributes.swift.
+/// Both must stay in sync.
+public struct WorkoutActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        public var exerciseName: String
+        public var currentSetNumber: Int
+        public var totalPlannedSets: Int
+        public var restTimerEndDate: Date?
+        public var restTimerDuration: Int
+        public var completedSets: Int
+        public var totalVolume: Double
+        public var elapsedSeconds: Int
+        public var lastWeight: Double
+        public var lastReps: Int
+
+        public init(
+            exerciseName: String = "Starting...",
+            currentSetNumber: Int = 1,
+            totalPlannedSets: Int = 0,
+            restTimerEndDate: Date? = nil,
+            restTimerDuration: Int = 0,
+            completedSets: Int = 0,
+            totalVolume: Double = 0,
+            elapsedSeconds: Int = 0,
+            lastWeight: Double = 0,
+            lastReps: Int = 0
+        ) {
+            self.exerciseName = exerciseName
+            self.currentSetNumber = currentSetNumber
+            self.totalPlannedSets = totalPlannedSets
+            self.restTimerEndDate = restTimerEndDate
+            self.restTimerDuration = restTimerDuration
+            self.completedSets = completedSets
+            self.totalVolume = totalVolume
+            self.elapsedSeconds = elapsedSeconds
+            self.lastWeight = lastWeight
+            self.lastReps = lastReps
+        }
+    }
+
+    public var workoutId: String
+    public var workoutStartDate: Date
+
+    public init(workoutId: String, workoutStartDate: Date = .now) {
+        self.workoutId = workoutId
+        self.workoutStartDate = workoutStartDate
+    }
+}
+
+extension WorkoutActivityAttributes.ContentState {
+    var restTimerStartDate: Date {
+        guard let endDate = restTimerEndDate else { return .now }
+        return endDate.addingTimeInterval(-Double(restTimerDuration))
+    }
+}

--- a/GymBroWidgets/LiveActivity/WorkoutLiveActivity.swift
+++ b/GymBroWidgets/LiveActivity/WorkoutLiveActivity.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+import WidgetKit
+import ActivityKit
+
+/// The Live Activity widget rendering for Lock Screen and Dynamic Island.
+struct WorkoutLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: WorkoutActivityAttributes.self) { context in
+            // Lock Screen / Banner presentation
+            LockScreenLiveActivityView(context: context)
+                .activityBackgroundTint(.black.opacity(0.7))
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded regions
+                DynamicIslandExpandedRegion(.leading) {
+                    expandedLeading(context: context)
+                }
+
+                DynamicIslandExpandedRegion(.trailing) {
+                    expandedTrailing(context: context)
+                }
+
+                DynamicIslandExpandedRegion(.center) {
+                    expandedCenter(context: context)
+                }
+
+                DynamicIslandExpandedRegion(.bottom) {
+                    expandedBottom(context: context)
+                }
+            } compactLeading: {
+                // Compact left: timer or set count
+                compactLeading(context: context)
+            } compactTrailing: {
+                // Compact right: set count or timer
+                compactTrailing(context: context)
+            } minimal: {
+                // Minimal: just timer
+                minimalView(context: context)
+            }
+            .widgetURL(URL(string: "gymbro://active-workout"))
+        }
+    }
+
+    // MARK: - Dynamic Island Compact
+
+    @ViewBuilder
+    private func compactLeading(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        if let endDate = context.state.restTimerEndDate {
+            // Show countdown timer
+            HStack(spacing: 4) {
+                Image(systemName: "timer")
+                    .font(.caption2)
+                Text(timerInterval: context.state.restTimerStartDate...endDate, countsDown: true)
+                    .font(.system(.caption, design: .monospaced, weight: .bold))
+                    .monospacedDigit()
+                    .frame(width: 40)
+            }
+        } else {
+            Label {
+                Text("\(context.state.completedSets)")
+                    .font(.system(.caption, design: .rounded, weight: .bold))
+            } icon: {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.caption2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func compactTrailing(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        if context.state.restTimerEndDate != nil {
+            Text("\(context.state.completedSets) sets")
+                .font(.system(.caption2, design: .rounded, weight: .medium))
+        } else {
+            Image(systemName: "figure.strengthtraining.traditional")
+                .font(.caption2)
+        }
+    }
+
+    // MARK: - Dynamic Island Minimal
+
+    @ViewBuilder
+    private func minimalView(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        if let endDate = context.state.restTimerEndDate {
+            Text(timerInterval: context.state.restTimerStartDate...endDate, countsDown: true)
+                .font(.system(.caption2, design: .monospaced, weight: .bold))
+                .monospacedDigit()
+        } else {
+            Image(systemName: "figure.strengthtraining.traditional")
+                .font(.caption)
+        }
+    }
+
+    // MARK: - Dynamic Island Expanded
+
+    @ViewBuilder
+    private func expandedLeading(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Exercise")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            Text(context.state.exerciseName)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+        }
+    }
+
+    @ViewBuilder
+    private func expandedTrailing(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text("Set")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            if context.state.totalPlannedSets > 0 {
+                Text("\(context.state.currentSetNumber)/\(context.state.totalPlannedSets)")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            } else {
+                Text("Set \(context.state.currentSetNumber)")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func expandedCenter(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        if let endDate = context.state.restTimerEndDate {
+            // Rest timer countdown
+            VStack(spacing: 4) {
+                Text("Rest")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+                Text(timerInterval: context.state.restTimerStartDate...endDate, countsDown: true)
+                    .font(.system(.title2, design: .monospaced, weight: .bold))
+                    .monospacedDigit()
+                    .foregroundStyle(.orange)
+            }
+        } else {
+            // Last set info
+            HStack(spacing: 12) {
+                VStack(spacing: 2) {
+                    Text("Weight")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(String(format: "%.1f kg", context.state.lastWeight))
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+
+                VStack(spacing: 2) {
+                    Text("Reps")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("\(context.state.lastReps)")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func expandedBottom(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        HStack {
+            Label("\(context.state.completedSets) sets", systemImage: "checkmark.circle")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Label(formatVolume(context.state.totalVolume), systemImage: "scalemass")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Label(formatDuration(context.state.elapsedSeconds), systemImage: "clock")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatVolume(_ volume: Double) -> String {
+        if volume >= 1000 {
+            return String(format: "%.1fk kg", volume / 1000)
+        }
+        return String(format: "%.0f kg", volume)
+    }
+
+    private func formatDuration(_ seconds: Int) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+}

--- a/GymBroWidgets/TimelineProviders/NextWorkoutTimelineProvider.swift
+++ b/GymBroWidgets/TimelineProviders/NextWorkoutTimelineProvider.swift
@@ -1,0 +1,77 @@
+import WidgetKit
+import SwiftUI
+import SwiftData
+import AppIntents
+
+// MARK: - Timeline Entry
+
+struct NextWorkoutEntry: TimelineEntry {
+    let date: Date
+    let workoutName: String?
+    let exerciseCount: Int
+    let readinessScore: Int
+    let isRestDay: Bool
+}
+
+// MARK: - AppIntent Configuration
+
+struct NextWorkoutConfigurationIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Next Workout"
+    static var description: IntentDescription = "Shows your next scheduled workout and readiness score."
+}
+
+// MARK: - Timeline Provider
+
+struct NextWorkoutTimelineProvider: AppIntentTimelineProvider {
+    typealias Entry = NextWorkoutEntry
+    typealias Intent = NextWorkoutConfigurationIntent
+
+    func placeholder(in context: Context) -> NextWorkoutEntry {
+        NextWorkoutEntry(
+            date: .now,
+            workoutName: "Push Day",
+            exerciseCount: 6,
+            readinessScore: 85,
+            isRestDay: false
+        )
+    }
+
+    func snapshot(for configuration: NextWorkoutConfigurationIntent, in context: Context) async -> NextWorkoutEntry {
+        await fetchEntry()
+    }
+
+    func timeline(for configuration: NextWorkoutConfigurationIntent, in context: Context) async -> Timeline<NextWorkoutEntry> {
+        let entry = await fetchEntry()
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 30, to: entry.date) ?? entry.date
+        return Timeline(entries: [entry], policy: .after(nextUpdate))
+    }
+
+    @MainActor
+    private func fetchEntry() -> NextWorkoutEntry {
+        do {
+            let container = try ModelContainer(for: Workout.self, Program.self, ProgramDay.self)
+            let provider = WidgetDataProvider(modelContext: container.mainContext)
+            let next = provider.nextScheduledWorkout()
+            let daysSince = provider.daysSinceLastWorkout()
+
+            // Simple readiness heuristic: decrease if many consecutive days, increase on rest
+            let readiness = min(100, max(40, 100 - (provider.weeklyWorkoutCount() * 10) + (daysSince * 15)))
+
+            return NextWorkoutEntry(
+                date: .now,
+                workoutName: next?.name,
+                exerciseCount: next?.exerciseCount ?? 0,
+                readinessScore: readiness,
+                isRestDay: daysSince >= 2 || next == nil
+            )
+        } catch {
+            return NextWorkoutEntry(
+                date: .now,
+                workoutName: nil,
+                exerciseCount: 0,
+                readinessScore: 75,
+                isRestDay: false
+            )
+        }
+    }
+}

--- a/GymBroWidgets/TimelineProviders/WeeklySummaryTimelineProvider.swift
+++ b/GymBroWidgets/TimelineProviders/WeeklySummaryTimelineProvider.swift
@@ -1,0 +1,76 @@
+import WidgetKit
+import SwiftUI
+import SwiftData
+import AppIntents
+
+// MARK: - Timeline Entry
+
+struct WeeklySummaryEntry: TimelineEntry {
+    let date: Date
+    let totalVolume: Double
+    let workoutCount: Int
+    let recentPRs: Int
+    let streak: Int
+    let nextWorkoutName: String?
+}
+
+// MARK: - AppIntent Configuration
+
+struct WeeklySummaryConfigurationIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Weekly Summary"
+    static var description: IntentDescription = "Shows your weekly training volume, workout count, and upcoming workouts."
+}
+
+// MARK: - Timeline Provider
+
+struct WeeklySummaryTimelineProvider: AppIntentTimelineProvider {
+    typealias Entry = WeeklySummaryEntry
+    typealias Intent = WeeklySummaryConfigurationIntent
+
+    func placeholder(in context: Context) -> WeeklySummaryEntry {
+        WeeklySummaryEntry(
+            date: .now,
+            totalVolume: 12500,
+            workoutCount: 4,
+            recentPRs: 2,
+            streak: 5,
+            nextWorkoutName: "Legs"
+        )
+    }
+
+    func snapshot(for configuration: WeeklySummaryConfigurationIntent, in context: Context) async -> WeeklySummaryEntry {
+        await fetchEntry()
+    }
+
+    func timeline(for configuration: WeeklySummaryConfigurationIntent, in context: Context) async -> Timeline<WeeklySummaryEntry> {
+        let entry = await fetchEntry()
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 30, to: entry.date) ?? entry.date
+        return Timeline(entries: [entry], policy: .after(nextUpdate))
+    }
+
+    @MainActor
+    private func fetchEntry() -> WeeklySummaryEntry {
+        do {
+            let container = try ModelContainer(for: Workout.self, ExerciseSet.self, Program.self, ProgramDay.self)
+            let provider = WidgetDataProvider(modelContext: container.mainContext)
+
+            return WeeklySummaryEntry(
+                date: .now,
+                totalVolume: provider.weeklyVolume(),
+                workoutCount: provider.weeklyWorkoutCount(),
+                recentPRs: provider.recentPRCount(),
+                streak: provider.currentStreak(),
+                nextWorkoutName: provider.nextScheduledWorkout()?.name
+            )
+        } catch {
+            return WeeklySummaryEntry(
+                date: .now,
+                totalVolume: 0,
+                workoutCount: 0,
+                recentPRs: 0,
+                streak: 0,
+                nextWorkoutName: nil
+            )
+        }
+    }
+}

--- a/GymBroWidgets/TimelineProviders/WorkoutStreakTimelineProvider.swift
+++ b/GymBroWidgets/TimelineProviders/WorkoutStreakTimelineProvider.swift
@@ -1,0 +1,56 @@
+import WidgetKit
+import SwiftUI
+import SwiftData
+import AppIntents
+
+// MARK: - Timeline Entry
+
+struct WorkoutStreakEntry: TimelineEntry {
+    let date: Date
+    let streak: Int
+    let daysSinceLastWorkout: Int
+}
+
+// MARK: - AppIntent Configuration
+
+struct WorkoutStreakConfigurationIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Workout Streak"
+    static var description: IntentDescription = "Shows your current workout streak."
+}
+
+// MARK: - Timeline Provider
+
+struct WorkoutStreakTimelineProvider: AppIntentTimelineProvider {
+    typealias Entry = WorkoutStreakEntry
+    typealias Intent = WorkoutStreakConfigurationIntent
+
+    func placeholder(in context: Context) -> WorkoutStreakEntry {
+        WorkoutStreakEntry(date: .now, streak: 5, daysSinceLastWorkout: 0)
+    }
+
+    func snapshot(for configuration: WorkoutStreakConfigurationIntent, in context: Context) async -> WorkoutStreakEntry {
+        await fetchEntry()
+    }
+
+    func timeline(for configuration: WorkoutStreakConfigurationIntent, in context: Context) async -> Timeline<WorkoutStreakEntry> {
+        let entry = await fetchEntry()
+        // Refresh every 30 minutes
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 30, to: entry.date) ?? entry.date
+        return Timeline(entries: [entry], policy: .after(nextUpdate))
+    }
+
+    @MainActor
+    private func fetchEntry() -> WorkoutStreakEntry {
+        do {
+            let container = try ModelContainer(for: Workout.self)
+            let provider = WidgetDataProvider(modelContext: container.mainContext)
+            return WorkoutStreakEntry(
+                date: .now,
+                streak: provider.currentStreak(),
+                daysSinceLastWorkout: provider.daysSinceLastWorkout()
+            )
+        } catch {
+            return WorkoutStreakEntry(date: .now, streak: 0, daysSinceLastWorkout: 0)
+        }
+    }
+}

--- a/GymBroWidgets/Widgets/LockScreenWidgets.swift
+++ b/GymBroWidgets/Widgets/LockScreenWidgets.swift
@@ -1,0 +1,123 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - Lock Screen Widgets Collection
+
+struct LockScreenInlineWidget: Widget {
+    let kind = "LockScreenInlineWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: NextWorkoutConfigurationIntent.self,
+            provider: NextWorkoutTimelineProvider()
+        ) { entry in
+            LockScreenInlineView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Workout Preview")
+        .description("Quick glance at your next workout.")
+        .supportedFamilies([.accessoryInline])
+    }
+}
+
+struct LockScreenInlineView: View {
+    let entry: NextWorkoutEntry
+
+    var body: some View {
+        if let name = entry.workoutName {
+            Text("💪 \(name) • \(entry.exerciseCount) exercises")
+        } else if entry.isRestDay {
+            Text("😴 Rest Day — Readiness \(entry.readinessScore)%")
+        } else {
+            Text("🏋️ Ready to train")
+        }
+    }
+}
+
+// MARK: - StandBy Widget (Rectangular, used in StandBy mode)
+
+struct StandByWorkoutWidget: Widget {
+    let kind = "StandByWorkoutWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: NextWorkoutConfigurationIntent.self,
+            provider: NextWorkoutTimelineProvider()
+        ) { entry in
+            StandByWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("GymBro StandBy")
+        .description("Today's readiness and next workout for StandBy mode.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+struct StandByWidgetView: View {
+    let entry: NextWorkoutEntry
+
+    var body: some View {
+        VStack(spacing: 8) {
+            // Readiness score dominant
+            ZStack {
+                Circle()
+                    .trim(from: 0, to: 0.75)
+                    .stroke(.quaternary, lineWidth: 8)
+                    .rotationEffect(.degrees(135))
+
+                Circle()
+                    .trim(from: 0, to: 0.75 * Double(entry.readinessScore) / 100)
+                    .stroke(readinessGradient, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                    .rotationEffect(.degrees(135))
+
+                VStack(spacing: 0) {
+                    Text("\(entry.readinessScore)")
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+
+                    Text("ready")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 80, height: 80)
+
+            if let name = entry.workoutName {
+                Text(name)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+            } else if entry.isRestDay {
+                Text("Rest Day")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+            }
+        }
+        .widgetURL(URL(string: "gymbro://workout"))
+    }
+
+    private var readinessGradient: AngularGradient {
+        AngularGradient(
+            colors: [.red, .orange, .yellow, .green],
+            center: .center,
+            startAngle: .degrees(135),
+            endAngle: .degrees(135 + 270 * Double(entry.readinessScore) / 100)
+        )
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Inline", as: .accessoryInline) {
+    LockScreenInlineWidget()
+} timeline: {
+    NextWorkoutEntry(date: .now, workoutName: "Chest & Triceps", exerciseCount: 5, readinessScore: 82, isRestDay: false)
+}
+
+#Preview("StandBy", as: .systemSmall) {
+    StandByWorkoutWidget()
+} timeline: {
+    NextWorkoutEntry(date: .now, workoutName: "Push Day", exerciseCount: 6, readinessScore: 88, isRestDay: false)
+    NextWorkoutEntry(date: .now, workoutName: nil, exerciseCount: 0, readinessScore: 95, isRestDay: true)
+}

--- a/GymBroWidgets/Widgets/NextWorkoutWidget.swift
+++ b/GymBroWidgets/Widgets/NextWorkoutWidget.swift
@@ -1,0 +1,155 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - Next Workout Widget (Medium)
+
+struct NextWorkoutWidget: Widget {
+    let kind = "NextWorkoutWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: NextWorkoutConfigurationIntent.self,
+            provider: NextWorkoutTimelineProvider()
+        ) { entry in
+            NextWorkoutWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Next Workout")
+        .description("See your next scheduled workout and readiness score.")
+        .supportedFamilies([.systemMedium, .accessoryRectangular])
+    }
+}
+
+// MARK: - Home Screen Medium
+
+struct NextWorkoutWidgetView: View {
+    let entry: NextWorkoutEntry
+
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemMedium:
+            systemMediumView
+        case .accessoryRectangular:
+            rectangularView
+        default:
+            systemMediumView
+        }
+    }
+
+    private var systemMediumView: some View {
+        HStack(spacing: 16) {
+            // Left: Next workout info
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Next Workout", systemImage: "figure.strengthtraining.traditional")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let name = entry.workoutName {
+                    Text(name)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .lineLimit(1)
+
+                    Text("\(entry.exerciseCount) exercises")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else if entry.isRestDay {
+                    Text("Rest Day")
+                        .font(.title2)
+                        .fontWeight(.bold)
+
+                    Text("Recovery is training too")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("No workout planned")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            // Right: Readiness gauge
+            readinessGauge
+        }
+        .widgetURL(URL(string: "gymbro://workout"))
+    }
+
+    private var readinessGauge: some View {
+        VStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .trim(from: 0, to: 0.75)
+                    .stroke(.quaternary, lineWidth: 6)
+                    .rotationEffect(.degrees(135))
+
+                Circle()
+                    .trim(from: 0, to: 0.75 * Double(entry.readinessScore) / 100)
+                    .stroke(readinessColor, style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                    .rotationEffect(.degrees(135))
+
+                Text("\(entry.readinessScore)")
+                    .font(.system(.title3, design: .rounded, weight: .bold))
+            }
+            .frame(width: 64, height: 64)
+
+            Text("Readiness")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var readinessColor: Color {
+        switch entry.readinessScore {
+        case 80...100: .green
+        case 60..<80: .yellow
+        case 40..<60: .orange
+        default: .red
+        }
+    }
+
+    // MARK: - Lock Screen Rectangular
+
+    private var rectangularView: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if let name = entry.workoutName {
+                Text(name)
+                    .font(.headline)
+                    .widgetAccentable()
+
+                Text("\(entry.exerciseCount) exercises • Readiness \(entry.readinessScore)%")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if entry.isRestDay {
+                Text("Rest Day 😴")
+                    .font(.headline)
+                    .widgetAccentable()
+
+                Text("Recover and come back stronger")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .widgetURL(URL(string: "gymbro://workout"))
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Medium", as: .systemMedium) {
+    NextWorkoutWidget()
+} timeline: {
+    NextWorkoutEntry(date: .now, workoutName: "Push Day", exerciseCount: 6, readinessScore: 85, isRestDay: false)
+    NextWorkoutEntry(date: .now, workoutName: nil, exerciseCount: 0, readinessScore: 95, isRestDay: true)
+}
+
+#Preview("Rectangular", as: .accessoryRectangular) {
+    NextWorkoutWidget()
+} timeline: {
+    NextWorkoutEntry(date: .now, workoutName: "Chest & Triceps", exerciseCount: 5, readinessScore: 78, isRestDay: false)
+}

--- a/GymBroWidgets/Widgets/WeeklySummaryWidget.swift
+++ b/GymBroWidgets/Widgets/WeeklySummaryWidget.swift
@@ -1,0 +1,167 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - Weekly Summary Widget (Large)
+
+struct WeeklySummaryWidget: Widget {
+    let kind = "WeeklySummaryWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: WeeklySummaryConfigurationIntent.self,
+            provider: WeeklySummaryTimelineProvider()
+        ) { entry in
+            WeeklySummaryWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Weekly Summary")
+        .description("Overview of your weekly training progress.")
+        .supportedFamilies([.systemLarge])
+    }
+}
+
+// MARK: - Home Screen Large
+
+struct WeeklySummaryWidgetView: View {
+    let entry: WeeklySummaryEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack {
+                Label("This Week", systemImage: "calendar")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("🔥 \(entry.streak)")
+                    .font(.callout)
+            }
+
+            Divider()
+
+            // Stats grid
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                statCard(
+                    title: "Volume",
+                    value: formatVolume(entry.totalVolume),
+                    icon: "scalemass.fill",
+                    color: .blue
+                )
+
+                statCard(
+                    title: "Workouts",
+                    value: "\(entry.workoutCount)",
+                    icon: "figure.strengthtraining.traditional",
+                    color: .green
+                )
+
+                statCard(
+                    title: "PRs This Week",
+                    value: "\(entry.recentPRs)",
+                    icon: "trophy.fill",
+                    color: .yellow
+                )
+
+                statCard(
+                    title: "Streak",
+                    value: "\(entry.streak) days",
+                    icon: "flame.fill",
+                    color: .orange
+                )
+            }
+
+            Divider()
+
+            // Next workout preview
+            HStack {
+                Image(systemName: "arrow.right.circle.fill")
+                    .foregroundStyle(.blue)
+                if let next = entry.nextWorkoutName {
+                    Text("Up next: \(next)")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                } else {
+                    Text("No workout scheduled")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+        }
+        .widgetURL(URL(string: "gymbro://history"))
+    }
+
+    private func statCard(title: String, value: String, icon: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .foregroundStyle(color)
+                    .font(.caption)
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(value)
+                .font(.system(.title3, design: .rounded, weight: .bold))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func formatVolume(_ volume: Double) -> String {
+        if volume >= 1000 {
+            return String(format: "%.1fk kg", volume / 1000)
+        }
+        return String(format: "%.0f kg", volume)
+    }
+}
+
+// MARK: - Readiness Widget (Lock Screen Circular Gauge)
+
+struct ReadinessWidget: Widget {
+    let kind = "ReadinessWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: NextWorkoutConfigurationIntent.self,
+            provider: NextWorkoutTimelineProvider()
+        ) { entry in
+            ReadinessWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Readiness")
+        .description("Your current training readiness score.")
+        .supportedFamilies([.accessoryCircular])
+    }
+}
+
+struct ReadinessWidgetView: View {
+    let entry: NextWorkoutEntry
+
+    var body: some View {
+        Gauge(value: Double(entry.readinessScore), in: 0...100) {
+            Image(systemName: "bolt.fill")
+        } currentValueLabel: {
+            Text("\(entry.readinessScore)")
+                .font(.system(.body, design: .rounded, weight: .bold))
+        }
+        .gaugeStyle(.accessoryCircular)
+        .widgetURL(URL(string: "gymbro://workout"))
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Large", as: .systemLarge) {
+    WeeklySummaryWidget()
+} timeline: {
+    WeeklySummaryEntry(date: .now, totalVolume: 14250, workoutCount: 4, recentPRs: 2, streak: 7, nextWorkoutName: "Legs")
+}
+
+#Preview("Readiness Circular", as: .accessoryCircular) {
+    ReadinessWidget()
+} timeline: {
+    NextWorkoutEntry(date: .now, workoutName: "Push", exerciseCount: 5, readinessScore: 82, isRestDay: false)
+}

--- a/GymBroWidgets/Widgets/WorkoutStreakWidget.swift
+++ b/GymBroWidgets/Widgets/WorkoutStreakWidget.swift
@@ -1,0 +1,145 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - Workout Streak Widget (Small)
+
+struct WorkoutStreakWidget: Widget {
+    let kind = "WorkoutStreakWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: WorkoutStreakConfigurationIntent.self,
+            provider: WorkoutStreakTimelineProvider()
+        ) { entry in
+            WorkoutStreakWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Workout Streak")
+        .description("Track your consecutive workout days.")
+        .supportedFamilies([.systemSmall, .accessoryCircular, .accessoryRectangular, .accessoryInline])
+    }
+}
+
+// MARK: - Home Screen Small
+
+struct WorkoutStreakWidgetView: View {
+    let entry: WorkoutStreakEntry
+
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            systemSmallView
+        case .accessoryCircular:
+            circularView
+        case .accessoryRectangular:
+            rectangularView
+        case .accessoryInline:
+            inlineView
+        default:
+            systemSmallView
+        }
+    }
+
+    private var systemSmallView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "flame.fill")
+                    .foregroundStyle(.orange)
+                    .font(.title2)
+                Spacer()
+            }
+
+            Spacer()
+
+            Text("\(entry.streak)")
+                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+
+            Text(entry.streak == 1 ? "day streak" : "day streak")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if entry.daysSinceLastWorkout > 0 {
+                Text("\(entry.daysSinceLastWorkout)d since last workout")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .widgetURL(URL(string: "gymbro://workout"))
+    }
+
+    // MARK: - Lock Screen Circular
+
+    private var circularView: some View {
+        ZStack {
+            AccessoryWidgetBackground()
+
+            VStack(spacing: 1) {
+                Image(systemName: "flame.fill")
+                    .font(.caption)
+                Text("\(entry.streak)")
+                    .font(.system(.title2, design: .rounded, weight: .bold))
+            }
+        }
+        .widgetURL(URL(string: "gymbro://workout"))
+    }
+
+    // MARK: - Lock Screen Rectangular
+
+    private var rectangularView: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "flame.fill")
+                .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(entry.streak)-day streak")
+                    .font(.headline)
+                    .widgetAccentable()
+
+                if entry.daysSinceLastWorkout > 0 {
+                    Text("Last workout \(entry.daysSinceLastWorkout)d ago")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Trained today 💪")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+        }
+        .widgetURL(URL(string: "gymbro://workout"))
+    }
+
+    // MARK: - Lock Screen Inline
+
+    private var inlineView: some View {
+        Text("🔥 \(entry.streak)-day streak")
+            .widgetURL(URL(string: "gymbro://workout"))
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Small", as: .systemSmall) {
+    WorkoutStreakWidget()
+} timeline: {
+    WorkoutStreakEntry(date: .now, streak: 5, daysSinceLastWorkout: 0)
+    WorkoutStreakEntry(date: .now, streak: 0, daysSinceLastWorkout: 3)
+}
+
+#Preview("Circular", as: .accessoryCircular) {
+    WorkoutStreakWidget()
+} timeline: {
+    WorkoutStreakEntry(date: .now, streak: 12, daysSinceLastWorkout: 0)
+}
+
+#Preview("Rectangular", as: .accessoryRectangular) {
+    WorkoutStreakWidget()
+} timeline: {
+    WorkoutStreakEntry(date: .now, streak: 7, daysSinceLastWorkout: 1)
+}

--- a/Packages/GymBroCore/Sources/GymBroCore/Models/WorkoutActivityAttributes.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Models/WorkoutActivityAttributes.swift
@@ -1,0 +1,59 @@
+import Foundation
+import ActivityKit
+
+/// Defines the static and dynamic data for the workout Live Activity.
+public struct WorkoutActivityAttributes: ActivityAttributes {
+    /// Static data set when the Live Activity starts (does not change).
+    public struct ContentState: Codable, Hashable {
+        // Current exercise info
+        public var exerciseName: String
+        public var currentSetNumber: Int
+        public var totalPlannedSets: Int
+
+        // Rest timer state
+        public var restTimerEndDate: Date?
+        public var restTimerDuration: Int
+
+        // Workout progress
+        public var completedSets: Int
+        public var totalVolume: Double
+        public var elapsedSeconds: Int
+
+        // Weight/reps for current set display
+        public var lastWeight: Double
+        public var lastReps: Int
+
+        public init(
+            exerciseName: String = "Starting...",
+            currentSetNumber: Int = 1,
+            totalPlannedSets: Int = 0,
+            restTimerEndDate: Date? = nil,
+            restTimerDuration: Int = 0,
+            completedSets: Int = 0,
+            totalVolume: Double = 0,
+            elapsedSeconds: Int = 0,
+            lastWeight: Double = 0,
+            lastReps: Int = 0
+        ) {
+            self.exerciseName = exerciseName
+            self.currentSetNumber = currentSetNumber
+            self.totalPlannedSets = totalPlannedSets
+            self.restTimerEndDate = restTimerEndDate
+            self.restTimerDuration = restTimerDuration
+            self.completedSets = completedSets
+            self.totalVolume = totalVolume
+            self.elapsedSeconds = elapsedSeconds
+            self.lastWeight = lastWeight
+            self.lastReps = lastReps
+        }
+    }
+
+    // Static attributes set at activity creation
+    public var workoutId: String
+    public var workoutStartDate: Date
+
+    public init(workoutId: String, workoutStartDate: Date = .now) {
+        self.workoutId = workoutId
+        self.workoutStartDate = workoutStartDate
+    }
+}

--- a/Packages/GymBroCore/Sources/GymBroCore/Services/LiveActivityService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/LiveActivityService.swift
@@ -1,0 +1,187 @@
+import Foundation
+import ActivityKit
+import os
+
+/// Manages the Live Activity lifecycle for active workout sessions.
+/// Handles starting, updating, and ending the Live Activity + Dynamic Island.
+@MainActor
+@Observable
+public final class LiveActivityService {
+    public static let shared = LiveActivityService()
+    private static let logger = Logger(subsystem: "com.gymbro", category: "LiveActivity")
+
+    public private(set) var isActivityActive: Bool = false
+    private var currentActivity: Activity<WorkoutActivityAttributes>?
+
+    private init() {}
+
+    // MARK: - Start
+
+    /// Starts a Live Activity when a workout begins.
+    public func startWorkoutActivity(workoutId: String) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            Self.logger.info("Live Activities are disabled by the user.")
+            return
+        }
+
+        let attributes = WorkoutActivityAttributes(
+            workoutId: workoutId,
+            workoutStartDate: .now
+        )
+
+        let initialState = WorkoutActivityAttributes.ContentState()
+
+        do {
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: initialState, staleDate: nil),
+                pushType: nil
+            )
+            currentActivity = activity
+            isActivityActive = true
+            Self.logger.info("Live Activity started: \(activity.id)")
+        } catch {
+            Self.logger.error("Failed to start Live Activity: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Update
+
+    /// Updates the Live Activity with new workout state (set completion, exercise change).
+    public func updateWorkoutActivity(
+        exerciseName: String,
+        currentSetNumber: Int,
+        totalPlannedSets: Int = 0,
+        completedSets: Int,
+        totalVolume: Double,
+        elapsedSeconds: Int,
+        lastWeight: Double,
+        lastReps: Int
+    ) {
+        guard let activity = currentActivity else { return }
+
+        let updatedState = WorkoutActivityAttributes.ContentState(
+            exerciseName: exerciseName,
+            currentSetNumber: currentSetNumber,
+            totalPlannedSets: totalPlannedSets,
+            restTimerEndDate: nil,
+            restTimerDuration: 0,
+            completedSets: completedSets,
+            totalVolume: totalVolume,
+            elapsedSeconds: elapsedSeconds,
+            lastWeight: lastWeight,
+            lastReps: lastReps
+        )
+
+        Task {
+            await activity.update(.init(state: updatedState, staleDate: nil))
+            Self.logger.debug("Live Activity updated: set \(currentSetNumber)")
+        }
+    }
+
+    /// Updates the Live Activity with rest timer countdown.
+    public func updateRestTimer(
+        exerciseName: String,
+        currentSetNumber: Int,
+        totalPlannedSets: Int = 0,
+        restDuration: Int,
+        completedSets: Int,
+        totalVolume: Double,
+        elapsedSeconds: Int,
+        lastWeight: Double,
+        lastReps: Int
+    ) {
+        guard let activity = currentActivity else { return }
+
+        let restEndDate = Date().addingTimeInterval(Double(restDuration))
+
+        let updatedState = WorkoutActivityAttributes.ContentState(
+            exerciseName: exerciseName,
+            currentSetNumber: currentSetNumber,
+            totalPlannedSets: totalPlannedSets,
+            restTimerEndDate: restEndDate,
+            restTimerDuration: restDuration,
+            completedSets: completedSets,
+            totalVolume: totalVolume,
+            elapsedSeconds: elapsedSeconds,
+            lastWeight: lastWeight,
+            lastReps: lastReps
+        )
+
+        Task {
+            await activity.update(.init(state: updatedState, staleDate: restEndDate))
+            Self.logger.debug("Live Activity rest timer updated: \(restDuration)s")
+        }
+    }
+
+    /// Clears the rest timer from the Live Activity (timer completed or skipped).
+    public func clearRestTimer(
+        exerciseName: String,
+        currentSetNumber: Int,
+        totalPlannedSets: Int = 0,
+        completedSets: Int,
+        totalVolume: Double,
+        elapsedSeconds: Int,
+        lastWeight: Double,
+        lastReps: Int
+    ) {
+        updateWorkoutActivity(
+            exerciseName: exerciseName,
+            currentSetNumber: currentSetNumber,
+            totalPlannedSets: totalPlannedSets,
+            completedSets: completedSets,
+            totalVolume: totalVolume,
+            elapsedSeconds: elapsedSeconds,
+            lastWeight: lastWeight,
+            lastReps: lastReps
+        )
+    }
+
+    // MARK: - End
+
+    /// Ends the Live Activity when workout finishes, showing a brief summary.
+    public func endWorkoutActivity(
+        totalSets: Int,
+        totalVolume: Double,
+        durationSeconds: Int
+    ) {
+        guard let activity = currentActivity else { return }
+
+        let finalState = WorkoutActivityAttributes.ContentState(
+            exerciseName: "Workout Complete 🎉",
+            currentSetNumber: 0,
+            totalPlannedSets: 0,
+            restTimerEndDate: nil,
+            restTimerDuration: 0,
+            completedSets: totalSets,
+            totalVolume: totalVolume,
+            elapsedSeconds: durationSeconds,
+            lastWeight: 0,
+            lastReps: 0
+        )
+
+        Task {
+            await activity.end(
+                .init(state: finalState, staleDate: nil),
+                dismissalPolicy: .after(.now.addingTimeInterval(30))
+            )
+            Self.logger.info("Live Activity ended after \(durationSeconds)s")
+        }
+
+        currentActivity = nil
+        isActivityActive = false
+    }
+
+    /// Immediately dismisses the Live Activity (workout cancelled).
+    public func dismissWorkoutActivity() {
+        guard let activity = currentActivity else { return }
+
+        Task {
+            await activity.end(nil, dismissalPolicy: .immediate)
+            Self.logger.info("Live Activity dismissed")
+        }
+
+        currentActivity = nil
+        isActivityActive = false
+    }
+}

--- a/Packages/GymBroCore/Sources/GymBroCore/Services/WidgetDataProvider.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/WidgetDataProvider.swift
@@ -1,0 +1,173 @@
+import Foundation
+import SwiftData
+
+/// Provides snapshot data for widgets by querying the shared SwiftData container.
+/// Widgets use this to fetch workout stats without depending on the main app process.
+@MainActor
+public struct WidgetDataProvider {
+    private let modelContext: ModelContext
+
+    public init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Streak
+
+    /// Returns the current consecutive-day workout streak.
+    public func currentStreak() -> Int {
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { $0.endTime != nil && !$0.isCancelled },
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+
+        guard let workouts = try? modelContext.fetch(descriptor), !workouts.isEmpty else {
+            return 0
+        }
+
+        let calendar = Calendar.current
+        var streak = 0
+        var checkDate = calendar.startOfDay(for: Date())
+
+        let workoutDates = Set(workouts.map { calendar.startOfDay(for: $0.date) })
+
+        while workoutDates.contains(checkDate) {
+            streak += 1
+            guard let previous = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
+            checkDate = previous
+        }
+
+        return streak
+    }
+
+    /// Days since the most recent completed workout.
+    public func daysSinceLastWorkout() -> Int {
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { $0.endTime != nil && !$0.isCancelled },
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+
+        guard let workouts = try? modelContext.fetch(descriptor),
+              let latest = workouts.first else {
+            return 0
+        }
+
+        return Calendar.current.dateComponents([.day], from: latest.date, to: Date()).day ?? 0
+    }
+
+    // MARK: - Weekly Volume
+
+    /// Total volume (kg) for the current calendar week.
+    public func weeklyVolume() -> Double {
+        let calendar = Calendar.current
+        let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: Date())?.start ?? Date()
+
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { $0.endTime != nil && !$0.isCancelled && $0.date >= startOfWeek }
+        )
+
+        guard let workouts = try? modelContext.fetch(descriptor) else { return 0 }
+        return workouts.reduce(0) { $0 + $1.totalVolume }
+    }
+
+    /// Number of completed workouts this calendar week.
+    public func weeklyWorkoutCount() -> Int {
+        let calendar = Calendar.current
+        let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: Date())?.start ?? Date()
+
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { $0.endTime != nil && !$0.isCancelled && $0.date >= startOfWeek }
+        )
+
+        return (try? modelContext.fetch(descriptor))?.count ?? 0
+    }
+
+    // MARK: - Next Workout
+
+    /// Returns info about the next scheduled workout from an active program, if any.
+    public func nextScheduledWorkout() -> NextWorkoutInfo? {
+        // Query active programs to find the next scheduled day
+        let descriptor = FetchDescriptor<Program>(
+            predicate: #Predicate<Program> { $0.isActive }
+        )
+
+        guard let programs = try? modelContext.fetch(descriptor),
+              let program = programs.first,
+              let nextDay = program.days.first else {
+            return nil
+        }
+
+        return NextWorkoutInfo(
+            name: nextDay.name,
+            scheduledDate: nil,
+            exerciseCount: nextDay.plannedExercises.count
+        )
+    }
+
+    // MARK: - Recent PRs
+
+    /// Number of personal records set in the last 7 days.
+    public func recentPRCount() -> Int {
+        let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+
+        let descriptor = FetchDescriptor<ExerciseSet>(
+            predicate: #Predicate<ExerciseSet> {
+                $0.completedAt != nil && $0.createdAt >= weekAgo && $0.setType == .working
+            }
+        )
+
+        // Simplified PR approximation: count sets that are the highest e1RM for their exercise
+        guard let sets = try? modelContext.fetch(descriptor) else { return 0 }
+
+        var prCount = 0
+        let byExercise = Dictionary(grouping: sets) { $0.exercise?.id }
+
+        for (_, exerciseSets) in byExercise {
+            if let best = exerciseSets.max(by: { $0.estimatedOneRepMax < $1.estimatedOneRepMax }) {
+                // Check if this is truly a PR against all-time history
+                if let exerciseId = best.exercise?.id {
+                    let allTimeDescriptor = FetchDescriptor<ExerciseSet>(
+                        predicate: #Predicate<ExerciseSet> {
+                            $0.exercise?.id == exerciseId && $0.completedAt != nil && $0.setType == .working
+                        }
+                    )
+                    if let allSets = try? modelContext.fetch(allTimeDescriptor) {
+                        let allTimeMax = allSets.map(\.estimatedOneRepMax).max() ?? 0
+                        if best.estimatedOneRepMax >= allTimeMax {
+                            prCount += 1
+                        }
+                    }
+                }
+            }
+        }
+
+        return prCount
+    }
+}
+
+// MARK: - Data Transfer Types
+
+public struct NextWorkoutInfo {
+    public let name: String
+    public let scheduledDate: Date?
+    public let exerciseCount: Int
+}
+
+public struct WidgetSnapshot {
+    public let streak: Int
+    public let daysSinceLastWorkout: Int
+    public let weeklyVolume: Double
+    public let weeklyWorkoutCount: Int
+    public let recentPRs: Int
+    public let nextWorkout: NextWorkoutInfo?
+    public let readinessScore: Int // 0-100
+
+    public static let placeholder = WidgetSnapshot(
+        streak: 5,
+        daysSinceLastWorkout: 0,
+        weeklyVolume: 12500,
+        weeklyWorkoutCount: 4,
+        recentPRs: 2,
+        nextWorkout: NextWorkoutInfo(name: "Push Day", scheduledDate: nil, exerciseCount: 6),
+        readinessScore: 85
+    )
+}

--- a/Packages/GymBroCore/Tests/GymBroCoreTests/WidgetDataProviderTests.swift
+++ b/Packages/GymBroCore/Tests/GymBroCoreTests/WidgetDataProviderTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import GymBroCore
+
+@Suite("WidgetDataProvider Tests")
+struct WidgetDataProviderTests {
+
+    @Test("WidgetSnapshot placeholder has reasonable values")
+    func placeholderValues() {
+        let placeholder = WidgetSnapshot.placeholder
+        #expect(placeholder.streak == 5)
+        #expect(placeholder.weeklyVolume == 12500)
+        #expect(placeholder.weeklyWorkoutCount == 4)
+        #expect(placeholder.recentPRs == 2)
+        #expect(placeholder.readinessScore == 85)
+        #expect(placeholder.nextWorkout?.name == "Push Day")
+    }
+
+    @Test("NextWorkoutInfo stores values correctly")
+    func nextWorkoutInfo() {
+        let info = NextWorkoutInfo(name: "Pull Day", scheduledDate: nil, exerciseCount: 5)
+        #expect(info.name == "Pull Day")
+        #expect(info.scheduledDate == nil)
+        #expect(info.exerciseCount == 5)
+    }
+
+    @Test("NextWorkoutInfo with scheduled date")
+    func nextWorkoutInfoWithDate() {
+        let date = Date()
+        let info = NextWorkoutInfo(name: "Legs", scheduledDate: date, exerciseCount: 8)
+        #expect(info.name == "Legs")
+        #expect(info.scheduledDate == date)
+        #expect(info.exerciseCount == 8)
+    }
+
+    @Test("WidgetSnapshot stores all fields")
+    func snapshotFields() {
+        let next = NextWorkoutInfo(name: "Upper", scheduledDate: nil, exerciseCount: 6)
+        let snapshot = WidgetSnapshot(
+            streak: 3,
+            daysSinceLastWorkout: 1,
+            weeklyVolume: 8000,
+            weeklyWorkoutCount: 3,
+            recentPRs: 1,
+            nextWorkout: next,
+            readinessScore: 72
+        )
+
+        #expect(snapshot.streak == 3)
+        #expect(snapshot.daysSinceLastWorkout == 1)
+        #expect(snapshot.weeklyVolume == 8000)
+        #expect(snapshot.weeklyWorkoutCount == 3)
+        #expect(snapshot.recentPRs == 1)
+        #expect(snapshot.readinessScore == 72)
+        #expect(snapshot.nextWorkout?.name == "Upper")
+    }
+}

--- a/Packages/GymBroCore/Tests/GymBroCoreTests/WorkoutActivityAttributesTests.swift
+++ b/Packages/GymBroCore/Tests/GymBroCoreTests/WorkoutActivityAttributesTests.swift
@@ -1,0 +1,102 @@
+import Testing
+import Foundation
+@testable import GymBroCore
+
+@Suite("WorkoutActivityAttributes Tests")
+struct WorkoutActivityAttributesTests {
+
+    @Test("Default ContentState has sensible defaults")
+    func defaultContentState() {
+        let state = WorkoutActivityAttributes.ContentState()
+        #expect(state.exerciseName == "Starting...")
+        #expect(state.currentSetNumber == 1)
+        #expect(state.totalPlannedSets == 0)
+        #expect(state.restTimerEndDate == nil)
+        #expect(state.restTimerDuration == 0)
+        #expect(state.completedSets == 0)
+        #expect(state.totalVolume == 0)
+        #expect(state.elapsedSeconds == 0)
+        #expect(state.lastWeight == 0)
+        #expect(state.lastReps == 0)
+    }
+
+    @Test("ContentState initializes with custom values")
+    func customContentState() {
+        let endDate = Date().addingTimeInterval(120)
+        let state = WorkoutActivityAttributes.ContentState(
+            exerciseName: "Bench Press",
+            currentSetNumber: 3,
+            totalPlannedSets: 5,
+            restTimerEndDate: endDate,
+            restTimerDuration: 120,
+            completedSets: 2,
+            totalVolume: 500,
+            elapsedSeconds: 600,
+            lastWeight: 100,
+            lastReps: 5
+        )
+
+        #expect(state.exerciseName == "Bench Press")
+        #expect(state.currentSetNumber == 3)
+        #expect(state.totalPlannedSets == 5)
+        #expect(state.restTimerEndDate == endDate)
+        #expect(state.restTimerDuration == 120)
+        #expect(state.completedSets == 2)
+        #expect(state.totalVolume == 500)
+        #expect(state.elapsedSeconds == 600)
+        #expect(state.lastWeight == 100)
+        #expect(state.lastReps == 5)
+    }
+
+    @Test("Attributes store workout ID and start date")
+    func attributesInit() {
+        let startDate = Date()
+        let attrs = WorkoutActivityAttributes(workoutId: "test-123", workoutStartDate: startDate)
+        #expect(attrs.workoutId == "test-123")
+        #expect(attrs.workoutStartDate == startDate)
+    }
+
+    @Test("ContentState conforms to Codable")
+    func contentStateCodable() throws {
+        let original = WorkoutActivityAttributes.ContentState(
+            exerciseName: "Squat",
+            currentSetNumber: 2,
+            totalPlannedSets: 4,
+            completedSets: 1,
+            totalVolume: 300,
+            elapsedSeconds: 420,
+            lastWeight: 140,
+            lastReps: 5
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(WorkoutActivityAttributes.ContentState.self, from: data)
+
+        #expect(decoded.exerciseName == original.exerciseName)
+        #expect(decoded.currentSetNumber == original.currentSetNumber)
+        #expect(decoded.totalPlannedSets == original.totalPlannedSets)
+        #expect(decoded.completedSets == original.completedSets)
+        #expect(decoded.totalVolume == original.totalVolume)
+        #expect(decoded.lastWeight == original.lastWeight)
+        #expect(decoded.lastReps == original.lastReps)
+    }
+
+    @Test("ContentState conforms to Hashable")
+    func contentStateHashable() {
+        let state1 = WorkoutActivityAttributes.ContentState(exerciseName: "Bench", currentSetNumber: 1)
+        let state2 = WorkoutActivityAttributes.ContentState(exerciseName: "Bench", currentSetNumber: 1)
+        let state3 = WorkoutActivityAttributes.ContentState(exerciseName: "Squat", currentSetNumber: 2)
+
+        #expect(state1 == state2)
+        #expect(state1 != state3)
+    }
+
+    @Test("LiveActivityService singleton exists")
+    @MainActor
+    func singletonExists() {
+        let service = LiveActivityService.shared
+        #expect(service.isActivityActive == false)
+    }
+}

--- a/Packages/GymBroUI/Sources/GymBroUI/ViewModels/ActiveWorkoutViewModel.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/ViewModels/ActiveWorkoutViewModel.swift
@@ -76,6 +76,9 @@ public final class ActiveWorkoutViewModel {
             Self.logger.error("Failed to save workout start: \(error.localizedDescription)")
             saveError = "Failed to save workout. Please try again."
         }
+
+        // Start Live Activity for Dynamic Island + Lock Screen
+        LiveActivityService.shared.startWorkoutActivity(workoutId: workout.id.uuidString)
     }
     
     public func setActiveExercise(_ exercise: Exercise) {
@@ -146,6 +149,9 @@ public final class ActiveWorkoutViewModel {
         if isWarmup {
             isWarmup = false
         }
+
+        // Update Live Activity with new set info
+        updateLiveActivityState()
     }
     
     public func addExercise(_ exercise: Exercise) {
@@ -171,6 +177,13 @@ public final class ActiveWorkoutViewModel {
             totalSets: workout.totalSets,
             personalRecords: countPersonalRecords()
         )
+
+        // End Live Activity with summary
+        LiveActivityService.shared.endWorkoutActivity(
+            totalSets: summary.totalSets,
+            totalVolume: summary.totalVolume,
+            durationSeconds: Int(summary.duration)
+        )
         
         return summary
     }
@@ -186,6 +199,9 @@ public final class ActiveWorkoutViewModel {
             Self.logger.error("Failed to save cancelled workout: \(error.localizedDescription)")
             saveError = "Failed to cancel workout. Your data may not be persisted."
         }
+
+        // Dismiss Live Activity immediately
+        LiveActivityService.shared.dismissWorkoutActivity()
     }
     
     private func loadSmartDefaults(for exercise: Exercise) {
@@ -199,13 +215,53 @@ public final class ActiveWorkoutViewModel {
     private func startRestTimer() {
         restTimerEndTime = Date().addingTimeInterval(TimeInterval(restTimerSeconds))
         isRestTimerActive = true
+
+        // Push rest timer to Live Activity / Dynamic Island
+        if let exercise = activeExercise {
+            LiveActivityService.shared.updateRestTimer(
+                exerciseName: exercise.name,
+                currentSetNumber: activeSetNumber,
+                restDuration: restTimerSeconds,
+                completedSets: totalCompletedSets,
+                totalVolume: totalVolume,
+                elapsedSeconds: Int(workoutDuration),
+                lastWeight: currentWeight,
+                lastReps: currentReps
+            )
+        }
     }
     
     public func skipRestTimer() {
         restTimerEndTime = nil
         isRestTimerActive = false
+
+        // Clear rest timer from Live Activity
+        if let exercise = activeExercise {
+            LiveActivityService.shared.clearRestTimer(
+                exerciseName: exercise.name,
+                currentSetNumber: activeSetNumber,
+                completedSets: totalCompletedSets,
+                totalVolume: totalVolume,
+                elapsedSeconds: Int(workoutDuration),
+                lastWeight: currentWeight,
+                lastReps: currentReps
+            )
+        }
     }
     
+    private func updateLiveActivityState() {
+        guard let exercise = activeExercise else { return }
+        LiveActivityService.shared.updateWorkoutActivity(
+            exerciseName: exercise.name,
+            currentSetNumber: activeSetNumber,
+            completedSets: totalCompletedSets,
+            totalVolume: totalVolume,
+            elapsedSeconds: Int(workoutDuration),
+            lastWeight: currentWeight,
+            lastReps: currentReps
+        )
+    }
+
     private func isPR(set: ExerciseSet) -> Bool {
         guard let exercise = activeExercise else { return false }
         


### PR DESCRIPTION
## Summary

Implements WidgetKit widgets (home screen, Lock Screen, StandBy) and ActivityKit Live Activity with Dynamic Island support for active workout sessions.

### Widgets (Issue #15)
- **Home screen**: WorkoutStreakWidget (small), NextWorkoutWidget (medium), WeeklySummaryWidget (large)
- **Lock Screen**: Circular streak/readiness gauge, rectangular next workout preview, inline text
- **StandBy**: Readiness score gauge with next workout name
- AppIntentTimelineProvider with 30-min refresh, deep links, placeholder views
- WidgetDataProvider in GymBroCore queries SwiftData for streak, volume, PRs

### Live Activity + Dynamic Island (Issue #16)
- WorkoutActivityAttributes + ContentState for exercise/timer/stats
- LiveActivityService singleton: start/update/end lifecycle
- Dynamic Island compact: timer + set count | expanded: exercise, weight, reps, timer, stats
- Lock Screen banner with rest timer countdown (orange highlight)
- Rest timer uses system \Text(timerInterval:countsDown:)\ for background-safe countdown
- ActiveWorkoutViewModel fully integrated: updates on set complete, rest timer, finish/cancel

### Tests
- WorkoutActivityAttributes (defaults, Codable, Hashable)
- WidgetDataProvider data types and placeholder values

Closes #15
Closes #16