### PR TITLE
feat: redesign ProgressDashboard — hero metric + insight cards + charts on demand

### DIFF
--- a/.changeset/progress-dashboard-redesign.md
+++ b/.changeset/progress-dashboard-redesign.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': minor
+---
+
+Redesign ProgressDashboard from 6-chart data dump to Apple Health–style summary. Hero metric with sparkline, swipeable insight cards, charts expand on demand. Uses GymBro design system, @ScaledMetric, reduceMotion, progressive disclosure.

--- a/Packages/GymBroUI/Sources/GymBroUI/ViewModels/ProgressDashboardViewModel.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/ViewModels/ProgressDashboardViewModel.swift
@@ -3,8 +3,48 @@ import Observation
 import SwiftData
 import GymBroCore
 
+// MARK: - Insight Model
+
+/// A single insight card shown in the swipeable pager.
+public struct ProgressInsight: Identifiable {
+    public let id: UUID
+    public let title: String
+    public let subtitle: String
+    public let icon: String
+    public let accentColor: Color
+    public let chartType: InsightChartType
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        subtitle: String,
+        icon: String,
+        accentColor: Color,
+        chartType: InsightChartType
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.icon = icon
+        self.accentColor = accentColor
+        self.chartType = chartType
+    }
+}
+
+/// Which chart to expand when an insight card is tapped.
+public enum InsightChartType: Sendable {
+    case e1rm
+    case volume
+    case tonnage
+    case muscleBalance
+    case plateau
+    case prs
+}
+
+// MARK: - ViewModel
+
 /// ViewModel that drives the progress dashboard.
