### PR TITLE
Connect WorkoutGeneratorService to Programs tab + home screen (#114)

### DIFF
--- a/.changeset/smart-workout-home.md
+++ b/.changeset/smart-workout-home.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+Connect WorkoutGeneratorService to Programs tab and home screen hero card

--- a/GymBro/ContentView.swift
+++ b/GymBro/ContentView.swift
@@ -143,20 +143,57 @@ struct ContentView: View {
 
 struct WorkoutTab: View {
     @State private var showStartWorkout = false
-    
+    @State private var smartWorkoutVM: ActiveWorkoutViewModel?
+    @State private var navigateToSmartWorkout = false
+
     var body: some View {
         NavigationStack {
-            EmptyStateView(
-                icon: "figure.strengthtraining.traditional",
-                title: "Ready to train?",
-                message: "Start your first workout and let's build something amazing",
-                actionTitle: "Start Workout"
-            ) {
-                showStartWorkout = true
+            ScrollView {
+                VStack(spacing: GymBroSpacing.lg) {
+                    SmartWorkoutHeroCard { vm in
+                        smartWorkoutVM = vm
+                        navigateToSmartWorkout = true
+                    }
+
+                    Button {
+                        showStartWorkout = true
+                    } label: {
+                        HStack(spacing: GymBroSpacing.sm) {
+                            Image(systemName: "plus.circle.fill")
+                                .foregroundStyle(GymBroColors.textSecondary)
+                            Text("Empty Workout")
+                                .font(GymBroTypography.subheadline)
+                                .foregroundStyle(GymBroColors.textSecondary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12))
+                                .foregroundStyle(GymBroColors.textTertiary)
+                        }
+                        .padding(GymBroSpacing.md)
+                        .background(
+                            RoundedRectangle(cornerRadius: GymBroRadius.md)
+                                .fill(GymBroColors.surfaceSecondary)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: GymBroRadius.md)
+                                .strokeBorder(GymBroColors.border, lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, GymBroSpacing.md)
+                .padding(.top, GymBroSpacing.md)
+                .padding(.bottom, GymBroSpacing.xxl)
             }
+            .gymBroDarkBackground()
             .navigationTitle("Workout")
             .sheet(isPresented: $showStartWorkout) {
                 StartWorkoutView()
+            }
+            .navigationDestination(isPresented: $navigateToSmartWorkout) {
+                if let vm = smartWorkoutVM {
+                    ActiveWorkoutView(viewModel: vm)
+                }
             }
         }
     }

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Programs/ActiveProgramView.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Programs/ActiveProgramView.swift
@@ -9,6 +9,10 @@ public struct ActiveProgramView: View {
     let program: Program
 
     @State private var viewModel: ProgramsTabViewModel?
+    @State private var showWorkoutPreview = false
+    @State private var generatorVM: WorkoutGeneratorViewModel?
+    @State private var activeWorkoutVM: ActiveWorkoutViewModel?
+    @State private var navigateToWorkout = false
     @ScaledMetric private var statSize: CGFloat = 36
 
     public init(program: Program) {
@@ -35,6 +39,20 @@ public struct ActiveProgramView: View {
                 let vm = ProgramsTabViewModel(modelContext: modelContext)
                 vm.loadPrograms()
                 viewModel = vm
+            }
+        }
+        .sheet(isPresented: $showWorkoutPreview) {
+            if let vm = generatorVM {
+                WorkoutPreviewSheet(generatorVM: vm) { workoutVM in
+                    activeWorkoutVM = workoutVM
+                    navigateToWorkout = true
+                }
+                .presentationDetents([.large])
+            }
+        }
+        .navigationDestination(isPresented: $navigateToWorkout) {
+            if let vm = activeWorkoutVM {
+                ActiveWorkoutView(viewModel: vm)
             }
         }
     }
@@ -157,6 +175,18 @@ public struct ActiveProgramView: View {
 
             if let today = program.todaysProgramDay {
                 todayCard(day: today)
+
+                Button {
+                    let vm = WorkoutGeneratorViewModel(modelContext: modelContext)
+                    generatorVM = vm
+                    showWorkoutPreview = true
+                } label: {
+                    HStack(spacing: GymBroSpacing.sm) {
+                        Image(systemName: "wand.and.stars")
+                        Text("Start Smart Workout")
+                    }
+                }
+                .buttonStyle(.gymBroPrimary)
             } else {
                 GymBroCard {
                     HStack(spacing: GymBroSpacing.md) {

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Programs/ProgramDetailView.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Programs/ProgramDetailView.swift
@@ -14,8 +14,8 @@ public struct ProgramDetailView: View {
     @State private var showStartConfirmation = false
     @State private var showStopConfirmation = false
     @State private var selectedWeek: Int = 1
-    @State private var generatorVM: WorkoutGeneratorViewModel?
     @State private var showWorkoutPreview = false
+    @State private var generatorVM: WorkoutGeneratorViewModel?
     @State private var activeWorkoutVM: ActiveWorkoutViewModel?
     @State private var navigateToWorkout = false
     @ScaledMetric private var iconSize: CGFloat = 20
@@ -46,14 +46,6 @@ public struct ProgramDetailView: View {
             if viewModel == nil {
                 viewModel = ProgramsTabViewModel(modelContext: modelContext)
             }
-            if generatorVM == nil {
-                generatorVM = WorkoutGeneratorViewModel(modelContext: modelContext)
-            }
-        }
-        .navigationDestination(isPresented: $navigateToWorkout) {
-            if let vm = activeWorkoutVM {
-                ActiveWorkoutView(viewModel: vm)
-            }
         }
         .confirmationDialog(
             "Start \(program.name)?",
@@ -62,14 +54,11 @@ public struct ProgramDetailView: View {
         ) {
             Button("Start Program") {
                 viewModel?.startProgram(program)
-                generateAndShowPreview()
+                dismiss()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This will replace your current active program. A workout will be generated from today's program day.")
-        }
-        .sheet(isPresented: $showWorkoutPreview) {
-            workoutPreviewSheet
+            Text("This will replace your current active program if you have one.")
         }
         .confirmationDialog(
             "Stop \(program.name)?",
@@ -83,6 +72,20 @@ public struct ProgramDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Your progress will be saved but the program will no longer be active.")
+        }
+        .sheet(isPresented: $showWorkoutPreview) {
+            if let vm = generatorVM {
+                WorkoutPreviewSheet(generatorVM: vm) { workoutVM in
+                    activeWorkoutVM = workoutVM
+                    navigateToWorkout = true
+                }
+                .presentationDetents([.large])
+            }
+        }
+        .navigationDestination(isPresented: $navigateToWorkout) {
+            if let vm = activeWorkoutVM {
+                ActiveWorkoutView(viewModel: vm)
+            }
         }
     }
 
@@ -321,10 +324,17 @@ public struct ProgramDetailView: View {
 
     @ViewBuilder
     private var actionButton: some View {
-        if isActive {
-            VStack(spacing: GymBroSpacing.md) {
-                Button("Start Workout") {
-                    generateAndShowPreview()
+        VStack(spacing: GymBroSpacing.md) {
+            if isActive {
+                Button {
+                    let vm = WorkoutGeneratorViewModel(modelContext: modelContext)
+                    generatorVM = vm
+                    showWorkoutPreview = true
+                } label: {
+                    HStack(spacing: GymBroSpacing.sm) {
+                        Image(systemName: "wand.and.stars")
+                        Text("Start Smart Workout")
+                    }
                 }
                 .buttonStyle(.gymBroPrimary)
 
@@ -332,182 +342,13 @@ public struct ProgramDetailView: View {
                     showStopConfirmation = true
                 }
                 .buttonStyle(.gymBroDestructive)
-            }
-        } else {
-            Button("Start This Program") {
-                showStartConfirmation = true
-            }
-            .buttonStyle(.gymBroPrimary)
-        }
-    }
-
-    // MARK: - Workout Generation
-
-    private func generateAndShowPreview() {
-        generatorVM?.generateWorkout()
-        showWorkoutPreview = true
-    }
-
-    private func startGeneratedWorkout() {
-        guard let generatorVM else { return }
-        if let workout = generatorVM.startWorkout() {
-            let exercises = workout.exercises
-            activeWorkoutVM = ActiveWorkoutViewModel(
-                modelContext: modelContext,
-                workout: workout,
-                exercises: exercises
-            )
-            showWorkoutPreview = false
-            navigateToWorkout = true
-        }
-    }
-
-    @ViewBuilder
-    private var workoutPreviewSheet: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: GymBroSpacing.lg) {
-                    if let generated = generatorVM?.generatedWorkout {
-                        if generated.isRestDay {
-                            restDayContent
-                        } else {
-                            previewHeader(generated)
-                            previewExerciseList(generated)
-                        }
-                    } else if generatorVM?.isGenerating == true {
-                        ProgressView("Generating workout…")
-                            .tint(GymBroColors.accentGreen)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else if let error = generatorVM?.errorMessage {
-                        Text(error)
-                            .foregroundStyle(GymBroColors.accentRed)
-                    }
+            } else {
+                Button("Start This Program") {
+                    showStartConfirmation = true
                 }
-                .padding(.horizontal, GymBroSpacing.md)
-                .padding(.top, GymBroSpacing.sm)
-                .padding(.bottom, GymBroSpacing.xxl)
-            }
-            .gymBroDarkBackground()
-            .navigationTitle("Workout Preview")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        showWorkoutPreview = false
-                    }
-                    .foregroundStyle(GymBroColors.textSecondary)
-                }
-            }
-            .safeAreaInset(edge: .bottom) {
-                if generatorVM?.generatedWorkout != nil && generatorVM?.isRestDay == false {
-                    Button("Start Workout") {
-                        startGeneratedWorkout()
-                    }
-                    .buttonStyle(.gymBroPrimary)
-                    .padding(.horizontal, GymBroSpacing.md)
-                    .padding(.bottom, GymBroSpacing.lg)
-                }
+                .buttonStyle(.gymBroPrimary)
             }
         }
-    }
-
-    @ViewBuilder
-    private func previewHeader(_ generated: GeneratedWorkout) -> some View {
-        VStack(alignment: .leading, spacing: GymBroSpacing.sm) {
-            Text(generated.sessionName)
-                .font(GymBroTypography.title2)
-                .foregroundStyle(GymBroColors.textPrimary)
-
-            HStack(spacing: GymBroSpacing.md) {
-                Label("\(generated.exercises.count) exercises", systemImage: "dumbbell.fill")
-                Label("~\(generated.estimatedDurationMinutes) min", systemImage: "clock")
-            }
-            .font(GymBroTypography.caption)
-            .foregroundStyle(GymBroColors.textSecondary)
-
-            if !generated.reasoningText.isEmpty {
-                GymBroCard(accent: GymBroColors.accentCyan) {
-                    Text(generated.reasoningText)
-                        .font(GymBroTypography.caption)
-                        .foregroundStyle(GymBroColors.textSecondary)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func previewExerciseList(_ generated: GeneratedWorkout) -> some View {
-        VStack(alignment: .leading, spacing: GymBroSpacing.md) {
-            Text("EXERCISES")
-                .font(GymBroTypography.caption2)
-                .foregroundStyle(GymBroColors.textTertiary)
-                .tracking(2)
-
-            ForEach(generated.exercises) { exercise in
-                GymBroCard {
-                    HStack(spacing: GymBroSpacing.md) {
-                        Text("\(exercise.order)")
-                            .font(GymBroTypography.caption2)
-                            .foregroundStyle(GymBroColors.textTertiary)
-                            .frame(width: 16)
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(exercise.exerciseName)
-                                .font(GymBroTypography.subheadline)
-                                .foregroundStyle(GymBroColors.textPrimary)
-
-                            HStack(spacing: GymBroSpacing.sm) {
-                                Text("\(exercise.targetSets)×\(exercise.targetReps)")
-                                    .font(GymBroTypography.caption)
-                                    .foregroundStyle(GymBroColors.accentCyan)
-
-                                if let rpe = exercise.targetRPE {
-                                    Text("RPE \(String(format: "%.0f", rpe))")
-                                        .font(GymBroTypography.caption)
-                                        .foregroundStyle(GymBroColors.accentAmber)
-                                }
-                            }
-
-                            if !exercise.notes.isEmpty {
-                                Text(exercise.notes)
-                                    .font(GymBroTypography.caption2)
-                                    .foregroundStyle(GymBroColors.textTertiary)
-                                    .lineLimit(2)
-                            }
-                        }
-
-                        Spacer()
-                    }
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var restDayContent: some View {
-        VStack(spacing: GymBroSpacing.lg) {
-            Image(systemName: "bed.double.fill")
-                .font(.system(size: 60))
-                .foregroundStyle(GymBroColors.accentCyan)
-
-            Text("Rest Day Recommended")
-                .font(GymBroTypography.title2)
-                .foregroundStyle(GymBroColors.textPrimary)
-
-            Text("Your body needs recovery. Take it easy today and come back stronger.")
-                .font(GymBroTypography.body)
-                .foregroundStyle(GymBroColors.textSecondary)
-                .multilineTextAlignment(.center)
-
-            if let reasoning = generatorVM?.reasoningText {
-                GymBroCard(accent: GymBroColors.accentCyan) {
-                    Text(reasoning)
-                        .font(GymBroTypography.caption)
-                        .foregroundStyle(GymBroColors.textSecondary)
-                }
-            }
-        }
-        .padding(.top, GymBroSpacing.xxl)
     }
 
     // MARK: - Helpers

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/SmartWorkoutHeroCard.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/SmartWorkoutHeroCard.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+import SwiftData
+import GymBroCore
+
+/// "Start Smart Workout" hero card — the first thing users see on the Workout tab.
+///
+/// Shows a preview of today's AI-generated workout based on active program + recovery.
+/// One tap → WorkoutPreviewSheet → confirm → ActiveWorkoutView.
+public struct SmartWorkoutHeroCard: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var generatorVM: WorkoutGeneratorViewModel?
+    @State private var showPreviewSheet = false
+    @State private var activeProgram: Program?
+    @State private var readinessScore: Double?
+    @State private var todayDayName: String?
+    @State private var isPressed = false
+
+    @ScaledMetric private var sparkIconSize: CGFloat = 24
+    @ScaledMetric private var chipIconSize: CGFloat = 12
+
+    /// Called when user confirms the workout in the preview sheet.
+    let onStartWorkout: (ActiveWorkoutViewModel) -> Void
+
+    public init(onStartWorkout: @escaping (ActiveWorkoutViewModel) -> Void) {
+        self.onStartWorkout = onStartWorkout
+    }
+
+    public var body: some View {
+        Button {
+            openPreview()
+        } label: {
+            cardContent
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isPressed ? 0.97 : 1.0)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.15), value: isPressed)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in isPressed = true }
+                .onEnded { _ in isPressed = false }
+        )
+        .sheet(isPresented: $showPreviewSheet) {
+            if let vm = generatorVM {
+                WorkoutPreviewSheet(generatorVM: vm, onStartWorkout: onStartWorkout)
+                    .presentationDetents([.large])
+            }
+        }
+        .task {
+            loadContext()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Start smart workout. \(summaryText)")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Card Content
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: GymBroSpacing.md) {
+            // Top row: icon + label
+            HStack(spacing: GymBroSpacing.sm) {
+                Image(systemName: "wand.and.stars")
+                    .font(.system(size: sparkIconSize, weight: .semibold))
+                    .foregroundStyle(GymBroColors.accentGreen)
+
+                Text("SMART WORKOUT")
+                    .font(GymBroTypography.caption2)
+                    .fontWeight(.bold)
+                    .foregroundStyle(GymBroColors.accentGreen)
+                    .tracking(2)
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(GymBroColors.accentGreen.opacity(0.7))
+            }
+
+            // Session name
+            Text(sessionTitle)
+                .font(GymBroTypography.title3)
+                .foregroundStyle(GymBroColors.textPrimary)
+
+            // Context chips
+            HStack(spacing: GymBroSpacing.md) {
+                if let dayName = todayDayName {
+                    contextChip(icon: "calendar", text: dayName)
+                }
+
+                if let readiness = readinessScore {
+                    contextChip(
+                        icon: "heart.fill",
+                        text: "Readiness \(Int(readiness))",
+                        color: colorForReadiness(readiness)
+                    )
+                }
+
+                contextChip(icon: "clock", text: "~45 min")
+            }
+
+            // Summary text
+            Text(summaryText)
+                .font(GymBroTypography.subheadline)
+                .foregroundStyle(GymBroColors.textSecondary)
+                .lineLimit(2)
+        }
+        .padding(GymBroSpacing.md + GymBroSpacing.xs)
+        .background(
+            RoundedRectangle(cornerRadius: GymBroRadius.xl)
+                .fill(GymBroColors.accentGreen.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: GymBroRadius.xl)
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [GymBroColors.accentGreen.opacity(0.4), GymBroColors.accentGreen.opacity(0.1)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1.5
+                )
+        )
+        .gymBroElevatedShadow()
+    }
+
+    // MARK: - Context Chip
+
+    private func contextChip(icon: String, text: String, color: Color = GymBroColors.textTertiary) -> some View {
+        HStack(spacing: GymBroSpacing.xs) {
+            Image(systemName: icon)
+                .font(.system(size: chipIconSize))
+            Text(text)
+                .font(GymBroTypography.caption2)
+        }
+        .foregroundStyle(color)
+    }
+
+    // MARK: - Data
+
+    private var sessionTitle: String {
+        if let program = activeProgram, let day = program.todaysProgramDay {
+            return day.name
+        }
+        return "Today's Workout"
+    }
+
+    private var summaryText: String {
+        if let program = activeProgram {
+            if let day = program.todaysProgramDay {
+                let exerciseNames = day.plannedExercises
+                    .sorted { $0.order < $1.order }
+                    .prefix(3)
+                    .compactMap { $0.exercise?.name }
+                let preview = exerciseNames.joined(separator: ", ")
+                let suffix = day.plannedExercises.count > 3 ? " +\(day.plannedExercises.count - 3) more" : ""
+                return "\(preview)\(suffix) — based on recovery"
+            }
+            return "Generating from \(program.name) — based on recovery"
+        }
+        return "AI-generated full body session — adapts to your recovery"
+    }
+
+    private func loadContext() {
+        let programDescriptor = FetchDescriptor<Program>(
+            predicate: #Predicate<Program> { $0.isActive }
+        )
+        activeProgram = try? modelContext.fetch(programDescriptor).first
+        todayDayName = activeProgram?.todaysProgramDay?.name
+
+        let readinessDescriptor = FetchDescriptor<ReadinessScore>(
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+        readinessScore = (try? modelContext.fetch(readinessDescriptor).first)?.overallScore
+    }
+
+    private func openPreview() {
+        let vm = WorkoutGeneratorViewModel(modelContext: modelContext)
+        generatorVM = vm
+        showPreviewSheet = true
+    }
+
+    private func colorForReadiness(_ score: Double) -> Color {
+        switch score {
+        case 80...100: return GymBroColors.accentGreen
+        case 60..<80: return GymBroColors.accentCyan
+        case 40..<60: return GymBroColors.accentAmber
+        default: return GymBroColors.accentRed
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Smart Workout Hero Card") {
+    VStack {
+        SmartWorkoutHeroCard { _ in }
+            .padding(.horizontal, GymBroSpacing.md)
+    }
+    .frame(maxHeight: .infinity)
+    .gymBroDarkBackground()
+}

--- a/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/WorkoutPreviewSheet.swift
+++ b/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/WorkoutPreviewSheet.swift
@@ -1,0 +1,405 @@
+import SwiftUI
+import SwiftData
+import GymBroCore
+
+/// Preview sheet for a generated workout — shows exercises, reasoning trail, and confirm/cancel.
+///
+/// Presented as a sheet from any entry point (hero card, program detail, active program).
+/// User reviews the plan, then confirms to start ActiveWorkoutView.
+public struct WorkoutPreviewSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var generatorVM: WorkoutGeneratorViewModel
+    @State private var showReasoning = false
+    @State private var activeWorkoutVM: ActiveWorkoutViewModel?
+    @State private var navigateToWorkout = false
+
+    @ScaledMetric private var exerciseIconSize: CGFloat = 28
+
+    /// Called when the user confirms and starts the workout.
+    private let onStartWorkout: (ActiveWorkoutViewModel) -> Void
+
+    public init(
+        generatorVM: WorkoutGeneratorViewModel,
+        onStartWorkout: @escaping (ActiveWorkoutViewModel) -> Void
+    ) {
+        self._generatorVM = State(initialValue: generatorVM)
+        self.onStartWorkout = onStartWorkout
+    }
+
+    public var body: some View {
+        NavigationStack {
+            ZStack {
+                GymBroColors.background.ignoresSafeArea()
+
+                if generatorVM.isGenerating {
+                    generatingState
+                } else if let workout = generatorVM.generatedWorkout {
+                    if workout.isRestDay {
+                        restDayState(workout)
+                    } else {
+                        workoutPreview(workout)
+                    }
+                } else {
+                    emptyState
+                }
+            }
+            .navigationTitle("Smart Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(GymBroColors.textSecondary)
+                }
+            }
+            .task {
+                if generatorVM.generatedWorkout == nil && !generatorVM.isGenerating {
+                    generatorVM.generateWorkout()
+                }
+            }
+        }
+    }
+
+    // MARK: - Generating State
+
+    private var generatingState: some View {
+        VStack(spacing: GymBroSpacing.lg) {
+            ProgressView()
+                .tint(GymBroColors.accentGreen)
+                .scaleEffect(1.5)
+
+            Text("Building your workout…")
+                .font(GymBroTypography.headline)
+                .foregroundStyle(GymBroColors.textPrimary)
+
+            Text("Analyzing recovery, readiness, and program")
+                .font(GymBroTypography.caption)
+                .foregroundStyle(GymBroColors.textSecondary)
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: GymBroSpacing.lg) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 48))
+                .foregroundStyle(GymBroColors.textTertiary)
+
+            Text("Tap to generate")
+                .font(GymBroTypography.headline)
+                .foregroundStyle(GymBroColors.textSecondary)
+
+            Button("Generate Workout") {
+                generatorVM.generateWorkout()
+            }
+            .buttonStyle(.gymBroPrimary)
+            .padding(.horizontal, GymBroSpacing.xl)
+        }
+    }
+
+    // MARK: - Rest Day
+
+    private func restDayState(_ workout: GeneratedWorkout) -> some View {
+        VStack(spacing: GymBroSpacing.lg) {
+            Image(systemName: "moon.zzz.fill")
+                .font(.system(size: 56))
+                .foregroundStyle(GymBroColors.accentAmber)
+
+            Text("Rest Day Recommended")
+                .font(GymBroTypography.title2)
+                .foregroundStyle(GymBroColors.textPrimary)
+
+            Text(workout.recommendation.rationale)
+                .font(GymBroTypography.body)
+                .foregroundStyle(GymBroColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, GymBroSpacing.lg)
+
+            reasoningSection(workout)
+
+            Button("Got It") { dismiss() }
+                .buttonStyle(GymBroSecondaryButtonStyle(accent: GymBroColors.accentAmber))
+                .padding(.horizontal, GymBroSpacing.lg)
+        }
+        .padding(.vertical, GymBroSpacing.xxl)
+    }
+
+    // MARK: - Workout Preview
+
+    private func workoutPreview(_ workout: GeneratedWorkout) -> some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: GymBroSpacing.lg) {
+                    sessionHeader(workout)
+                    exerciseList(workout)
+                    reasoningSection(workout)
+                }
+                .padding(.horizontal, GymBroSpacing.md)
+                .padding(.top, GymBroSpacing.md)
+                .padding(.bottom, 120)
+            }
+
+            confirmBar(workout)
+        }
+    }
+
+    // MARK: - Session Header
+
+    private func sessionHeader(_ workout: GeneratedWorkout) -> some View {
+        GymBroCard(accent: GymBroColors.accentGreen) {
+            VStack(alignment: .leading, spacing: GymBroSpacing.md) {
+                Text(workout.sessionName)
+                    .font(GymBroTypography.title3)
+                    .foregroundStyle(GymBroColors.textPrimary)
+
+                HStack(spacing: GymBroSpacing.lg) {
+                    Label("\(workout.exercises.count) exercises", systemImage: "dumbbell.fill")
+                        .font(GymBroTypography.caption)
+                        .foregroundStyle(GymBroColors.textSecondary)
+
+                    Label("~\(workout.estimatedDurationMinutes) min", systemImage: "clock")
+                        .font(GymBroTypography.caption)
+                        .foregroundStyle(GymBroColors.textSecondary)
+
+                    Spacer()
+                }
+
+                actionBadge(workout.recommendation.action)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionBadge(_ action: RecommendedAction) -> some View {
+        let (text, color, icon) = actionInfo(action)
+        HStack(spacing: GymBroSpacing.sm) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+            Text(text)
+                .font(GymBroTypography.caption)
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, GymBroSpacing.sm)
+        .padding(.vertical, GymBroSpacing.xs)
+        .background(
+            Capsule().fill(color.opacity(0.12))
+        )
+    }
+
+    private func actionInfo(_ action: RecommendedAction) -> (String, Color, String) {
+        switch action {
+        case .proceedAsPlanned:
+            return ("Full send", GymBroColors.accentGreen, "bolt.fill")
+        case .lighterVariant:
+            return ("Lighter variant", GymBroColors.accentAmber, "arrow.down.circle")
+        case .modifyExercises:
+            return ("Modified exercises", GymBroColors.accentCyan, "arrow.triangle.2.circlepath")
+        case .restDay:
+            return ("Rest day", GymBroColors.accentRed, "moon.zzz.fill")
+        }
+    }
+
+    // MARK: - Exercise List
+
+    private func exerciseList(_ workout: GeneratedWorkout) -> some View {
+        VStack(alignment: .leading, spacing: GymBroSpacing.sm) {
+            Text("EXERCISES")
+                .font(GymBroTypography.caption2)
+                .foregroundStyle(GymBroColors.textTertiary)
+                .tracking(2)
+
+            ForEach(Array(workout.exercises.enumerated()), id: \.element.id) { index, exercise in
+                exercisePreviewRow(exercise, index: index)
+            }
+        }
+    }
+
+    private func exercisePreviewRow(_ exercise: GeneratedExercise, index: Int) -> some View {
+        GymBroCard {
+            HStack(spacing: GymBroSpacing.md) {
+                Circle()
+                    .fill(GymBroColors.surfaceElevated)
+                    .frame(width: exerciseIconSize, height: exerciseIconSize)
+                    .overlay(
+                        Text("\(index + 1)")
+                            .font(GymBroTypography.caption2)
+                            .foregroundStyle(GymBroColors.textSecondary)
+                    )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(exercise.exerciseName)
+                        .font(GymBroTypography.subheadline)
+                        .foregroundStyle(GymBroColors.textPrimary)
+
+                    HStack(spacing: GymBroSpacing.sm) {
+                        Text("\(exercise.targetSets)×\(exercise.targetReps)")
+                            .font(GymBroTypography.caption)
+                            .foregroundStyle(GymBroColors.accentCyan)
+
+                        if let rpe = exercise.targetRPE {
+                            Text("RPE \(String(format: "%.0f", rpe))")
+                                .font(GymBroTypography.caption)
+                                .foregroundStyle(GymBroColors.accentAmber)
+                        }
+
+                        if exercise.weightMultiplier < 1.0 {
+                            Text("\(Int(exercise.weightMultiplier * 100))% load")
+                                .font(GymBroTypography.caption)
+                                .foregroundStyle(GymBroColors.accentAmber)
+                        }
+                    }
+
+                    if !exercise.notes.isEmpty {
+                        Text(exercise.notes)
+                            .font(GymBroTypography.caption2)
+                            .foregroundStyle(GymBroColors.textTertiary)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer()
+
+                Button {
+                    generatorVM.swapExercise(at: index)
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 14))
+                        .foregroundStyle(GymBroColors.textTertiary)
+                        .frame(width: 36, height: 36)
+                        .background(GymBroColors.surfaceElevated, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Swap \(exercise.exerciseName)")
+            }
+        }
+    }
+
+    // MARK: - Reasoning Section
+
+    private func reasoningSection(_ workout: GeneratedWorkout) -> some View {
+        VStack(alignment: .leading, spacing: GymBroSpacing.sm) {
+            Button {
+                withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.2)) {
+                    showReasoning.toggle()
+                }
+            } label: {
+                HStack(spacing: GymBroSpacing.sm) {
+                    Image(systemName: "brain.head.profile")
+                        .foregroundStyle(GymBroColors.accentCyan)
+
+                    Text("WHY THIS WORKOUT?")
+                        .font(GymBroTypography.caption2)
+                        .foregroundStyle(GymBroColors.textTertiary)
+                        .tracking(2)
+
+                    Spacer()
+
+                    Image(systemName: showReasoning ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 12))
+                        .foregroundStyle(GymBroColors.textTertiary)
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(showReasoning ? "Hide reasoning" : "Show reasoning")
+
+            if showReasoning {
+                GymBroCard(accent: GymBroColors.accentCyan) {
+                    VStack(alignment: .leading, spacing: GymBroSpacing.sm) {
+                        ForEach(workout.reasoning.indices, id: \.self) { idx in
+                            let step = workout.reasoning[idx]
+                            reasoningRow(step)
+                        }
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    private func reasoningRow(_ step: ReasoningStep) -> some View {
+        HStack(alignment: .top, spacing: GymBroSpacing.sm) {
+            Image(systemName: reasoningIcon(step.factor))
+                .font(.system(size: 12))
+                .foregroundStyle(reasoningColor(step.impact))
+                .frame(width: 16, alignment: .center)
+
+            Text(step.summary)
+                .font(GymBroTypography.caption)
+                .foregroundStyle(GymBroColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func reasoningIcon(_ factor: ReasoningFactor) -> String {
+        switch factor {
+        case .muscleRecovery: return "figure.cooldown"
+        case .readiness: return "heart.fill"
+        case .overtraining: return "exclamationmark.triangle"
+        case .programTemplate: return "calendar"
+        case .exerciseHistory: return "clock.arrow.circlepath"
+        case .timeConstraint: return "clock"
+        case .userProfile: return "person.fill"
+        }
+    }
+
+    private func reasoningColor(_ impact: ReasoningImpact) -> Color {
+        switch impact {
+        case .exerciseSelection: return GymBroColors.accentCyan
+        case .volumeIntensity: return GymBroColors.accentAmber
+        case .restDay: return GymBroColors.accentRed
+        }
+    }
+
+    // MARK: - Confirm Bar
+
+    private func confirmBar(_ workout: GeneratedWorkout) -> some View {
+        VStack(spacing: GymBroSpacing.sm) {
+            Divider().background(GymBroColors.border)
+
+            Button {
+                startGeneratedWorkout()
+            } label: {
+                HStack(spacing: GymBroSpacing.sm) {
+                    Image(systemName: "flame.fill")
+                    Text("Let's Go")
+                }
+            }
+            .buttonStyle(.gymBroPrimary)
+            .padding(.horizontal, GymBroSpacing.md)
+            .padding(.bottom, GymBroSpacing.md)
+        }
+        .background(GymBroColors.background)
+    }
+
+    // MARK: - Actions
+
+    private func startGeneratedWorkout() {
+        guard let workout = generatorVM.startWorkout() else { return }
+
+        let exercises = workout.exercises
+        let vm = ActiveWorkoutViewModel(
+            modelContext: modelContext,
+            workout: workout,
+            exercises: exercises
+        )
+        dismiss()
+        onStartWorkout(vm)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Workout Preview") {
+    WorkoutPreviewSheet(
+        generatorVM: WorkoutGeneratorViewModel(
+            modelContext: try! ModelContext(
+                ModelContainer(for: Program.self, Exercise.self, Workout.self, ExerciseSet.self,
+                               configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+            )
+        ),
+        onStartWorkout: { _ in }
+    )
+}


### PR DESCRIPTION
## Summary

Wire WorkoutGeneratorService into the full user-facing flow. **The Workout tab now opens with a Smart Workout hero card** — one tap to preview, confirm, and start training.

### What's new

| View | Change |
|------|--------|
| **SmartWorkoutHeroCard** (new) | Hero card on Workout tab. Shows today's session preview (program day name, readiness score, estimated duration). One tap → WorkoutPreviewSheet. |
| **WorkoutPreviewSheet** (new) | Full generated workout preview with exercise list, per-exercise swap buttons, collapsible reasoning trail, rest day handling, and confirm-to-start flow. |
| **ProgramDetailView** | ''Start Smart Workout'' button when program is active → generates workout → preview → ActiveWorkoutView. |
| **ActiveProgramView** | ''Start Smart Workout'' below today's workout card → same preview → go flow. |
| **ContentView/WorkoutTab** | Replaced empty state with hero card + secondary ''Empty Workout'' quick-start. |

### Design system compliance

- All views use GymBroColors, GymBroTypography, GymBroSpacing, GymBroCard, GymBroButton styles
- @ScaledMetric for Dynamic Type
- All animations gated on \educeMotion\
- VoiceOver accessibility labels on interactive elements

### Flow

\\\
Workout Tab → SmartWorkoutHeroCard → WorkoutPreviewSheet → Confirm → ActiveWorkoutView
Programs Tab → ProgramDetailView → ''Start Smart Workout'' → WorkoutPreviewSheet → Confirm → ActiveWorkoutView
Programs Tab → ActiveProgramView → ''Start Smart Workout'' → WorkoutPreviewSheet → Confirm → ActiveWorkoutView
\\\

Working as Trinity (iOS Dev).

Closes #114

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>