### PR TITLE
feat: add Exercise Library screen with Room + MVI

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.gymbro.feature.exerciselibrary.ExerciseLibraryRoute
 
 @Composable
 fun GymBroNavGraph() {
@@ -17,8 +18,18 @@ fun GymBroNavGraph() {
 
     NavHost(
         navController = navController,
-        startDestination = "workout",
+        startDestination = "exercise_library",
     ) {
+        composable("exercise_library") {
+            ExerciseLibraryRoute(
+                onNavigateToDetail = { exerciseId ->
+                    navController.navigate("exercise_detail/$exerciseId")
+                },
+            )
+        }
+        composable("exercise_detail/{exerciseId}") {
+            PlaceholderScreen(title = "Exercise Detail")
+        }
         composable("workout") {
             PlaceholderScreen(title = "Workout")
         }

--- a/android/core/schemas/com.gymbro.core.database.GymBroDatabase/1.json
+++ b/android/core/schemas/com.gymbro.core.database.GymBroDatabase/1.json
@@ -1,0 +1,55 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "2f9a1a0337408de006bde6b0bcfcc286",
+    "entities": [
+      {
+        "tableName": "exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `muscleGroup` TEXT NOT NULL, `equipment` TEXT NOT NULL, `instructions` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleGroup",
+            "columnName": "muscleGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipment",
+            "columnName": "equipment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructions",
+            "columnName": "instructions",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2f9a1a0337408de006bde6b0bcfcc286')"
+    ]
+  }
+}

--- a/android/core/schemas/com.gymbro.core.database.GymBroDatabase/2.json
+++ b/android/core/schemas/com.gymbro.core.database.GymBroDatabase/2.json
@@ -1,0 +1,66 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "f6ffea0d52fb2bf8666a097f21046b9e",
+    "entities": [
+      {
+        "tableName": "exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `muscleGroup` TEXT NOT NULL, `category` TEXT NOT NULL, `equipment` TEXT NOT NULL, `description` TEXT NOT NULL, `youtubeUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleGroup",
+            "columnName": "muscleGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipment",
+            "columnName": "equipment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtubeUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f6ffea0d52fb2bf8666a097f21046b9e')"
+    ]
+  }
+}

--- a/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
@@ -2,13 +2,14 @@ package com.gymbro.core.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.gymbro.core.database.dao.ExerciseDao
 import com.gymbro.core.database.entity.ExerciseEntity
 
 @Database(
     entities = [ExerciseEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = true,
 )
 abstract class GymBroDatabase : RoomDatabase() {
-    abstract fun exerciseDao(): com.gymbro.core.database.dao.ExerciseDao
+    abstract fun exerciseDao(): ExerciseDao
 }

--- a/android/core/src/main/java/com/gymbro/core/database/dao/package-info.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/dao/package-info.kt
@@ -12,12 +12,34 @@ interface ExerciseDao {
     @Query("SELECT * FROM exercises ORDER BY name ASC")
     fun getAllExercises(): Flow<List<ExerciseEntity>>
 
+    @Query("SELECT * FROM exercises WHERE muscleGroup = :muscleGroup ORDER BY name ASC")
+    fun getExercisesByMuscleGroup(muscleGroup: String): Flow<List<ExerciseEntity>>
+
+    @Query("SELECT * FROM exercises WHERE name LIKE '%' || :query || '%' ORDER BY name ASC")
+    fun searchExercises(query: String): Flow<List<ExerciseEntity>>
+
+    @Query(
+        """
+        SELECT * FROM exercises 
+        WHERE (:muscleGroup IS NULL OR muscleGroup = :muscleGroup)
+        AND (:query IS NULL OR name LIKE '%' || :query || '%')
+        ORDER BY name ASC
+        """
+    )
+    fun getFilteredExercises(muscleGroup: String?, query: String?): Flow<List<ExerciseEntity>>
+
     @Query("SELECT * FROM exercises WHERE id = :id")
     suspend fun getExerciseById(id: String): ExerciseEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertExercise(exercise: ExerciseEntity)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(exercises: List<ExerciseEntity>)
+
     @Query("DELETE FROM exercises WHERE id = :id")
     suspend fun deleteExercise(id: String)
+
+    @Query("SELECT COUNT(*) FROM exercises")
+    suspend fun count(): Int
 }

--- a/android/core/src/main/java/com/gymbro/core/database/entity/package-info.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/entity/package-info.kt
@@ -10,6 +10,8 @@ data class ExerciseEntity(
     val id: String = UUID.randomUUID().toString(),
     val name: String,
     val muscleGroup: String,
+    val category: String = "COMPOUND",
     val equipment: String = "BARBELL",
-    val instructions: String = "",
+    val description: String = "",
+    val youtubeUrl: String? = null,
 )

--- a/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
@@ -2,12 +2,20 @@ package com.gymbro.core.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.gymbro.core.database.GymBroDatabase
+import com.gymbro.core.database.dao.ExerciseDao
+import com.gymbro.core.database.entity.ExerciseEntity
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Singleton
 
 @Module
@@ -21,6 +29,231 @@ object DatabaseModule {
             context,
             GymBroDatabase::class.java,
             "gymbro.db",
-        ).build()
+        )
+            .fallbackToDestructiveMigration(true)
+            .addCallback(SeedDatabaseCallback())
+            .build()
+    }
+
+    @Provides
+    fun provideExerciseDao(database: GymBroDatabase): ExerciseDao {
+        return database.exerciseDao()
     }
 }