-/// Fetches workout data from SwiftData and computes all progress metrics.
+/// Computes hero metric, insight cards, and on-demand chart data.
 @MainActor
 @Observable
 public final class ProgressDashboardViewModel {
@@ -13,7 +53,7 @@ public final class ProgressDashboardViewModel {
     public var selectedExerciseName: String?
     public var availableExercises: [String] = []
 
-    // Chart data
+    // Chart data (loaded on demand)
     public var e1rmData: [E1RMDataPoint] = []
     public var volumeData: [VolumeDataPoint] = []
     public var tonnageData: [VolumeDataPoint] = []
@@ -21,6 +61,19 @@ public final class ProgressDashboardViewModel {
     public var muscleBalance: [MuscleGroupBalance] = []
     public var prEvents: [PREvent] = []
     public var plateauAnalyses: [PlateauAnalysis] = []
+
+    // Hero metric
+    public var heroValue: Double = 0
+    public var heroUnit: String = "kg"
+    public var heroLabel: String = "Est. 1RM"
+    public var heroTrend: HeroTrend = .flat
+    public var sparklineValues: [Double] = []
+
+    // Insights
+    public var insights: [ProgressInsight] = []
+
+    // Drill-down state
+    public var expandedChart: InsightChartType?
 
     public var isLoading: Bool = false
 
@@ -36,6 +89,15 @@ public final class ProgressDashboardViewModel {
         self.progressService = progressService
         self.plateauService = plateauService
         self.e1rmCalculator = e1rmCalculator
+    }
+
+    /// Toggle a chart's expanded state.
+    public func toggleChart(_ type: InsightChartType) {
+        if expandedChart == type {
+            expandedChart = nil
+        } else {
+            expandedChart = type
+        }
     }
 
     /// Refreshes all progress data from SwiftData.
@@ -76,6 +138,140 @@ public final class ProgressDashboardViewModel {
         frequencyData = progressService.weeklyFrequency(workouts: workouts, timeWindow: selectedTimeWindow)
         muscleBalance = progressService.muscleGroupBalance(sets: allSets, timeWindow: selectedTimeWindow)
 
+        computeHeroMetric()
+        computeInsights()
+
         isLoading = false
+    }
+
+    // MARK: - Hero Metric
+
+    private func computeHeroMetric() {
+        if !e1rmData.isEmpty {
+            let latest = e1rmData.last!.e1rm
+            heroValue = latest
+            heroUnit = "kg"
+            heroLabel = "Est. 1RM"
+            sparklineValues = e1rmData.suffix(12).map(\.e1rm)
+
+            if e1rmData.count >= 2 {
+                let previous = e1rmData[e1rmData.count - 2].e1rm
+                if latest > previous + 0.5 {
+                    heroTrend = .up
+                } else if latest < previous - 0.5 {
+                    heroTrend = .down
+                } else {
+                    heroTrend = .flat
+                }
+            } else {
+                heroTrend = .flat
+            }
+        } else if !volumeData.isEmpty {
+            let latest = volumeData.last!.totalVolume
+            heroValue = latest
+            heroUnit = "kg vol"
+            heroLabel = "Weekly Volume"
+            sparklineValues = volumeData.suffix(12).map(\.totalVolume)
+
+            if volumeData.count >= 2 {
+                let previous = volumeData[volumeData.count - 2].totalVolume
+                if latest > previous * 1.02 {
+                    heroTrend = .up
+                } else if latest < previous * 0.98 {
+                    heroTrend = .down
+                } else {
+                    heroTrend = .flat
+                }
+            } else {
+                heroTrend = .flat
+            }
+        } else {
+            heroValue = 0
+            heroTrend = .flat
+            sparklineValues = []
+        }
+    }
+
+    // MARK: - Insights
+
+    private func computeInsights() {
+        var cards: [ProgressInsight] = []
+
+        // Plateau insight
+        if let plateau = plateauAnalyses.first(where: { $0.isPlateaued }) {
+            let rec = plateau.recommendations.first ?? "Try varying rep ranges"
+            cards.append(ProgressInsight(
+                title: "\(plateau.exerciseName) plateau",
+                subtitle: rec,
+                icon: "exclamationmark.triangle.fill",
+                accentColor: GymBroColors.accentAmber,
+                chartType: .plateau
+            ))
+        }
+
+        // Volume trend insight
+        if volumeData.count >= 2 {
+            let recent = volumeData.suffix(2)
+            let current = recent.last!.totalVolume
+            let previous = recent.first!.totalVolume
+            if previous > 0 {
+                let pctChange = ((current - previous) / previous) * 100
+                let direction = pctChange >= 0 ? "up" : "down"
+                let pctFormatted = String(format: "%.0f", abs(pctChange))
+                let icon = pctChange >= 0 ? "arrow.up.right.circle.fill" : "arrow.down.right.circle.fill"
+                let color = pctChange >= 0 ? GymBroColors.accentGreen : GymBroColors.accentRed
+                cards.append(ProgressInsight(
+                    title: "Volume \(direction) \(pctFormatted)%",
+                    subtitle: "Week-over-week change",
+                    icon: icon,
+                    accentColor: color,
+                    chartType: .volume
+                ))
+            }
+        }
+
+        // PR insight
+        if !prEvents.isEmpty {
+            let recentPRs = prEvents.suffix(5)
+            let count = recentPRs.count
+            cards.append(ProgressInsight(
+                title: "\(count) personal record\(count == 1 ? "" : "s")",
+                subtitle: recentPRs.last.map { "\($0.exerciseName) — \($0.recordType)" } ?? "",
+                icon: "trophy.fill",
+                accentColor: GymBroColors.accentAmber,
+                chartType: .prs
+            ))
+        }
+
+        // e1RM trend insight (if we have data and didn't already show plateau)
+        if !e1rmData.isEmpty && !plateauAnalyses.contains(where: { $0.isPlateaued }) {
+            if e1rmData.count >= 2 {
+                let change = e1rmData.last!.e1rm - e1rmData.first!.e1rm
+                let direction = change >= 0 ? "Gaining" : "Declining"
+                let changeFormatted = String(format: "%@%.1f", change >= 0 ? "+" : "", change)
+                cards.append(ProgressInsight(
+                    title: "\(direction) strength",
+                    subtitle: "\(changeFormatted) kg over period",
+                    icon: "bolt.fill",
+                    accentColor: GymBroColors.accentCyan,
+                    chartType: .e1rm
+                ))
+            }
+        }
+
+        // Muscle balance insight (always useful)
+        if !muscleBalance.isEmpty {
+            let top = muscleBalance.first!
+            let pctFormatted = String(format: "%.0f", top.percentage)
+            cards.append(ProgressInsight(
+                title: "Top group: \(top.muscleGroup)",
+                subtitle: "\(pctFormatted)% of volume",
+                icon: "figure.strengthtraining.traditional",
+                accentColor: GymBroColors.accentCyan,
+                chartType: .muscleBalance
+            ))
+        }
+
+        insights = cards
     }
 }

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Progress/ProgressDashboardView.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Progress/ProgressDashboardView.swift
@@ -2,43 +2,38 @@ import SwiftUI
 import Charts
 import GymBroCore
 
-/// Main progress dashboard showing strength trends, volume, and insights.
+/// Main progress dashboard — Apple Health–style summary → drill-down.
+/// Hero metric at top, swipeable insight cards, charts expand on demand.
 public struct ProgressDashboardView: View {
     @State private var viewModel = ProgressDashboardViewModel()
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ScaledMetric(relativeTo: .body) private var sparklineHeight: CGFloat = 60
 
     public init() {}
 
     public var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(spacing: 20) {
-                    timeWindowPicker
-                    exercisePicker
-
-                    if viewModel.isLoading {
-                        ProgressView("Calculating...")
-                    } else if viewModel.availableExercises.isEmpty && viewModel.volumeData.isEmpty {
-                        ContentUnavailableView {
-                            Label("No Progress Data", systemImage: "chart.bar")
-                        } description: {
-                            Text("Complete a few workouts to see your progress trends here.")
-                        }
-                    } else {
-                        PlateauAlertsSection(analyses: viewModel.plateauAnalyses)
-                        E1RMChartView(data: viewModel.e1rmData)
-                        VolumeChartView(data: viewModel.volumeData)
-                        TonnageChartView(data: viewModel.tonnageData)
-                        MuscleBalanceChart(data: viewModel.muscleBalance)
-                        PRTimelineSection(events: viewModel.prEvents)
-                    }
+                VStack(spacing: GymBroSpacing.lg) {
+                    controlsSection
+                    contentSection
                 }
-                .padding()
+                .padding(.horizontal, GymBroSpacing.md)
+                .padding(.bottom, GymBroSpacing.xl)
             }
             .navigationTitle("Progress")
+            .gymBroDarkBackground()
         }
     }
 
     // MARK: - Controls
+
+    private var controlsSection: some View {
+        VStack(spacing: GymBroSpacing.sm) {
+            timeWindowPicker
+            exercisePicker
+        }
+    }
 
     private var timeWindowPicker: some View {
         Picker("Time Range", selection: $viewModel.selectedTimeWindow) {
@@ -63,71 +58,261 @@ public struct ProgressDashboardView: View {
             }
         }
     }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var contentSection: some View {
+        if viewModel.isLoading {
+            ProgressView("Calculating...")
+                .frame(maxWidth: .infinity, minHeight: 200)
+        } else if viewModel.availableExercises.isEmpty && viewModel.volumeData.isEmpty {
+            ContentUnavailableView {
+                Label("No Progress Data", systemImage: "chart.bar")
+            } description: {
+                Text("Complete a few workouts to see your progress trends here.")
+            }
+        } else {
+            heroSection
+            insightCards
+            expandedChartSection
+        }
+    }
+
+    // MARK: - Hero Metric
+
+    private var heroSection: some View {
+        GymBroCard {
+            VStack(spacing: GymBroSpacing.sm) {
+                Text(viewModel.heroLabel.uppercased())
+                    .font(GymBroTypography.caption2)
+                    .foregroundStyle(GymBroColors.textTertiary)
+                    .tracking(2)
+
+                HeroNumber(
+                    value: viewModel.heroValue,
+                    format: "%.1f",
+                    unit: viewModel.heroUnit,
+                    trend: viewModel.heroTrend
+                )
+
+                if !viewModel.sparklineValues.isEmpty {
+                    SparklineView(
+                        data: viewModel.sparklineValues,
+                        color: viewModel.heroTrend == .down
+                            ? GymBroColors.accentRed
+                            : GymBroColors.accentGreen
+                    )
+                    .frame(height: sparklineHeight)
+                    .padding(.horizontal, GymBroSpacing.md)
+                }
+
+                if let exercise = viewModel.selectedExerciseName {
+                    Text(exercise)
+                        .font(GymBroTypography.caption)
+                        .foregroundStyle(GymBroColors.textSecondary)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, GymBroSpacing.sm)
+        }
+    }
+
+    // MARK: - Insight Cards
+
+    @ViewBuilder
+    private var insightCards: some View {
+        if !viewModel.insights.isEmpty {
+            TabView {
+                ForEach(viewModel.insights) { insight in
+                    InsightCardView(insight: insight) {
+                        withAnimation(reduceMotion ? .none : .spring(response: 0.35, dampingFraction: 0.85)) {
+                            viewModel.toggleChart(insight.chartType)
+                        }
+                    }
+                    .padding(.horizontal, GymBroSpacing.xs)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .automatic))
+            .frame(height: 130)
+        }
+    }
+
+    // MARK: - Expanded Chart
+
+    @ViewBuilder
+    private var expandedChartSection: some View {
+        if let chart = viewModel.expandedChart {
+            Group {
+                switch chart {
+                case .e1rm:
+                    E1RMChartView(data: viewModel.e1rmData)
+                case .volume:
+                    VolumeChartView(data: viewModel.volumeData)
+                case .tonnage:
+                    TonnageChartView(data: viewModel.tonnageData)
+                case .muscleBalance:
+                    MuscleBalanceChart(data: viewModel.muscleBalance)
+                case .plateau:
+                    PlateauDetailSection(analyses: viewModel.plateauAnalyses)
+                case .prs:
+                    PRTimelineSection(events: viewModel.prEvents)
+                }
+            }
+            .transition(.asymmetric(
+                insertion: .move(edge: .bottom).combined(with: .opacity),
+                removal: .opacity
+            ))
+
+            Button {
+                withAnimation(reduceMotion ? .none : .spring(response: 0.3, dampingFraction: 0.8)) {
+                    viewModel.expandedChart = nil
+                }
+            } label: {
+                Label("Collapse", systemImage: "chevron.up")
+                    .font(GymBroTypography.caption)
+                    .foregroundStyle(GymBroColors.textTertiary)
+            }
+        }
+    }
 }
 
-// MARK: - Extracted Subviews
+// MARK: - Sparkline
 
-private struct PlateauAlertsSection: View {
+/// Minimal sparkline for the hero section — no axes, just the trend shape.
+struct SparklineView: View {
+    let data: [Double]
+    var color: Color = GymBroColors.accentGreen
+
+    var body: some View {
+        Chart(Array(data.enumerated()), id: \.offset) { index, value in
+            LineMark(
+                x: .value("Index", index),
+                y: .value("Value", value)
+            )
+            .interpolationMethod(.catmullRom)
+            .foregroundStyle(color)
+
+            AreaMark(
+                x: .value("Index", index),
+                y: .value("Value", value)
+            )
+            .interpolationMethod(.catmullRom)
+            .foregroundStyle(color.opacity(0.15))
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+    }
+}
+
+// MARK: - Insight Card
+
+/// Single insight card — tappable, shows icon + text in GymBroCard.
+struct InsightCardView: View {
+    let insight: ProgressInsight
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            GymBroCard(accent: insight.accentColor) {
+                HStack(spacing: GymBroSpacing.md) {
+                    Image(systemName: insight.icon)
+                        .font(.title2)
+                        .foregroundStyle(insight.accentColor)
+                        .frame(width: 36)
+
+                    VStack(alignment: .leading, spacing: GymBroSpacing.xs) {
+                        Text(insight.title)
+                            .font(GymBroTypography.headline)
+                            .foregroundStyle(GymBroColors.textPrimary)
+                            .lineLimit(1)
+
+                        Text(insight.subtitle)
+                            .font(GymBroTypography.caption)
+                            .foregroundStyle(GymBroColors.textSecondary)
+                            .lineLimit(2)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(GymBroColors.textTertiary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(insight.title). \(insight.subtitle). Tap to see chart.")
+    }
+}
+
+// MARK: - Plateau Detail
+
+private struct PlateauDetailSection: View {
     let analyses: [PlateauAnalysis]
 
     var body: some View {
         ForEach(analyses) { analysis in
             if analysis.isPlateaued {
-                VStack(alignment: .leading, spacing: 8) {
-                    Label("Plateau Detected", systemImage: "exclamationmark.triangle.fill")
-                        .font(.headline)
-                        .foregroundStyle(.orange)
+                GymBroCard(accent: GymBroColors.accentAmber) {
+                    VStack(alignment: .leading, spacing: GymBroSpacing.sm) {
+                        Label("Plateau Detected", systemImage: "exclamationmark.triangle.fill")
+                            .font(GymBroTypography.headline)
+                            .foregroundStyle(GymBroColors.accentAmber)
 
-                    Text("\(analysis.exerciseName) — Score: \(analysis.compositeScore, specifier: "%.0f%%")")
-                        .font(.subheadline)
+                        Text("\(analysis.exerciseName) — Score: \(analysis.compositeScore, specifier: "%.0f%%")")
+                            .font(GymBroTypography.subheadline)
+                            .foregroundStyle(GymBroColors.textPrimary)
 
-                    ForEach(analysis.recommendations, id: \.self) { rec in
-                        Label(rec, systemImage: "lightbulb")
-                            .font(.caption)
+                        ForEach(analysis.recommendations, id: \.self) { rec in
+                            Label(rec, systemImage: "lightbulb")
+                                .font(GymBroTypography.caption)
+                                .foregroundStyle(GymBroColors.textSecondary)
+                        }
                     }
                 }
-                .padding()
-                .background(Color.orange.opacity(0.1))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
             }
         }
     }
 }
+
+// MARK: - PR Timeline
 
 private struct PRTimelineSection: View {
     let events: [PREvent]
 
     var body: some View {
         if !events.isEmpty {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Personal Records")
-                    .font(.headline)
+            GymBroCard(accent: GymBroColors.accentAmber) {
+                VStack(alignment: .leading, spacing: GymBroSpacing.md) {
+                    Text("Personal Records")
+                        .font(GymBroTypography.headline)
+                        .foregroundStyle(GymBroColors.textPrimary)
 
-                ForEach(events.suffix(10)) { pr in
-                    HStack {
-                        Image(systemName: "trophy.fill")
-                            .foregroundStyle(.yellow)
-                        VStack(alignment: .leading) {
-                            Text("\(pr.recordType): \(pr.value, specifier: "%.1f") kg")
-                                .font(.subheadline.bold())
-                            Text(pr.date, style: .date)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                    ForEach(events.suffix(10)) { pr in
+                        HStack {
+                            Image(systemName: "trophy.fill")
+                                .foregroundStyle(GymBroColors.accentAmber)
+                            VStack(alignment: .leading) {
+                                Text("\(pr.recordType): \(pr.value, specifier: "%.1f") kg")
+                                    .font(GymBroTypography.subheadline.bold())
+                                    .foregroundStyle(GymBroColors.textPrimary)
+                                Text(pr.date, style: .date)
+                                    .font(GymBroTypography.caption)
+                                    .foregroundStyle(GymBroColors.textSecondary)
+                            }
+                            Spacer()
+                            HStack(spacing: 2) {
+                                Image(systemName: "arrow.up.right")
+                                Text("+\(pr.value - pr.previousBest, specifier: "%.1f")")
+                            }
+                            .font(GymBroTypography.caption.bold())
+                            .foregroundStyle(GymBroColors.accentGreen)
                         }
-                        Spacer()
-                        HStack(spacing: 2) {
-                            Image(systemName: "arrow.up.right")
-                            Text("+\(pr.value - pr.previousBest, specifier: "%.1f")")
-                        }
-                        .font(.caption.bold())
-                        .foregroundStyle(.green)
                     }
                 }
             }
-            .padding()
-            .background(Color(.systemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .shadow(radius: 1)
         }
     }
 }

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Progress/ProgressPreviews.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Progress/ProgressPreviews.swift
@@ -22,3 +22,57 @@ import GymBroCore
     }
     .gymBroDarkBackground()
 }
+
+#Preview("Sparkline") {
+    VStack(spacing: GymBroSpacing.lg) {
+        SparklineView(
+            data: [100, 102, 105, 103, 108, 110, 109, 112, 115, 118, 120, 122],
+            color: GymBroColors.accentGreen
+        )
+        .frame(height: 60)
+
+        SparklineView(
+            data: [120, 118, 115, 112, 110, 108, 106, 105],
+            color: GymBroColors.accentRed
+        )
+        .frame(height: 60)
+    }
+    .padding(GymBroSpacing.lg)
+    .gymBroDarkBackground()
+}
+
+#Preview("Insight Card") {
+    VStack(spacing: GymBroSpacing.md) {
+        InsightCardView(
+            insight: ProgressInsight(
+                title: "Bench plateau detected",
+                subtitle: "Try varying rep ranges or adding pause reps",
+                icon: "exclamationmark.triangle.fill",
+                accentColor: GymBroColors.accentAmber,
+                chartType: .plateau
+            )
+        ) {}
+
+        InsightCardView(
+            insight: ProgressInsight(
+                title: "Volume up 12%",
+                subtitle: "Week-over-week change",
+                icon: "arrow.up.right.circle.fill",
+                accentColor: GymBroColors.accentGreen,
+                chartType: .volume
+            )
+        ) {}
+
+        InsightCardView(
+            insight: ProgressInsight(
+                title: "3 personal records",
+                subtitle: "Bench Press — e1RM",
+                icon: "trophy.fill",
+                accentColor: GymBroColors.accentAmber,
+                chartType: .prs
+            )
+        ) {}
+    }
+    .padding(GymBroSpacing.md)
+    .gymBroDarkBackground()
+}


### PR DESCRIPTION
## Summary

Redesigns ProgressDashboardView from a 6-chart data dump into an Apple Health-style progressive disclosure experience.

### Before
6 charts rendered simultaneously — information overload. A spreadsheet disguised as an app.

### After
- **Hero metric**: Big HeroNumber (e1RM or weekly volume) with sparkline trend — the one number that matters
- **Insight cards**: 2–3 swipeable cards via \TabView(.page)\ — plateau alerts, volume trends, PR count
- **Charts on demand**: Tap any insight card → full chart expands inline with spring animation. Collapse button to dismiss.

### Design System
- Uses \GymBroCard\, \HeroNumber\, \GymBroColors\, \GymBroTypography\, \GymBroSpacing\
- Dark-first aesthetic with neon accents
- \@ScaledMetric\ for Dynamic Type-aware sparkline height
- \educeMotion\ respected — animations skipped when accessibility preference is on
- VoiceOver: combined accessibility labels on insight cards

### Files Changed
| File | Change |
|------|--------|
| \ProgressDashboardViewModel.swift\ | Add hero metric computation, insight card generation, chart toggle |
| \ProgressDashboardView.swift\ | Full redesign: hero section, SparklineView, InsightCardView, PlateauDetailSection, PRTimelineSection |
| \ProgressPreviews.swift\ | Add sparkline and insight card previews |
| \.changeset/progress-dashboard-redesign.md\ | Changeset |

Working as Trinity (iOS Developer).

Closes #113