### PR TITLE
feat: PR celebration UI — confetti overlay, badges, and history view (#111)

### DIFF
--- a/.changeset/pr-celebration-ui.md
+++ b/.changeset/pr-celebration-ui.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': minor
+---
+
+PR celebration UI: PRDetectionService wraps PersonalRecordService to check PRs after each set. PRCelebrationOverlay shows confetti + trophy badge with auto-dismiss. PRBadge marks PR sets inline. PRHistoryView lists all-time PRs per exercise. Wired into ActiveWorkoutViewModel with full test coverage.

--- a/Packages/GymBroCore/Sources/GymBroCore/Services/PRDetectionService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/PRDetectionService.swift
@@ -1,0 +1,98 @@
+import Foundation
+import SwiftData
+import os
+
+/// Result of a PR check — which record types were broken and the values achieved.
+public struct PRDetectionResult: Sendable {
+    public let exerciseName: String
+    public let recordTypes: [PersonalRecord.RecordType]
+    public let weight: Double
+    public let reps: Int
+    public let e1rm: Double
+
+    public var isPR: Bool { !recordTypes.isEmpty }
+
+    /// Human-readable badge text for the highest-priority record type.
+    public var primaryBadgeText: String {
+        guard let primary = recordTypes.first else { return "" }
+        switch primary {
+        case .maxE1RM:   return "New 1RM!"
+        case .maxWeight: return "Weight PR!"
+        case .maxVolume: return "Volume Record!"
+        case .maxReps:   return "Rep PR!"
+        }
+    }
+
+    /// Short detail string shown below the badge.
+    public var detailText: String {
+        guard let primary = recordTypes.first else { return "" }
+        switch primary {
+        case .maxE1RM:
+            return String(format: "%.1f kg estimated 1RM", e1rm)
+        case .maxWeight:
+            return String(format: "%.1f kg × %d", weight, reps)
+        case .maxVolume:
+            return String(format: "%.0f kg volume", weight * Double(reps))
+        case .maxReps:
+            return "\(reps) reps @ \(String(format: "%.1f", weight)) kg"
+        }
+    }
+}
+
+/// Checks whether a just-completed set is a new personal record.
+/// Thin wrapper around PersonalRecordService with caching-friendly API.
+public final class PRDetectionService {
+    private static let logger = Logger(subsystem: "com.gymbro", category: "PRDetection")
+
+    private let personalRecordService: PersonalRecordService
+
+    public init(modelContext: ModelContext) {
+        self.personalRecordService = PersonalRecordService(modelContext: modelContext)
+    }
+
+    /// Check all PR categories for a just-completed set.
+    public func checkForPR(set: ExerciseSet) -> PRDetectionResult {
+        let exerciseName = set.exercise?.name ?? "Unknown"
+
+        do {
+            let recordTypes = try personalRecordService.getRecordTypes(for: set)
+            // Sort by priority: e1RM > weight > volume > reps
+            let sorted = recordTypes.sorted { priority($0) < priority($1) }
+            return PRDetectionResult(
+                exerciseName: exerciseName,
+                recordTypes: sorted,
+                weight: set.weightKg,
+                reps: set.reps,
+                e1rm: set.estimatedOneRepMax
+            )
+        } catch {
+            Self.logger.error("PR detection failed: \(error.localizedDescription)")
+            return PRDetectionResult(
+                exerciseName: exerciseName,
+                recordTypes: [],
+                weight: set.weightKg,
+                reps: set.reps,
+                e1rm: set.estimatedOneRepMax
+            )
+        }
+    }
+
+    /// Fetch all-time PRs for an exercise, one per record type.
+    public func getAllTimePRs(for exercise: Exercise) -> [PersonalRecord] {
+        do {
+            return try personalRecordService.getPersonalRecords(for: exercise)
+        } catch {
+            Self.logger.error("Failed to fetch all-time PRs: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    private func priority(_ type: PersonalRecord.RecordType) -> Int {
+        switch type {
+        case .maxE1RM:   return 0
+        case .maxWeight: return 1
+        case .maxVolume: return 2
+        case .maxReps:   return 3
+        }
+    }
+}

--- a/Packages/GymBroCore/Sources/GymBroCore/Services/PersonalRecordService.swift
+++ b/Packages/GymBroCore/Sources/GymBroCore/Services/PersonalRecordService.swift
@@ -6,7 +6,7 @@ public struct PersonalRecord {
     public let exerciseSet: ExerciseSet
     public let recordType: RecordType
     
-    public enum RecordType {
+    public enum RecordType: Hashable, Sendable {
         case maxWeight
         case maxReps
         case maxVolume

--- a/Packages/GymBroCore/Tests/GymBroCoreTests/PRDetectionServiceTests.swift
+++ b/Packages/GymBroCore/Tests/GymBroCoreTests/PRDetectionServiceTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+import SwiftData
+@testable import GymBroCore
+
+final class PRDetectionServiceTests: XCTestCase {
+    var modelContext: ModelContext!
+    var exercise: Exercise!
+    var workout: Workout!
+    var service: PRDetectionService!
+
+    override func setUp() async throws {
+        let schema = Schema([
+            Workout.self,
+            Exercise.self,
+            ExerciseSet.self,
+            Program.self,
+            ProgramDay.self,
+            PlannedExercise.self,
+            UserProfile.self,
+            BodyweightEntry.self,
+            MuscleGroup.self,
+            SupersetGroup.self,
+            ProgramWeek.self
+        ])
+
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        modelContext = ModelContext(container)
+
+        exercise = Exercise(name: "Bench Press", category: .compound, equipment: .barbell)
+        workout = Workout()
+        modelContext.insert(exercise)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        service = PRDetectionService(modelContext: modelContext)
+    }
+
+    // MARK: - First set is always a PR
+
+    func testFirstWorkingSetIsAlwaysPR() throws {
+        let set = ExerciseSet(exercise: exercise, workout: workout, weightKg: 100, reps: 5, setType: .working)
+        set.completedAt = Date()
+        modelContext.insert(set)
+        try modelContext.save()
+
+        let result = service.checkForPR(set: set)
+
+        XCTAssertTrue(result.isPR)
+        XCTAssertFalse(result.recordTypes.isEmpty)
+        XCTAssertEqual(result.exerciseName, "Bench Press")
+        XCTAssertEqual(result.weight, 100)
+        XCTAssertEqual(result.reps, 5)
+    }
+
+    // MARK: - Weight PR detection
+
+    func testDetectsWeightPR() throws {
+        let oldSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 80, reps: 5, setType: .working)
+        oldSet.completedAt = Date().addingTimeInterval(-3600)
+        modelContext.insert(oldSet)
+        try modelContext.save()
+
+        let newSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 85, reps: 5, setType: .working)
+        newSet.completedAt = Date()
+        modelContext.insert(newSet)
+        try modelContext.save()
+
+        let result = service.checkForPR(set: newSet)
+
+        XCTAssertTrue(result.isPR)
+        XCTAssertTrue(result.recordTypes.contains(.maxWeight))
+    }
+
+    // MARK: - No PR when values don't beat records
+
+    func testNoPRWhenBelowPreviousBest() throws {
+        let oldSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 100, reps: 10, setType: .working)
+        oldSet.completedAt = Date().addingTimeInterval(-3600)
+        modelContext.insert(oldSet)
+        try modelContext.save()
+
+        let newSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 80, reps: 5, setType: .working)
+        newSet.completedAt = Date()
+        modelContext.insert(newSet)
+        try modelContext.save()
+
+        let result = service.checkForPR(set: newSet)
+
+        XCTAssertFalse(result.isPR)
+        XCTAssertTrue(result.recordTypes.isEmpty)
+    }
+
+    // MARK: - Warmup sets excluded
+
+    func testWarmupSetIsNeverPR() throws {
+        let set = ExerciseSet(exercise: exercise, workout: workout, weightKg: 200, reps: 1, setType: .warmup)
+        set.completedAt = Date()
+        modelContext.insert(set)
+        try modelContext.save()
+
+        let result = service.checkForPR(set: set)
+
+        XCTAssertFalse(result.isPR)
+    }
+
+    // MARK: - Multiple record types
+
+    func testDetectsMultipleRecordTypes() throws {
+        let oldSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 60, reps: 3, setType: .working)
+        oldSet.completedAt = Date().addingTimeInterval(-3600)
+        modelContext.insert(oldSet)
+        try modelContext.save()
+
+        // New set beats weight, reps, volume, and e1RM
+        let newSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 80, reps: 8, setType: .working)
+        newSet.completedAt = Date()
+        modelContext.insert(newSet)
+        try modelContext.save()
+
+        let result = service.checkForPR(set: newSet)
+
+        XCTAssertTrue(result.isPR)
+        XCTAssertGreaterThanOrEqual(result.recordTypes.count, 2)
+    }
+
+    // MARK: - Badge text
+
+    func testBadgeTextForE1RM() {
+        let result = PRDetectionResult(
+            exerciseName: "Squat",
+            recordTypes: [.maxE1RM],
+            weight: 140,
+            reps: 3,
+            e1rm: 154
+        )
+        XCTAssertEqual(result.primaryBadgeText, "New 1RM!")
+        XCTAssertTrue(result.detailText.contains("154.0"))
+    }
+
+    func testBadgeTextForWeightPR() {
+        let result = PRDetectionResult(
+            exerciseName: "Bench",
+            recordTypes: [.maxWeight],
+            weight: 100,
+            reps: 5,
+            e1rm: 116.7
+        )
+        XCTAssertEqual(result.primaryBadgeText, "Weight PR!")
+    }
+
+    func testBadgeTextForVolumePR() {
+        let result = PRDetectionResult(
+            exerciseName: "OHP",
+            recordTypes: [.maxVolume],
+            weight: 60,
+            reps: 12,
+            e1rm: 84
+        )
+        XCTAssertEqual(result.primaryBadgeText, "Volume Record!")
+    }
+
+    func testBadgeTextForRepPR() {
+        let result = PRDetectionResult(
+            exerciseName: "Curl",
+            recordTypes: [.maxReps],
+            weight: 20,
+            reps: 20,
+            e1rm: 33.3
+        )
+        XCTAssertEqual(result.primaryBadgeText, "Rep PR!")
+    }
+
+    // MARK: - Empty result
+
+    func testEmptyResultHasNoBadgeText() {
+        let result = PRDetectionResult(
+            exerciseName: "Test",
+            recordTypes: [],
+            weight: 50,
+            reps: 5,
+            e1rm: 58.3
+        )
+        XCTAssertFalse(result.isPR)
+        XCTAssertEqual(result.primaryBadgeText, "")
+        XCTAssertEqual(result.detailText, "")
+    }
+
+    // MARK: - getAllTimePRs
+
+    func testGetAllTimePRsReturnsRecords() throws {
+        let set = ExerciseSet(exercise: exercise, workout: workout, weightKg: 100, reps: 5, setType: .working)
+        set.completedAt = Date()
+        modelContext.insert(set)
+        try modelContext.save()
+
+        let records = service.getAllTimePRs(for: exercise)
+
+        XCTAssertFalse(records.isEmpty)
+        XCTAssertTrue(records.count <= 4) // max 4 record types
+    }
+
+    func testGetAllTimePRsEmptyForNewExercise() throws {
+        let newExercise = Exercise(name: "Deadlift", category: .compound, equipment: .barbell)
+        modelContext.insert(newExercise)
+        try modelContext.save()
+
+        let records = service.getAllTimePRs(for: newExercise)
+
+        XCTAssertTrue(records.isEmpty)
+    }
+
+    // MARK: - Priority ordering
+
+    func testRecordTypesAreSortedByPriority() throws {
+        let oldSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 40, reps: 2, setType: .working)
+        oldSet.completedAt = Date().addingTimeInterval(-3600)
+        modelContext.insert(oldSet)
+        try modelContext.save()
+
+        let newSet = ExerciseSet(exercise: exercise, workout: workout, weightKg: 100, reps: 10, setType: .working)
+        newSet.completedAt = Date()
+        modelContext.insert(newSet)
+        try modelContext.save()
+
+        let result = service.checkForPR(set: newSet)
+
+        XCTAssertTrue(result.isPR)
+        // e1RM should be first (highest priority)
+        if let first = result.recordTypes.first {
+            XCTAssertEqual(first, .maxE1RM)
+        }
+    }
+}