+
+private class SeedDatabaseCallback : RoomDatabase.Callback() {
+    override fun onCreate(db: SupportSQLiteDatabase) {
+        super.onCreate(db)
+        CoroutineScope(Dispatchers.IO).launch {
+            seedExercises().forEach { exercise ->
+                db.execSQL(
+                    """INSERT OR IGNORE INTO exercises (id, name, muscleGroup, category, equipment, description, youtubeUrl) 
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    arrayOf(
+                        exercise.id,
+                        exercise.name,
+                        exercise.muscleGroup,
+                        exercise.category,
+                        exercise.equipment,
+                        exercise.description,
+                        exercise.youtubeUrl,
+                    ),
+                )
+            }
+        }
+    }
+}
+
+private fun seedExercises(): List<ExerciseEntity> = listOf(
+    // Chest
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("bench-press".toByteArray()).toString(),
+        name = "Barbell Bench Press",
+        muscleGroup = "CHEST",
+        category = "COMPOUND",
+        equipment = "BARBELL",
+        description = "Lie on a flat bench, grip the bar slightly wider than shoulder-width, lower to chest, press up.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("incline-bench".toByteArray()).toString(),
+        name = "Incline Dumbbell Press",
+        muscleGroup = "CHEST",
+        category = "COMPOUND",
+        equipment = "DUMBBELL",
+        description = "Set bench to 30-45 degrees, press dumbbells from chest level to lockout.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("cable-fly".toByteArray()).toString(),
+        name = "Cable Fly",
+        muscleGroup = "CHEST",
+        category = "ISOLATION",
+        equipment = "CABLE",
+        description = "Stand between cable towers, bring handles together in a hugging motion.",
+    ),
+    // Back
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("deadlift".toByteArray()).toString(),
+        name = "Conventional Deadlift",
+        muscleGroup = "BACK",
+        category = "COMPOUND",
+        equipment = "BARBELL",
+        description = "Hinge at hips, grip bar outside knees, drive through floor to lockout.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("barbell-row".toByteArray()).toString(),
+        name = "Barbell Row",
+        muscleGroup = "BACK",
+        category = "COMPOUND",
+        equipment = "BARBELL",
+        description = "Hinge forward ~45 degrees, pull bar to lower chest/upper abdomen.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("lat-pulldown".toByteArray()).toString(),
+        name = "Lat Pulldown",
+        muscleGroup = "BACK",
+        category = "ACCESSORY",
+        equipment = "CABLE",
+        description = "Pull wide bar to upper chest, squeeze lats at bottom.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("pull-up".toByteArray()).toString(),
+        name = "Pull-Up",
+        muscleGroup = "BACK",
+        category = "COMPOUND",
+        equipment = "BODYWEIGHT",
+        description = "Hang from bar with overhand grip, pull chin above bar.",
+    ),
+    // Legs
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("back-squat".toByteArray()).toString(),
+        name = "Barbell Back Squat",
+        muscleGroup = "QUADRICEPS",
+        category = "COMPOUND",
+        equipment = "BARBELL",
+        description = "Bar on upper back, squat to parallel or below, drive up through heels.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("leg-press".toByteArray()).toString(),
+        name = "Leg Press",
+        muscleGroup = "QUADRICEPS",
+        category = "COMPOUND",
+        equipment = "MACHINE",
+        description = "Feet shoulder-width on platform, lower sled until 90-degree knee bend, press up.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("rdl".toByteArray()).toString(),
+        name = "Romanian Deadlift",
+        muscleGroup = "HAMSTRINGS",
+        category = "COMPOUND",
+        equipment = "BARBELL",
+        description = "Slight knee bend, hinge at hips lowering bar along shins until hamstring stretch.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("leg-curl".toByteArray()).toString(),
+        name = "Lying Leg Curl",
+        muscleGroup = "HAMSTRINGS",
+        category = "ISOLATION",
+        equipment = "MACHINE",
+        description = "Lie face down, curl pad toward glutes, control the eccentric.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("leg-extension".toByteArray()).toString(),
+        name = "Leg Extension",
+        muscleGroup = "QUADRICEPS",
+        category = "ISOLATION",
+        equipment = "MACHINE",
+        description = "Sit on machine, extend legs to full lockout, squeeze quads at top.",
+    ),
+    // Shoulders
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("ohp".toByteArray()).toString(),
+        name = "Overhead Press",
+        muscleGroup = "SHOULDERS",
+        category = "COMPOUND",
+        equipment = "BARBELL",
+        description = "Press barbell from front rack position overhead to lockout.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("lateral-raise".toByteArray()).toString(),
+        name = "Lateral Raise",
+        muscleGroup = "SHOULDERS",
+        category = "ISOLATION",
+        equipment = "DUMBBELL",
+        description = "Raise dumbbells to sides until arms are parallel to floor.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("face-pull".toByteArray()).toString(),
+        name = "Face Pull",
+        muscleGroup = "SHOULDERS",
+        category = "ACCESSORY",
+        equipment = "CABLE",
+        description = "Pull rope to face level, externally rotate shoulders at end position.",
+    ),
+    // Arms
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("barbell-curl".toByteArray()).toString(),
+        name = "Barbell Curl",
+        muscleGroup = "BICEPS",
+        category = "ISOLATION",
+        equipment = "BARBELL",
+        description = "Curl barbell from full extension to peak contraction, keep elbows stationary.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("hammer-curl".toByteArray()).toString(),
+        name = "Hammer Curl",
+        muscleGroup = "BICEPS",
+        category = "ISOLATION",
+        equipment = "DUMBBELL",
+        description = "Curl dumbbells with neutral grip (palms facing each other).",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("tricep-pushdown".toByteArray()).toString(),
+        name = "Tricep Pushdown",
+        muscleGroup = "TRICEPS",
+        category = "ISOLATION",
+        equipment = "CABLE",
+        description = "Push cable attachment down until arms are fully extended, elbows at sides.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("skull-crusher".toByteArray()).toString(),
+        name = "Skull Crusher",
+        muscleGroup = "TRICEPS",
+        category = "ISOLATION",
+        equipment = "BARBELL",
+        description = "Lie on bench, lower bar to forehead by bending elbows, extend back up.",
+    ),
+    // Core
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("hanging-leg-raise".toByteArray()).toString(),
+        name = "Hanging Leg Raise",
+        muscleGroup = "CORE",
+        category = "ISOLATION",
+        equipment = "BODYWEIGHT",
+        description = "Hang from bar, raise legs to parallel or above, control the descent.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("cable-crunch".toByteArray()).toString(),
+        name = "Cable Crunch",
+        muscleGroup = "CORE",
+        category = "ISOLATION",
+        equipment = "CABLE",
+        description = "Kneel at cable machine, crunch down bringing elbows to knees.",
+    ),
+    // Glutes
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("hip-thrust".toByteArray()).toString(),
+        name = "Barbell Hip Thrust",
+        muscleGroup = "GLUTES",
+        category = "COMPOUND",
+        equipment = "BARBELL",
+        description = "Back against bench, drive hips up with barbell across lap, squeeze glutes at top.",
+    ),
+    ExerciseEntity(
+        id = UUID.nameUUIDFromBytes("bulgarian-split-squat".toByteArray()).toString(),
+        name = "Bulgarian Split Squat",
+        muscleGroup = "QUADRICEPS",
+        category = "COMPOUND",
+        equipment = "DUMBBELL",
+        description = "Rear foot elevated on bench, lunge down until front thigh is parallel.",
+    ),
+)

--- a/android/core/src/main/java/com/gymbro/core/di/RepositoryModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/RepositoryModule.kt
@@ -1,0 +1,16 @@
+package com.gymbro.core.di
+
+import com.gymbro.core.repository.ExerciseRepository
+import com.gymbro.core.repository.ExerciseRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    abstract fun bindExerciseRepository(impl: ExerciseRepositoryImpl): ExerciseRepository
+}

--- a/android/core/src/main/java/com/gymbro/core/model/Exercise.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/Exercise.kt
@@ -6,23 +6,32 @@ data class Exercise(
     val id: UUID = UUID.randomUUID(),
     val name: String,
     val muscleGroup: MuscleGroup,
+    val category: ExerciseCategory = ExerciseCategory.COMPOUND,
     val equipment: Equipment = Equipment.BARBELL,
-    val instructions: String = "",
+    val description: String = "",
+    val youtubeUrl: String? = null,
 )
 
-enum class MuscleGroup {
-    CHEST,
-    BACK,
-    SHOULDERS,
-    BICEPS,
-    TRICEPS,
-    QUADRICEPS,
-    HAMSTRINGS,
-    GLUTES,
-    CALVES,
-    CORE,
-    FOREARMS,
-    FULL_BODY,
+enum class MuscleGroup(val displayName: String) {
+    CHEST("Chest"),
+    BACK("Back"),
+    SHOULDERS("Shoulders"),
+    BICEPS("Biceps"),
+    TRICEPS("Triceps"),
+    QUADRICEPS("Quadriceps"),
+    HAMSTRINGS("Hamstrings"),
+    GLUTES("Glutes"),
+    CALVES("Calves"),
+    CORE("Core"),
+    FOREARMS("Forearms"),
+    FULL_BODY("Full Body"),
+}
+
+enum class ExerciseCategory(val displayName: String) {
+    COMPOUND("Compound"),
+    ISOLATION("Isolation"),
+    ACCESSORY("Accessory"),
+    CARDIO("Cardio"),
 }
 
 enum class Equipment {

--- a/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepository.kt
@@ -1,0 +1,10 @@
+package com.gymbro.core.repository
+
+import com.gymbro.core.model.Exercise
+import kotlinx.coroutines.flow.Flow
+
+interface ExerciseRepository {
+    fun getAllExercises(): Flow<List<Exercise>>
+    fun getFilteredExercises(muscleGroup: String?, query: String?): Flow<List<Exercise>>
+    suspend fun getExerciseById(id: String): Exercise?
+}

--- a/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.gymbro.core.repository
+
+import com.gymbro.core.database.dao.ExerciseDao
+import com.gymbro.core.database.entity.ExerciseEntity
+import com.gymbro.core.model.Equipment
+import com.gymbro.core.model.Exercise
+import com.gymbro.core.model.ExerciseCategory
+import com.gymbro.core.model.MuscleGroup
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+import javax.inject.Inject
+
+class ExerciseRepositoryImpl @Inject constructor(
+    private val exerciseDao: ExerciseDao,
+) : ExerciseRepository {
+
+    override fun getAllExercises(): Flow<List<Exercise>> =
+        exerciseDao.getAllExercises().map { entities -> entities.map { it.toDomain() } }
+
+    override fun getFilteredExercises(muscleGroup: String?, query: String?): Flow<List<Exercise>> =
+        exerciseDao.getFilteredExercises(muscleGroup, query).map { entities ->
+            entities.map { it.toDomain() }
+        }
+
+    override suspend fun getExerciseById(id: String): Exercise? =
+        exerciseDao.getExerciseById(id)?.toDomain()
+}
+
+private fun ExerciseEntity.toDomain(): Exercise = Exercise(
+    id = UUID.fromString(id),
+    name = name,
+    muscleGroup = MuscleGroup.entries.find { it.name == muscleGroup } ?: MuscleGroup.FULL_BODY,
+    category = ExerciseCategory.entries.find { it.name == category } ?: ExerciseCategory.COMPOUND,
+    equipment = Equipment.entries.find { it.name == equipment } ?: Equipment.OTHER,
+    description = description,
+    youtubeUrl = youtubeUrl,
+)

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryContract.kt
@@ -1,0 +1,21 @@
+package com.gymbro.feature.exerciselibrary
+
+import com.gymbro.core.model.Exercise
+import com.gymbro.core.model.MuscleGroup
+
+data class ExerciseLibraryState(
+    val exercises: List<Exercise> = emptyList(),
+    val searchQuery: String = "",
+    val selectedMuscleGroup: MuscleGroup? = null,
+    val isLoading: Boolean = true,
+)
+
+sealed interface ExerciseLibraryEvent {
+    data class SearchQueryChanged(val query: String) : ExerciseLibraryEvent
+    data class MuscleGroupSelected(val muscleGroup: MuscleGroup?) : ExerciseLibraryEvent
+    data class ExerciseClicked(val exercise: Exercise) : ExerciseLibraryEvent
+}
+
+sealed interface ExerciseLibraryEffect {
+    data class NavigateToDetail(val exerciseId: String) : ExerciseLibraryEffect
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -1,0 +1,313 @@
+package com.gymbro.feature.exerciselibrary
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gymbro.core.model.Exercise
+import com.gymbro.core.model.ExerciseCategory
+import com.gymbro.core.model.MuscleGroup
+
+private val AccentGreen = Color(0xFF00FF87)
+private val AccentCyan = Color(0xFF00E5FF)
+private val AccentAmber = Color(0xFFFFAB00)
+private val AccentRed = Color(0xFFCF6679)
+
+@Composable
+fun ExerciseLibraryRoute(
+    viewModel: ExerciseLibraryViewModel = hiltViewModel(),
+    onNavigateToDetail: (String) -> Unit = {},
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is ExerciseLibraryEffect.NavigateToDetail -> {
+                    onNavigateToDetail(effect.exerciseId)
+                }
+            }
+        }
+    }
+
+    ExerciseLibraryScreen(
+        state = state.value,
+        onEvent = viewModel::onEvent,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ExerciseLibraryScreen(
+    state: ExerciseLibraryState,
+    onEvent: (ExerciseLibraryEvent) -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Exercise Library",
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            // Search bar
+            TextField(
+                value = state.searchQuery,
+                onValueChange = { onEvent(ExerciseLibraryEvent.SearchQueryChanged(it)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                placeholder = {
+                    Text("Search exercises…", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                },
+                leadingIcon = {
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = "Search",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.surface,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    cursorColor = AccentGreen,
+                    focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                ),
+            )
+
+            // Muscle group filter chips
+            val filterGroups = listOf(
+                MuscleGroup.CHEST, MuscleGroup.BACK, MuscleGroup.QUADRICEPS,
+                MuscleGroup.SHOULDERS, MuscleGroup.BICEPS, MuscleGroup.CORE,
+            )
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                filterGroups.forEach { group ->
+                    val isSelected = state.selectedMuscleGroup == group
+                    FilterChip(
+                        selected = isSelected,
+                        onClick = {
+                            onEvent(
+                                ExerciseLibraryEvent.MuscleGroupSelected(
+                                    if (isSelected) null else group,
+                                ),
+                            )
+                        },
+                        label = { Text(group.displayName, fontSize = 13.sp) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            selectedContainerColor = AccentGreen.copy(alpha = 0.15f),
+                            selectedLabelColor = AccentGreen,
+                        ),
+                        border = FilterChipDefaults.filterChipBorder(
+                            borderColor = MaterialTheme.colorScheme.surfaceVariant,
+                            selectedBorderColor = AccentGreen.copy(alpha = 0.5f),
+                            enabled = true,
+                            selected = isSelected,
+                        ),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Content
+            when {
+                state.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(color = AccentGreen)
+                    }
+                }
+                state.exercises.isEmpty() -> {
+                    EmptyExercisesView()
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        items(
+                            items = state.exercises,
+                            key = { it.id.toString() },
+                        ) { exercise ->
+                            ExerciseRow(
+                                exercise = exercise,
+                                onClick = { onEvent(ExerciseLibraryEvent.ExerciseClicked(exercise)) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExerciseRow(
+    exercise: Exercise,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = exercise.name,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CategoryBadge(category = exercise.category)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "•",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = exercise.muscleGroup.displayName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@Composable
+private fun CategoryBadge(category: ExerciseCategory) {
+    val color = when (category) {
+        ExerciseCategory.COMPOUND -> AccentGreen
+        ExerciseCategory.ISOLATION -> AccentAmber
+        ExerciseCategory.ACCESSORY -> AccentCyan
+        ExerciseCategory.CARDIO -> AccentRed
+    }
+
+    Text(
+        text = category.displayName.uppercase(),
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Bold,
+        color = color,
+        modifier = Modifier
+            .background(
+                color = color.copy(alpha = 0.15f),
+                shape = RoundedCornerShape(4.dp),
+            )
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    )
+}
+
+@Composable
+private fun EmptyExercisesView() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Default.Search,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(48.dp),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "No exercises found",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Try adjusting your search or filters",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
@@ -1,0 +1,69 @@
+package com.gymbro.feature.exerciselibrary
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gymbro.core.repository.ExerciseRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ExerciseLibraryViewModel @Inject constructor(
+    private val exerciseRepository: ExerciseRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ExerciseLibraryState())
+    val state: StateFlow<ExerciseLibraryState> = _state.asStateFlow()
+
+    private val _effect = Channel<ExerciseLibraryEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    private var loadJob: Job? = null
+
+    init {
+        loadExercises()
+    }
+
+    fun onEvent(event: ExerciseLibraryEvent) {
+        when (event) {
+            is ExerciseLibraryEvent.SearchQueryChanged -> {
+                _state.update { it.copy(searchQuery = event.query) }
+                loadExercises()
+            }
+            is ExerciseLibraryEvent.MuscleGroupSelected -> {
+                _state.update { it.copy(selectedMuscleGroup = event.muscleGroup) }
+                loadExercises()
+            }
+            is ExerciseLibraryEvent.ExerciseClicked -> {
+                viewModelScope.launch {
+                    _effect.send(
+                        ExerciseLibraryEffect.NavigateToDetail(event.exercise.id.toString()),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun loadExercises() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            val currentState = _state.value
+            val muscleGroup = currentState.selectedMuscleGroup?.name
+            val query = currentState.searchQuery.takeIf { it.isNotBlank() }
+
+            exerciseRepository.getFilteredExercises(muscleGroup, query)
+                .collect { exercises ->
+                    _state.update {
+                        it.copy(exercises = exercises, isLoading = false)
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First real Android feature screen — Exercise Library ported from iOS ExerciseLibraryView.

### What's included

**Core module:**
- \ExerciseEntity\ with category, description, youtubeUrl fields
- \ExerciseDao\ with getAll, getByMuscleGroup, search, filtered queries  
- \ExerciseRepository\ interface + Room-backed implementation
- Hilt modules for DAO and Repository provision
- Seed database callback pre-populating 23 exercises across all muscle groups
- Database v2 schema with exported schema files

**Feature module:**
- MVI contract: \ExerciseLibraryState\, \ExerciseLibraryEvent\, \ExerciseLibraryEffect\
- \ExerciseLibraryViewModel\ with search + muscle group filtering
- \ExerciseLibraryScreen\ with search bar, filter chips, LazyColumn
- Category badges matching iOS color scheme (green/amber/cyan/red)
- Route/Screen separation per Compose best practices

**App module:**
- Exercise library set as default/home destination in NavGraph
- Exercise detail placeholder route wired

### Architecture
- MVI pattern: sealed Event/Effect interfaces, StateFlow, Channel for effects
- Repository pattern: interface in core, Room impl injected via Hilt
- Route/Screen composable separation (lifecycle-aware collection in Route, stateless Screen)

### Verified
- \ssembleDebug\ passes cleanly with zero warnings

Closes #146

Working as Tank (Backend Developer)
