### PR TITLE
feat: add Android CI workflow for Gradle builds

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,63 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main, master ]
+    paths: ['android/**']
+  pull_request:
+    branches: [ main, master ]
+    paths: ['android/**']
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Build debug APK
+      working-directory: android
+      run: ./gradlew assembleDebug
+
+    - name: Run unit tests
+      working-directory: android
+      run: ./gradlew testDebugUnitTest
+
+    - name: Upload debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-apk
+        path: android/app/build/outputs/apk/debug/
+        if-no-files-found: ignore
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Run Android Lint
+      working-directory: android
+      run: ./gradlew lintDebug


### PR DESCRIPTION
Adds a GitHub Actions CI workflow for the Android project.

## What
- **Build job:** Sets up JDK 21 (temurin) + Gradle with caching, runs `assembleDebug` and `testDebugUnitTest`, uploads debug APK artifact
- **Lint job:** Runs `lintDebug` in parallel
- Triggers on push/PR to master when `android/**` files change

Follows conventions from existing `ci.yml` (checkout@v4, upload-artifact@v4, parallel jobs).

Closes #144