--- a/Packages/GymBroUI/Sources/GymBroUI/Components/PRBadge.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Components/PRBadge.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import GymBroCore
+
+/// Small inline badge indicating a set is a personal record.
+/// Shown next to the checkmark on ExerciseSetRow.
+public struct PRBadge: View {
+    let recordTypes: [PersonalRecord.RecordType]
+
+    @ScaledMetric(relativeTo: .caption2) private var iconSize: CGFloat = 10
+
+    public init(recordTypes: [PersonalRecord.RecordType]) {
+        self.recordTypes = recordTypes
+    }
+
+    public var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "trophy.fill")
+                .font(.system(size: iconSize))
+            Text(badgeLabel)
+                .font(GymBroTypography.caption2)
+        }
+        .foregroundStyle(GymBroColors.accentAmber)
+        .padding(.horizontal, GymBroSpacing.sm)
+        .padding(.vertical, 3)
+        .background(
+            Capsule().fill(GymBroColors.accentAmber.opacity(0.15))
+        )
+        .accessibilityLabel("Personal record: \(badgeLabel)")
+    }
+
+    private var badgeLabel: String {
+        guard let primary = recordTypes.first else { return "PR" }
+        switch primary {
+        case .maxE1RM:   return "1RM"
+        case .maxWeight: return "Weight PR"
+        case .maxVolume: return "Volume PR"
+        case .maxReps:   return "Rep PR"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("PR Badges") {
+    VStack(spacing: GymBroSpacing.md) {
+        PRBadge(recordTypes: [.maxE1RM])
+        PRBadge(recordTypes: [.maxWeight])
+        PRBadge(recordTypes: [.maxVolume])
+        PRBadge(recordTypes: [.maxReps])
+        PRBadge(recordTypes: [.maxE1RM, .maxWeight, .maxReps])
+    }
+    .padding()
+    .gymBroDarkBackground()
+}

--- a/Packages/GymBroUI/Sources/GymBroUI/ViewModels/ActiveWorkoutViewModel.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/ViewModels/ActiveWorkoutViewModel.swift
@@ -12,6 +12,7 @@ public final class ActiveWorkoutViewModel {
     private let modelContext: ModelContext
     private let smartDefaultsService: SmartDefaultsService
     private let supersetService = SupersetService.shared
+    private let prDetectionService: PRDetectionService
     
     public private(set) var workout: Workout
     public private(set) var activeExercise: Exercise?
@@ -23,6 +24,11 @@ public final class ActiveWorkoutViewModel {
     public private(set) var restTimerEndTime: Date?
     public private(set) var isRestTimerActive: Bool = false
     public var saveError: String?
+
+    /// Active PR celebration — set when a PR is detected, nil otherwise.
+    public private(set) var activePRCelebration: PRDetectionResult?
+    /// Maps set IDs to their PR record types for badge display on completed rows.
+    public private(set) var prRecordsBySetId: [UUID: [PersonalRecord.RecordType]] = [:]
     
     private var restTimerSeconds: Int = 120
     
@@ -57,6 +63,7 @@ public final class ActiveWorkoutViewModel {
         self.modelContext = modelContext
         self.workout = workout
         self.smartDefaultsService = SmartDefaultsService(modelContext: modelContext)
+        self.prDetectionService = PRDetectionService(modelContext: modelContext)
         
         if !exercises.isEmpty {
             self.activeExercise = exercises.first
@@ -137,8 +144,11 @@ public final class ActiveWorkoutViewModel {
         
         HapticFeedbackService.shared.setCompleted()
         
-        if isPR(set: set) {
+        let prResult = prDetectionService.checkForPR(set: set)
+        if prResult.isPR {
             HapticFeedbackService.shared.personalRecordAchieved()
+            activePRCelebration = prResult
+            prRecordsBySetId[set.id] = prResult.recordTypes
         }
         
         activeSetNumber += 1
@@ -259,6 +269,17 @@ public final class ActiveWorkoutViewModel {
         currentReps = defaults.reps
         currentRPE = nil
         isWarmup = false
+    }
+
+    /// Dismiss the PR celebration overlay.
+    public func dismissPRCelebration() {
+        activePRCelebration = nil
+    }
+
+    /// Fetch all-time PRs for the active exercise (for PRHistoryView).
+    public func getAllTimePRs() -> [PersonalRecord] {
+        guard let exercise = activeExercise else { return [] }
+        return prDetectionService.getAllTimePRs(for: exercise)
     }
     
     private func startRestTimer() {
@@ -430,8 +451,11 @@ public final class ActiveWorkoutViewModel {
         
         HapticFeedbackService.shared.setCompleted()
         
-        if isPR(set: set) {
+        let rpPRResult = prDetectionService.checkForPR(set: set)
+        if rpPRResult.isPR {
             HapticFeedbackService.shared.personalRecordAchieved()
+            activePRCelebration = rpPRResult
+            prRecordsBySetId[set.id] = rpPRResult.recordTypes
         }
         
         activeSetNumber += 1

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Progress/PRHistoryView.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Progress/PRHistoryView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import SwiftData
+import GymBroCore
+
+/// Shows all-time personal records for a given exercise, one row per record type.
+public struct PRHistoryView: View {
+    let exercise: Exercise
+    let records: [PersonalRecord]
+    let unitSystem: UnitSystem
+
+    @ScaledMetric(relativeTo: .title2) private var headerSize: CGFloat = 24
+    @ScaledMetric(relativeTo: .title3) private var valueSize: CGFloat = 20
+
+    public init(exercise: Exercise, records: [PersonalRecord], unitSystem: UnitSystem = .metric) {
+        self.exercise = exercise
+        self.records = records
+        self.unitSystem = unitSystem
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: GymBroSpacing.lg) {
+                // Header
+                VStack(spacing: GymBroSpacing.sm) {
+                    Image(systemName: "trophy.fill")
+                        .font(.system(size: headerSize))
+                        .foregroundStyle(GymBroColors.accentAmber)
+                        .accessibilityHidden(true)
+
+                    Text(exercise.name)
+                        .font(.system(size: headerSize, weight: .bold))
+                        .foregroundStyle(GymBroColors.textPrimary)
+
+                    Text("All-Time Personal Records")
+                        .font(GymBroTypography.subheadline)
+                        .foregroundStyle(GymBroColors.textSecondary)
+                }
+                .padding(.top, GymBroSpacing.lg)
+
+                if records.isEmpty {
+                    emptyState
+                } else {
+                    VStack(spacing: GymBroSpacing.md) {
+                        ForEach(Array(records.enumerated()), id: \.offset) { _, record in
+                            PRRecordCard(record: record, unitSystem: unitSystem, valueSize: valueSize)
+                        }
+                    }
+                    .padding(.horizontal, GymBroSpacing.md)
+                }
+            }
+            .padding(.bottom, GymBroSpacing.xxl)
+        }
+        .gymBroDarkBackground()
+        .navigationTitle("PR History")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: GymBroSpacing.md) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.system(size: 48))
+                .foregroundStyle(GymBroColors.textTertiary)
+                .accessibilityHidden(true)
+
+            Text("No records yet")
+                .font(GymBroTypography.title3)
+                .foregroundStyle(GymBroColors.textSecondary)
+
+            Text("Complete working sets to start tracking PRs")
+                .font(GymBroTypography.subheadline)
+                .foregroundStyle(GymBroColors.textTertiary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, GymBroSpacing.xxl)
+    }
+}
+
+/// Single PR record card showing type, value, and date.
+struct PRRecordCard: View {
+    let record: PersonalRecord
+    let unitSystem: UnitSystem
+    let valueSize: CGFloat
+
+    var body: some View {
+        GymBroCard(accent: GymBroColors.accentAmber) {
+            HStack(spacing: GymBroSpacing.md) {
+                Image(systemName: iconName)
+                    .font(.system(size: 24))
+                    .foregroundStyle(GymBroColors.accentAmber)
+                    .frame(width: 40)
+
+                VStack(alignment: .leading, spacing: GymBroSpacing.xs) {
+                    Text(typeLabel)
+                        .font(GymBroTypography.caption2)
+                        .foregroundStyle(GymBroColors.textTertiary)
+                        .tracking(0.5)
+
+                    Text(valueText)
+                        .font(GymBroTypography.monoNumber(size: valueSize))
+                        .foregroundStyle(GymBroColors.textPrimary)
+                }
+
+                Spacer()
+
+                if let date = record.exerciseSet.completedAt {
+                    Text(date, style: .date)
+                        .font(GymBroTypography.caption)
+                        .foregroundStyle(GymBroColors.textTertiary)
+                }
+            }
+        }
+    }
+
+    private var typeLabel: String {
+        switch record.recordType {
+        case .maxE1RM:   return "ESTIMATED 1RM"
+        case .maxWeight: return "MAX WEIGHT"
+        case .maxVolume: return "MAX VOLUME"
+        case .maxReps:   return "MAX REPS"
+        }
+    }
+
+    private var iconName: String {
+        switch record.recordType {
+        case .maxE1RM:   return "flame.fill"
+        case .maxWeight: return "scalemass.fill"
+        case .maxVolume: return "chart.bar.fill"
+        case .maxReps:   return "repeat"
+        }
+    }
+
+    private var valueText: String {
+        let set = record.exerciseSet
+        switch record.recordType {
+        case .maxE1RM:
+            return String(format: "%.1f %@", e1rmInUnit, unitLabel)
+        case .maxWeight:
+            return String(format: "%.1f %@ × %d", weightInUnit(set.weightKg), unitLabel, set.reps)
+        case .maxVolume:
+            return String(format: "%.0f %@", volumeInUnit(set.volume), unitLabel)
+        case .maxReps:
+            return "\(set.reps) reps @ \(String(format: "%.1f", weightInUnit(set.weightKg))) \(unitLabel)"
+        }
+    }
+
+    private var e1rmInUnit: Double {
+        let e1rm = record.exerciseSet.estimatedOneRepMax
+        return unitSystem == .metric ? e1rm : e1rm * 2.20462
+    }
+
+    private func weightInUnit(_ kg: Double) -> Double {
+        unitSystem == .metric ? kg : kg * 2.20462
+    }
+
+    private func volumeInUnit(_ kgVol: Double) -> Double {
+        unitSystem == .metric ? kgVol : kgVol * 2.20462
+    }
+
+    private var unitLabel: String {
+        unitSystem == .metric ? "kg" : "lb"
+    }
+}
+
+// MARK: - Preview
+
+#Preview("PR History — Empty") {
+    NavigationStack {
+        PRHistoryView(
+            exercise: Exercise(name: "Bench Press", category: .compound, equipment: .barbell),
+            records: []
+        )
+    }
+}

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/ActiveWorkoutView.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/ActiveWorkoutView.swift
@@ -52,6 +52,15 @@ public struct ActiveWorkoutView: View {
                 Spacer()
                 bottomActionBar
             }
+
+            // PR Celebration Overlay
+            if let prResult = viewModel.activePRCelebration {
+                PRCelebrationOverlay(result: prResult) {
+                    viewModel.dismissPRCelebration()
+                }
+                .transition(.opacity)
+                .zIndex(100)
+            }
         }
         .navigationTitle("Active Workout")
         .navigationBarTitleDisplayMode(.inline)
@@ -254,11 +263,17 @@ public struct ActiveWorkoutView: View {
                 .tracking(1.5)
 
             ForEach(Array(viewModel.completedSetsForActiveExercise.enumerated()), id: \.element.id) { _, set in
-                ExerciseSetRow(
-                    set: set,
-                    setNumber: set.setNumber,
-                    unitSystem: unitSystem
-                )
+                HStack(spacing: GymBroSpacing.sm) {
+                    ExerciseSetRow(
+                        set: set,
+                        setNumber: set.setNumber,
+                        unitSystem: unitSystem
+                    )
+
+                    if let recordTypes = viewModel.prRecordsBySetId[set.id], !recordTypes.isEmpty {
+                        PRBadge(recordTypes: recordTypes)
+                    }
+                }
             }
         }
     }

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/PRCelebrationOverlay.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/PRCelebrationOverlay.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+import GymBroCore
+
+/// Full-screen overlay triggered when a PR is detected.
+/// Shows confetti, a PR badge, and auto-dismisses after 3 seconds.
+public struct PRCelebrationOverlay: View {
+    let result: PRDetectionResult
+    let onDismiss: () -> Void
+
+    @State private var isVisible = false
+    @State private var badgeScale: CGFloat = 0.3
+    @State private var badgeOpacity: Double = 0
+    @ScaledMetric(relativeTo: .largeTitle) private var trophySize: CGFloat = 48
+    @ScaledMetric(relativeTo: .title) private var badgeTitleSize: CGFloat = 28
+    @ScaledMetric(relativeTo: .body) private var detailSize: CGFloat = 16
+
+    public init(result: PRDetectionResult, onDismiss: @escaping () -> Void) {
+        self.result = result
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        ZStack {
+            // Dim background
+            Color.black.opacity(isVisible ? 0.6 : 0)
+                .ignoresSafeArea()
+                .onTapGesture { dismiss() }
+
+            // Confetti layer
+            if isVisible {
+                ConfettiCelebrationView(particleCount: 80)
+                    .ignoresSafeArea()
+            }
+
+            // Badge card
+            VStack(spacing: GymBroSpacing.md) {
+                Image(systemName: "trophy.fill")
+                    .font(.system(size: trophySize))
+                    .foregroundStyle(GymBroColors.accentAmber)
+                    .accessibilityHidden(true)
+
+                Text(result.primaryBadgeText)
+                    .font(.system(size: badgeTitleSize, weight: .heavy, design: .rounded))
+                    .foregroundStyle(GymBroColors.accentAmber)
+
+                Text(result.exerciseName)
+                    .font(GymBroTypography.title3)
+                    .foregroundStyle(GymBroColors.textPrimary)
+
+                Text(result.detailText)
+                    .font(.system(size: detailSize, weight: .medium))
+                    .foregroundStyle(GymBroColors.textSecondary)
+
+                if result.recordTypes.count > 1 {
+                    HStack(spacing: GymBroSpacing.sm) {
+                        ForEach(result.recordTypes.dropFirst(), id: \.self) { type in
+                            PRTypePill(type: type)
+                        }
+                    }
+                    .padding(.top, GymBroSpacing.xs)
+                }
+            }
+            .padding(GymBroSpacing.xl)
+            .background(
+                RoundedRectangle(cornerRadius: GymBroRadius.xl)
+                    .fill(GymBroColors.surfacePrimary)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: GymBroRadius.xl)
+                    .strokeBorder(GymBroColors.accentAmber.opacity(0.4), lineWidth: 2)
+            )
+            .scaleEffect(badgeScale)
+            .opacity(badgeOpacity)
+            .padding(.horizontal, GymBroSpacing.xl)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Personal record! \(result.primaryBadgeText) on \(result.exerciseName). \(result.detailText)")
+        .onAppear {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.6)) {
+                isVisible = true
+                badgeScale = 1.0
+                badgeOpacity = 1.0
+            }
+
+            // Auto-dismiss after 3 seconds
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                dismiss()
+            }
+        }
+    }
+
+    private func dismiss() {
+        withAnimation(.easeOut(duration: 0.3)) {
+            isVisible = false
+            badgeScale = 0.8
+            badgeOpacity = 0
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            onDismiss()
+        }
+    }
+}
+
+/// Small pill showing an additional PR type (e.g., when a set is both a weight PR and e1RM PR).
+struct PRTypePill: View {
+    let type: PersonalRecord.RecordType
+
+    var body: some View {
+        Text(label)
+            .font(GymBroTypography.caption2)
+            .foregroundStyle(GymBroColors.accentAmber)
+            .padding(.horizontal, GymBroSpacing.sm)
+            .padding(.vertical, GymBroSpacing.xs)
+            .background(
+                Capsule().fill(GymBroColors.accentAmber.opacity(0.15))
+            )
+    }
+
+    private var label: String {
+        switch type {
+        case .maxE1RM:   return "1RM"
+        case .maxWeight: return "Weight"
+        case .maxVolume: return "Volume"
+        case .maxReps:   return "Reps"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("PR Celebration") {
+    ZStack {
+        GymBroColors.background.ignoresSafeArea()
+
+        PRCelebrationOverlay(
+            result: PRDetectionResult(
+                exerciseName: "Bench Press",
+                recordTypes: [.maxE1RM, .maxWeight],
+                weight: 120.0,
+                reps: 3,
+                e1rm: 132.0
+            ),
+            onDismiss: {}
+        )
+    }
+}

--- a/Packages/GymBroUI/Tests/GymBroUITests/PRCelebrationIntegrationTests.swift
+++ b/Packages/GymBroUI/Tests/GymBroUITests/PRCelebrationIntegrationTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+import SwiftData
+@testable import GymBroUI
+@testable import GymBroCore
+
+@MainActor
+final class PRCelebrationIntegrationTests: XCTestCase {
+    var modelContext: ModelContext!
+    var workout: Workout!
+    var exercise: Exercise!
+    var viewModel: ActiveWorkoutViewModel!
+
+    override func setUp() async throws {
+        let schema = Schema([
+            Workout.self,
+            Exercise.self,
+            ExerciseSet.self,
+            Program.self,
+            ProgramDay.self,
+            PlannedExercise.self,
+            UserProfile.self,
+            BodyweightEntry.self,
+            MuscleGroup.self,
+            SupersetGroup.self,
+            ProgramWeek.self
+        ])
+
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        modelContext = ModelContext(container)
+
+        workout = Workout()
+        exercise = Exercise(name: "Squat", category: .compound, equipment: .barbell)
+
+        modelContext.insert(workout)
+        modelContext.insert(exercise)
+        try modelContext.save()
+
+        viewModel = ActiveWorkoutViewModel(
+            modelContext: modelContext,
+            workout: workout,
+            exercises: [exercise]
+        )
+    }
+
+    // MARK: - PR Celebration triggers on first set
+
+    func testFirstSetTriggersPRCelebration() {
+        XCTAssertNil(viewModel.activePRCelebration)
+
+        viewModel.updateWeight(100)
+        viewModel.updateReps(5)
+        viewModel.completeSet()
+
+        XCTAssertNotNil(viewModel.activePRCelebration)
+        XCTAssertTrue(viewModel.activePRCelebration!.isPR)
+        XCTAssertEqual(viewModel.activePRCelebration!.exerciseName, "Squat")
+    }
+
+    // MARK: - PR badge stored for set
+
+    func testPRBadgeStoredForCompletedSet() {
+        viewModel.updateWeight(100)
+        viewModel.updateReps(5)
+        viewModel.completeSet()
+
+        let completedSet = workout.sets.first!
+        XCTAssertNotNil(viewModel.prRecordsBySetId[completedSet.id])
+        XCTAssertFalse(viewModel.prRecordsBySetId[completedSet.id]!.isEmpty)
+    }
+
+    // MARK: - Dismiss celebration
+
+    func testDismissPRCelebration() {
+        viewModel.updateWeight(100)
+        viewModel.updateReps(5)
+        viewModel.completeSet()
+
+        XCTAssertNotNil(viewModel.activePRCelebration)
+
+        viewModel.dismissPRCelebration()
+
+        XCTAssertNil(viewModel.activePRCelebration)
+    }
+
+    // MARK: - Non-PR set doesn't trigger celebration
+
+    func testNonPRSetDoesNotTriggerCelebration() {
+        // Complete a strong first set
+        viewModel.updateWeight(100)
+        viewModel.updateReps(10)
+        viewModel.completeSet()
+
+        // Dismiss celebration from first set
+        viewModel.dismissPRCelebration()
+        XCTAssertNil(viewModel.activePRCelebration)
+
+        // Complete a weaker set
+        viewModel.updateWeight(60)
+        viewModel.updateReps(3)
+        viewModel.completeSet()
+
+        // Should not trigger a new celebration
+        XCTAssertNil(viewModel.activePRCelebration)
+    }
+
+    // MARK: - Non-PR set has no badge
+
+    func testNonPRSetHasNoBadge() {
+        viewModel.updateWeight(100)
+        viewModel.updateReps(10)
+        viewModel.completeSet()
+        viewModel.dismissPRCelebration()
+
+        viewModel.updateWeight(60)
+        viewModel.updateReps(3)
+        viewModel.completeSet()
+
+        let secondSet = workout.sets.sorted { ($0.completedAt ?? .distantPast) < ($1.completedAt ?? .distantPast) }.last!
+        XCTAssertNil(viewModel.prRecordsBySetId[secondSet.id])
+    }
+
+    // MARK: - Warmup set never triggers celebration
+
+    func testWarmupSetNeverTriggersCelebration() {
+        viewModel.toggleWarmup()
+        viewModel.updateWeight(200)
+        viewModel.updateReps(1)
+        viewModel.completeSet()
+
+        XCTAssertNil(viewModel.activePRCelebration)
+    }
+
+    // MARK: - getAllTimePRs returns data
+
+    func testGetAllTimePRsAfterSets() {
+        viewModel.updateWeight(100)
+        viewModel.updateReps(5)
+        viewModel.completeSet()
+
+        let records = viewModel.getAllTimePRs()
+        XCTAssertFalse(records.isEmpty)
+    }
+
+    // MARK: - Multiple PRs track correctly
+
+    func testMultiplePRsTrackedAcrossSets() {
+        // First set — always a PR
+        viewModel.updateWeight(80)
+        viewModel.updateReps(5)
+        viewModel.completeSet()
+        viewModel.dismissPRCelebration()
+
+        let firstSetId = workout.sets.first!.id
+        XCTAssertNotNil(viewModel.prRecordsBySetId[firstSetId])
+
+        // Second set — heavier, should also be a PR
+        viewModel.updateWeight(100)
+        viewModel.updateReps(5)
+        viewModel.completeSet()
+
+        XCTAssertNotNil(viewModel.activePRCelebration)
+        let secondSetId = workout.sets.sorted { ($0.completedAt ?? .distantPast) < ($1.completedAt ?? .distantPast) }.last!.id
+        XCTAssertNotNil(viewModel.prRecordsBySetId[secondSetId])
+
+        // Both sets should have badges
+        XCTAssertEqual(viewModel.prRecordsBySetId.count, 2)
+    }
+}


### PR DESCRIPTION
## What

Wire PersonalRecordService into the active workout flow so users actually **see** their PRs. The biggest missed dopamine hit — fixed.

### New files
| File | Purpose |
|------|---------|
| \PRDetectionService.swift\ | Wraps PersonalRecordService, checks all 4 PR types after each set, returns prioritized results with badge text |
| \PRCelebrationOverlay.swift\ | Full-screen confetti + trophy badge, spring animation, 3s auto-dismiss |
| \PRBadge.swift\ | Compact inline badge on completed set rows (1RM / Weight PR / Volume PR / Rep PR) |
| \PRHistoryView.swift\ | All-time PRs per exercise with type/value/date cards |
| \PRDetectionServiceTests.swift\ | 15 unit tests covering detection, priorities, warmup exclusion, badge text |
| \PRCelebrationIntegrationTests.swift\ | 8 integration tests covering ViewModel → celebration flow |

### Modified files
- **ActiveWorkoutViewModel** — added \prDetectionService\, \ctivePRCelebration\, \prRecordsBySetId\, \dismissPRCelebration()\, \getAllTimePRs()\
- **ActiveWorkoutView** — overlay in ZStack (\.zIndex(100)\), PR badges in completed sets section
- **PersonalRecordService** — \RecordType\ now \Hashable + Sendable\

### How it works
1. User completes a set → \completeSet()\ calls \prDetectionService.checkForPR(set:)\
2. If any PR detected → haptic + \ctivePRCelebration\ set → overlay appears with confetti
3. Auto-dismiss after 3s (or tap background)
4. PR badge persists on the set row via \prRecordsBySetId\
5. Works for both normal sets and rest-pause sets

### Testing
- 15 unit tests (PRDetectionServiceTests)
- 8 integration tests (PRCelebrationIntegrationTests)
- ⚠️ No Xcode on Windows — cannot run CI locally

Closes #111