### PR TITLE
feat: add Workout logging screen with set tracking + rest timer

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -2,15 +2,35 @@ package com.gymbro.app.navigation
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.gymbro.core.model.Equipment
+import com.gymbro.core.model.Exercise
+import com.gymbro.core.model.ExerciseCategory
+import com.gymbro.core.model.MuscleGroup
 import com.gymbro.feature.exerciselibrary.ExerciseLibraryRoute
+import com.gymbro.feature.workout.ActiveWorkoutRoute
+import com.gymbro.feature.workout.WorkoutSummaryScreen
+
+private val AccentGreen = Color(0xFF00FF87)
 
 @Composable
 fun GymBroNavGraph() {
@@ -21,17 +41,123 @@ fun GymBroNavGraph() {
         startDestination = "exercise_library",
     ) {
         composable("exercise_library") {
-            ExerciseLibraryRoute(
-                onNavigateToDetail = { exerciseId ->
-                    navController.navigate("exercise_detail/$exerciseId")
+            Scaffold(
+                floatingActionButton = {
+                    FloatingActionButton(
+                        onClick = { navController.navigate("active_workout") },
+                        containerColor = AccentGreen,
+                        contentColor = Color.Black,
+                        shape = CircleShape,
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = "Start Workout", modifier = Modifier.size(28.dp))
+                    }
                 },
-            )
+                containerColor = MaterialTheme.colorScheme.background,
+            ) { innerPadding ->
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    ExerciseLibraryRoute(
+                        onNavigateToDetail = { exerciseId ->
+                            navController.navigate("exercise_detail/$exerciseId")
+                        },
+                    )
+                }
+            }
         }
         composable("exercise_detail/{exerciseId}") {
             PlaceholderScreen(title = "Exercise Detail")
         }
-        composable("workout") {
-            PlaceholderScreen(title = "Workout")
+        composable("active_workout") { backStackEntry ->
+            val savedStateHandle = backStackEntry.savedStateHandle
+            val pickedId = savedStateHandle.get<String>("picked_exercise_id")
+            val pickedName = savedStateHandle.get<String>("picked_exercise_name")
+            val pickedMuscle = savedStateHandle.get<String>("picked_exercise_muscle")
+            val pickedCategory = savedStateHandle.get<String>("picked_exercise_category")
+            val pickedEquipment = savedStateHandle.get<String>("picked_exercise_equipment")
+
+            val pickedExercise = if (pickedId != null && pickedName != null) {
+                savedStateHandle.remove<String>("picked_exercise_id")
+                savedStateHandle.remove<String>("picked_exercise_name")
+                savedStateHandle.remove<String>("picked_exercise_muscle")
+                savedStateHandle.remove<String>("picked_exercise_category")
+                savedStateHandle.remove<String>("picked_exercise_equipment")
+                Exercise(
+                    id = java.util.UUID.fromString(pickedId),
+                    name = pickedName,
+                    muscleGroup = MuscleGroup.entries.find { it.name == pickedMuscle } ?: MuscleGroup.FULL_BODY,
+                    category = ExerciseCategory.entries.find { it.name == pickedCategory } ?: ExerciseCategory.COMPOUND,
+                    equipment = Equipment.entries.find { it.name == pickedEquipment } ?: Equipment.OTHER,
+                )
+            } else null
+
+            ActiveWorkoutRoute(
+                onNavigateToExercisePicker = {
+                    navController.navigate("exercise_picker")
+                },
+                onNavigateToSummary = { duration, volume, sets, exercises, prs ->
+                    navController.navigate(
+                        "workout_summary/$duration/$volume/$sets/$exercises/$prs"
+                    ) {
+                        popUpTo("active_workout") { inclusive = true }
+                    }
+                },
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
+                pickedExercise = pickedExercise,
+            )
+        }
+        composable("exercise_picker") {
+            ExerciseLibraryRoute(
+                onNavigateToDetail = { },
+                onExercisePicked = { exercise ->
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set("picked_exercise_id", exercise.id.toString())
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set("picked_exercise_name", exercise.name)
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set("picked_exercise_muscle", exercise.muscleGroup.name)
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set("picked_exercise_category", exercise.category.name)
+                    navController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set("picked_exercise_equipment", exercise.equipment.name)
+                    navController.popBackStack()
+                },
+                isPickerMode = true,
+            )
+        }
+        composable(
+            route = "workout_summary/{duration}/{volume}/{sets}/{exercises}/{prs}",
+            arguments = listOf(
+                navArgument("duration") { type = NavType.LongType },
+                navArgument("volume") { type = NavType.FloatType },
+                navArgument("sets") { type = NavType.IntType },
+                navArgument("exercises") { type = NavType.IntType },
+                navArgument("prs") { type = NavType.IntType },
+            ),
+        ) { backStackEntry ->
+            val duration = backStackEntry.arguments?.getLong("duration") ?: 0L
+            val volume = backStackEntry.arguments?.getFloat("volume")?.toDouble() ?: 0.0
+            val sets = backStackEntry.arguments?.getInt("sets") ?: 0
+            val exercises = backStackEntry.arguments?.getInt("exercises") ?: 0
+            val prs = backStackEntry.arguments?.getInt("prs") ?: 0
+
+            WorkoutSummaryScreen(
+                durationSeconds = duration,
+                totalVolume = volume,
+                totalSets = sets,
+                exerciseCount = exercises,
+                prsCount = prs,
+                onDone = {
+                    navController.navigate("exercise_library") {
+                        popUpTo("exercise_library") { inclusive = true }
+                    }
+                },
+            )
         }
         composable("history") {
             PlaceholderScreen(title = "History")

--- a/android/core/schemas/com.gymbro.core.database.GymBroDatabase/3.json
+++ b/android/core/schemas/com.gymbro.core.database.GymBroDatabase/3.json
@@ -1,0 +1,222 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "729f0503abd787d029423e11c4a72a0d",
+    "entities": [
+      {
+        "tableName": "exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `muscleGroup` TEXT NOT NULL, `category` TEXT NOT NULL, `equipment` TEXT NOT NULL, `description` TEXT NOT NULL, `youtubeUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleGroup",
+            "columnName": "muscleGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipment",
+            "columnName": "equipment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtubeUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `completedAt` INTEGER, `durationSeconds` INTEGER NOT NULL, `notes` TEXT NOT NULL, `completed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "workout_sets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `workoutId` TEXT NOT NULL, `exerciseId` TEXT NOT NULL, `setNumber` INTEGER NOT NULL, `weight` REAL NOT NULL, `reps` INTEGER NOT NULL, `rpe` REAL, `isWarmup` INTEGER NOT NULL, `completedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`workoutId`) REFERENCES `workouts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`exerciseId`) REFERENCES `exercises`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setNumber",
+            "columnName": "setNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rpe",
+            "columnName": "rpe",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "isWarmup",
+            "columnName": "isWarmup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_sets_workoutId",
+            "unique": false,
+            "columnNames": [
+              "workoutId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_sets_workoutId` ON `${TABLE_NAME}` (`workoutId`)"
+          },
+          {
+            "name": "index_workout_sets_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_sets_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workouts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "workoutId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "exercises",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exerciseId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '729f0503abd787d029423e11c4a72a0d')"
+    ]
+  }
+}

--- a/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
@@ -3,13 +3,21 @@ package com.gymbro.core.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.gymbro.core.database.dao.ExerciseDao
+import com.gymbro.core.database.dao.WorkoutDao
 import com.gymbro.core.database.entity.ExerciseEntity
+import com.gymbro.core.database.entity.WorkoutEntity
+import com.gymbro.core.database.entity.WorkoutSetEntity
 
 @Database(
-    entities = [ExerciseEntity::class],
-    version = 2,
+    entities = [
+        ExerciseEntity::class,
+        WorkoutEntity::class,
+        WorkoutSetEntity::class,
+    ],
+    version = 3,
     exportSchema = true,
 )
 abstract class GymBroDatabase : RoomDatabase() {
     abstract fun exerciseDao(): ExerciseDao
+    abstract fun workoutDao(): WorkoutDao
 }

--- a/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
@@ -1,0 +1,55 @@
+package com.gymbro.core.database.dao
+
+import androidx.room.Dao
+import androidx.room.Embedded
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Relation
+import androidx.room.Transaction
+import androidx.room.Update
+import com.gymbro.core.database.entity.WorkoutEntity
+import com.gymbro.core.database.entity.WorkoutSetEntity
+import kotlinx.coroutines.flow.Flow
+
+data class WorkoutWithSets(
+    @Embedded val workout: WorkoutEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "workoutId",
+    )
+    val sets: List<WorkoutSetEntity>,
+)
+
+@Dao
+interface WorkoutDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertWorkout(workout: WorkoutEntity)
+
+    @Update
+    suspend fun updateWorkout(workout: WorkoutEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSet(set: WorkoutSetEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSets(sets: List<WorkoutSetEntity>)
+
+    @Query("DELETE FROM workout_sets WHERE id = :setId")
+    suspend fun deleteSet(setId: String)
+
+    @Transaction
+    @Query("SELECT * FROM workouts WHERE id = :workoutId")
+    suspend fun getWorkoutWithSets(workoutId: String): WorkoutWithSets?
+
+    @Transaction
+    @Query("SELECT * FROM workouts WHERE id = :workoutId")
+    fun observeWorkoutWithSets(workoutId: String): Flow<WorkoutWithSets?>
+
+    @Transaction
+    @Query("SELECT * FROM workouts WHERE completed = 1 ORDER BY startedAt DESC LIMIT :limit")
+    fun getRecentWorkouts(limit: Int = 20): Flow<List<WorkoutWithSets>>
+
+    @Query("SELECT MAX(weight) FROM workout_sets WHERE exerciseId = :exerciseId AND reps >= :reps")
+    suspend fun getBestWeight(exerciseId: String, reps: Int): Double?
+}

--- a/android/core/src/main/java/com/gymbro/core/database/entity/WorkoutEntity.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/entity/WorkoutEntity.kt
@@ -1,0 +1,16 @@
+package com.gymbro.core.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+@Entity(tableName = "workouts")
+data class WorkoutEntity(
+    @PrimaryKey
+    val id: String = UUID.randomUUID().toString(),
+    val startedAt: Long, // epoch millis
+    val completedAt: Long? = null,
+    val durationSeconds: Long = 0,
+    val notes: String = "",
+    val completed: Boolean = false,
+)

--- a/android/core/src/main/java/com/gymbro/core/database/entity/WorkoutSetEntity.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/entity/WorkoutSetEntity.kt
@@ -1,0 +1,41 @@
+package com.gymbro.core.database.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+@Entity(
+    tableName = "workout_sets",
+    foreignKeys = [
+        ForeignKey(
+            entity = WorkoutEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["workoutId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = ExerciseEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["exerciseId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("workoutId"),
+        Index("exerciseId"),
+    ],
+)
+data class WorkoutSetEntity(
+    @PrimaryKey
+    val id: String = UUID.randomUUID().toString(),
+    val workoutId: String,
+    val exerciseId: String,
+    val setNumber: Int,
+    val weight: Double,
+    val reps: Int,
+    val rpe: Double? = null,
+    val isWarmup: Boolean = false,
+    val completedAt: Long = System.currentTimeMillis(),
+)

--- a/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.gymbro.core.database.GymBroDatabase
 import com.gymbro.core.database.dao.ExerciseDao
+import com.gymbro.core.database.dao.WorkoutDao
 import com.gymbro.core.database.entity.ExerciseEntity
 import dagger.Module
 import dagger.Provides
@@ -38,6 +39,11 @@ object DatabaseModule {
     @Provides
     fun provideExerciseDao(database: GymBroDatabase): ExerciseDao {
         return database.exerciseDao()
+    }
+
+    @Provides
+    fun provideWorkoutDao(database: GymBroDatabase): WorkoutDao {
+        return database.workoutDao()
     }
 }
 

--- a/android/core/src/main/java/com/gymbro/core/di/RepositoryModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/RepositoryModule.kt
@@ -2,6 +2,8 @@ package com.gymbro.core.di
 
 import com.gymbro.core.repository.ExerciseRepository
 import com.gymbro.core.repository.ExerciseRepositoryImpl
+import com.gymbro.core.repository.WorkoutRepository
+import com.gymbro.core.repository.WorkoutRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,4 +15,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindExerciseRepository(impl: ExerciseRepositoryImpl): ExerciseRepository
+
+    @Binds
+    abstract fun bindWorkoutRepository(impl: WorkoutRepositoryImpl): WorkoutRepository
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
@@ -1,0 +1,16 @@
+package com.gymbro.core.repository
+
+import com.gymbro.core.model.ExerciseSet
+import com.gymbro.core.model.Workout
+import kotlinx.coroutines.flow.Flow
+
+interface WorkoutRepository {
+    suspend fun startWorkout(): Workout
+    suspend fun addSet(workoutId: String, set: ExerciseSet)
+    suspend fun removeSet(setId: String)
+    suspend fun completeWorkout(workoutId: String, durationSeconds: Long, notes: String)
+    suspend fun getWorkout(workoutId: String): Workout?
+    fun observeWorkout(workoutId: String): Flow<Workout?>
+    fun getRecentWorkouts(limit: Int = 20): Flow<List<Workout>>
+    suspend fun getBestWeight(exerciseId: String, reps: Int): Double?
+}

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
@@ -1,0 +1,103 @@
+package com.gymbro.core.repository
+
+import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.database.dao.WorkoutWithSets
+import com.gymbro.core.database.entity.WorkoutEntity
+import com.gymbro.core.database.entity.WorkoutSetEntity
+import com.gymbro.core.model.ExerciseSet
+import com.gymbro.core.model.Workout
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.Instant
+import java.util.UUID
+import javax.inject.Inject
+
+class WorkoutRepositoryImpl @Inject constructor(
+    private val workoutDao: WorkoutDao,
+) : WorkoutRepository {
+
+    override suspend fun startWorkout(): Workout {
+        val now = Instant.now()
+        val entity = WorkoutEntity(
+            id = UUID.randomUUID().toString(),
+            startedAt = now.toEpochMilli(),
+        )
+        workoutDao.insertWorkout(entity)
+        return Workout(
+            id = UUID.fromString(entity.id),
+            name = "",
+            startedAt = now,
+        )
+    }
+
+    override suspend fun addSet(workoutId: String, set: ExerciseSet) {
+        val entity = WorkoutSetEntity(
+            id = set.id.toString(),
+            workoutId = workoutId,
+            exerciseId = set.exerciseId.toString(),
+            setNumber = 0, // calculated by caller
+            weight = set.weightKg,
+            reps = set.reps,
+            rpe = set.rpe,
+            isWarmup = set.isWarmup,
+            completedAt = set.completedAt.toEpochMilli(),
+        )
+        workoutDao.insertSet(entity)
+    }
+
+    override suspend fun removeSet(setId: String) {
+        workoutDao.deleteSet(setId)
+    }
+
+    override suspend fun completeWorkout(workoutId: String, durationSeconds: Long, notes: String) {
+        val existing = workoutDao.getWorkoutWithSets(workoutId) ?: return
+        workoutDao.updateWorkout(
+            existing.workout.copy(
+                completedAt = System.currentTimeMillis(),
+                durationSeconds = durationSeconds,
+                notes = notes,
+                completed = true,
+            ),
+        )
+    }
+
+    override suspend fun getWorkout(workoutId: String): Workout? {
+        return workoutDao.getWorkoutWithSets(workoutId)?.toDomain()
+    }
+
+    override fun observeWorkout(workoutId: String): Flow<Workout?> {
+        return workoutDao.observeWorkoutWithSets(workoutId).map { it?.toDomain() }
+    }
+
+    override fun getRecentWorkouts(limit: Int): Flow<List<Workout>> {
+        return workoutDao.getRecentWorkouts(limit).map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+
+    override suspend fun getBestWeight(exerciseId: String, reps: Int): Double? {
+        return workoutDao.getBestWeight(exerciseId, reps)
+    }
+}
+
+private fun WorkoutWithSets.toDomain(): Workout {
+    val domainSets = sets.map { set ->
+        ExerciseSet(
+            id = UUID.fromString(set.id),
+            exerciseId = UUID.fromString(set.exerciseId),
+            weightKg = set.weight,
+            reps = set.reps,
+            rpe = set.rpe,
+            isWarmup = set.isWarmup,
+            completedAt = Instant.ofEpochMilli(set.completedAt),
+        )
+    }
+    return Workout(
+        id = UUID.fromString(workout.id),
+        name = "",
+        startedAt = Instant.ofEpochMilli(workout.startedAt),
+        completedAt = workout.completedAt?.let { Instant.ofEpochMilli(it) },
+        sets = domainSets,
+        notes = workout.notes,
+    )
+}

--- a/android/feature/build.gradle.kts
+++ b/android/feature/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.compose.ui.graphics)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.extended)
     debugImplementation(libs.compose.ui.tooling)
 
     // Lifecycle

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -58,6 +58,8 @@ private val AccentRed = Color(0xFFCF6679)
 fun ExerciseLibraryRoute(
     viewModel: ExerciseLibraryViewModel = hiltViewModel(),
     onNavigateToDetail: (String) -> Unit = {},
+    onExercisePicked: ((Exercise) -> Unit)? = null,
+    isPickerMode: Boolean = false,
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle()
 
@@ -73,7 +75,14 @@ fun ExerciseLibraryRoute(
 
     ExerciseLibraryScreen(
         state = state.value,
-        onEvent = viewModel::onEvent,
+        onEvent = { event ->
+            if (isPickerMode && event is ExerciseLibraryEvent.ExerciseClicked) {
+                onExercisePicked?.invoke(event.exercise)
+            } else {
+                viewModel.onEvent(event)
+            }
+        },
+        isPickerMode = isPickerMode,
     )
 }
 
@@ -82,13 +91,14 @@ fun ExerciseLibraryRoute(
 fun ExerciseLibraryScreen(
     state: ExerciseLibraryState,
     onEvent: (ExerciseLibraryEvent) -> Unit,
+    isPickerMode: Boolean = false,
 ) {
     Scaffold(
         topBar = {
             TopAppBar(
                 title = {
                     Text(
-                        text = "Exercise Library",
+                        text = if (isPickerMode) "Pick Exercise" else "Exercise Library",
                         style = MaterialTheme.typography.headlineMedium,
                     )
                 },

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -1,0 +1,61 @@
+package com.gymbro.feature.workout
+
+import com.gymbro.core.model.Exercise
+
+data class ActiveWorkoutState(
+    val workoutId: String? = null,
+    val exercises: List<WorkoutExerciseUi> = emptyList(),
+    val elapsedSeconds: Long = 0,
+    val totalVolume: Double = 0.0,
+    val totalSets: Int = 0,
+    val restTimerSeconds: Int = 0,
+    val restTimerTotal: Int = 90,
+    val isRestTimerActive: Boolean = false,
+    val isCompleting: Boolean = false,
+)
+
+data class WorkoutExerciseUi(
+    val exercise: Exercise,
+    val sets: List<WorkoutSetUi> = emptyList(),
+)
+
+data class WorkoutSetUi(
+    val id: String,
+    val setNumber: Int,
+    val weight: String = "",
+    val reps: String = "",
+    val rpe: String = "",
+    val isWarmup: Boolean = false,
+    val isCompleted: Boolean = false,
+)
+
+sealed interface ActiveWorkoutEvent {
+    data object AddExerciseClicked : ActiveWorkoutEvent
+    data class ExercisePicked(val exercise: Exercise) : ActiveWorkoutEvent
+    data class AddSet(val exerciseIndex: Int) : ActiveWorkoutEvent
+    data class UpdateSetWeight(val exerciseIndex: Int, val setIndex: Int, val weight: String) : ActiveWorkoutEvent
+    data class UpdateSetReps(val exerciseIndex: Int, val setIndex: Int, val reps: String) : ActiveWorkoutEvent
+    data class UpdateSetRpe(val exerciseIndex: Int, val setIndex: Int, val rpe: String) : ActiveWorkoutEvent
+    data class ToggleWarmup(val exerciseIndex: Int, val setIndex: Int) : ActiveWorkoutEvent
+    data class CompleteSet(val exerciseIndex: Int, val setIndex: Int) : ActiveWorkoutEvent
+    data class RemoveSet(val exerciseIndex: Int, val setIndex: Int) : ActiveWorkoutEvent
+    data class RemoveExercise(val exerciseIndex: Int) : ActiveWorkoutEvent
+    data object StartRestTimer : ActiveWorkoutEvent
+    data object SkipRestTimer : ActiveWorkoutEvent
+    data class AdjustRestTimer(val deltaSeconds: Int) : ActiveWorkoutEvent
+    data object CompleteWorkout : ActiveWorkoutEvent
+    data object DiscardWorkout : ActiveWorkoutEvent
+}
+
+sealed interface ActiveWorkoutEffect {
+    data object ShowExercisePicker : ActiveWorkoutEffect
+    data class NavigateToSummary(
+        val durationSeconds: Long,
+        val totalVolume: Double,
+        val totalSets: Int,
+        val exerciseCount: Int,
+        val prsCount: Int,
+    ) : ActiveWorkoutEffect
+    data object NavigateBack : ActiveWorkoutEffect
+    data object RestTimerFinished : ActiveWorkoutEffect
+}

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -1,0 +1,617 @@
+package com.gymbro.feature.workout
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gymbro.core.model.Exercise
+
+private val AccentGreen = Color(0xFF00FF87)
+private val AccentCyan = Color(0xFF00E5FF)
+private val AccentAmber = Color(0xFFFFAB00)
+private val AccentRed = Color(0xFFCF6679)
+private val SurfaceCard = Color(0xFF1A1A1A)
+private val SurfaceDark = Color(0xFF0A0A0A)
+
+@Composable
+fun ActiveWorkoutRoute(
+    viewModel: ActiveWorkoutViewModel = hiltViewModel(),
+    onNavigateToExercisePicker: () -> Unit = {},
+    onNavigateToSummary: (Long, Double, Int, Int, Int) -> Unit = { _, _, _, _, _ -> },
+    onNavigateBack: () -> Unit = {},
+    pickedExercise: Exercise? = null,
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle()
+
+    // Handle picked exercise
+    LaunchedEffect(pickedExercise) {
+        if (pickedExercise != null) {
+            viewModel.onEvent(ActiveWorkoutEvent.ExercisePicked(pickedExercise))
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is ActiveWorkoutEffect.ShowExercisePicker -> onNavigateToExercisePicker()
+                is ActiveWorkoutEffect.NavigateToSummary -> onNavigateToSummary(
+                    effect.durationSeconds,
+                    effect.totalVolume,
+                    effect.totalSets,
+                    effect.exerciseCount,
+                    effect.prsCount,
+                )
+                is ActiveWorkoutEffect.NavigateBack -> onNavigateBack()
+                is ActiveWorkoutEffect.RestTimerFinished -> { /* vibration/sound handled externally */ }
+            }
+        }
+    }
+
+    ActiveWorkoutScreen(
+        state = state.value,
+        onEvent = viewModel::onEvent,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ActiveWorkoutScreen(
+    state: ActiveWorkoutState,
+    onEvent: (ActiveWorkoutEvent) -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Column {
+                            Text(
+                                text = "Active Workout",
+                                style = MaterialTheme.typography.titleLarge,
+                            )
+                            Text(
+                                text = formatDuration(state.elapsedSeconds),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = AccentCyan,
+                            )
+                        }
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = { onEvent(ActiveWorkoutEvent.DiscardWorkout) }) {
+                            Icon(Icons.Default.Close, contentDescription = "Discard")
+                        }
+                    },
+                    actions = {
+                        Button(
+                            onClick = { onEvent(ActiveWorkoutEvent.CompleteWorkout) },
+                            enabled = state.totalSets > 0 && !state.isCompleting,
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = AccentGreen,
+                                contentColor = Color.Black,
+                                disabledContainerColor = AccentGreen.copy(alpha = 0.3f),
+                            ),
+                            shape = RoundedCornerShape(8.dp),
+                        ) {
+                            Text("Finish", fontWeight = FontWeight.Bold)
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = SurfaceDark,
+                        titleContentColor = Color.White,
+                        navigationIconContentColor = Color.White,
+                    ),
+                )
+            },
+            containerColor = SurfaceDark,
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            ) {
+                // Stats bar
+                WorkoutStatsBar(
+                    elapsedSeconds = state.elapsedSeconds,
+                    totalVolume = state.totalVolume,
+                    totalSets = state.totalSets,
+                )
+
+                // Exercise list
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    itemsIndexed(
+                        items = state.exercises,
+                        key = { index, ex -> "${ex.exercise.id}_$index" },
+                    ) { exerciseIndex, exerciseUi ->
+                        ExerciseCard(
+                            exerciseUi = exerciseUi,
+                            exerciseIndex = exerciseIndex,
+                            onEvent = onEvent,
+                        )
+                    }
+
+                    item {
+                        AddExerciseButton(
+                            onClick = { onEvent(ActiveWorkoutEvent.AddExerciseClicked) },
+                        )
+                    }
+
+                    // Bottom spacer for rest timer overlay
+                    item { Spacer(modifier = Modifier.height(80.dp)) }
+                }
+            }
+        }
+
+        // Rest timer overlay
+        AnimatedVisibility(
+            visible = state.isRestTimerActive,
+            enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+            exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+            modifier = Modifier.align(Alignment.BottomCenter),
+        ) {
+            RestTimerBar(
+                remainingSeconds = state.restTimerSeconds,
+                totalSeconds = state.restTimerTotal,
+                onSkip = { onEvent(ActiveWorkoutEvent.SkipRestTimer) },
+                onAdjust = { delta -> onEvent(ActiveWorkoutEvent.AdjustRestTimer(delta)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun WorkoutStatsBar(
+    elapsedSeconds: Long,
+    totalVolume: Double,
+    totalSets: Int,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(SurfaceCard)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        StatItem(label = "Duration", value = formatDuration(elapsedSeconds), color = AccentCyan)
+        StatItem(label = "Volume", value = "${totalVolume.toInt()} kg", color = AccentGreen)
+        StatItem(label = "Sets", value = "$totalSets", color = AccentAmber)
+    }
+}
+
+@Composable
+private fun StatItem(label: String, value: String, color: Color) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = color,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.6f),
+        )
+    }
+}
+
+@Composable
+private fun ExerciseCard(
+    exerciseUi: WorkoutExerciseUi,
+    exerciseIndex: Int,
+    onEvent: (ActiveWorkoutEvent) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(SurfaceCard)
+            .padding(16.dp),
+    ) {
+        // Exercise header
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.FitnessCenter,
+                contentDescription = null,
+                tint = AccentGreen,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = exerciseUi.exercise.name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(
+                onClick = { onEvent(ActiveWorkoutEvent.RemoveExercise(exerciseIndex)) },
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Remove exercise",
+                    tint = Color.White.copy(alpha = 0.4f),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = exerciseUi.exercise.muscleGroup.displayName,
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.White.copy(alpha = 0.5f),
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Column headers
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp),
+        ) {
+            Text("SET", style = setHeaderStyle(), modifier = Modifier.width(36.dp))
+            Text("KG", style = setHeaderStyle(), modifier = Modifier.weight(1f), textAlign = TextAlign.Center)
+            Text("REPS", style = setHeaderStyle(), modifier = Modifier.weight(1f), textAlign = TextAlign.Center)
+            Text("RPE", style = setHeaderStyle(), modifier = Modifier.width(48.dp), textAlign = TextAlign.Center)
+            Spacer(modifier = Modifier.width(40.dp)) // for complete button
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Set rows
+        exerciseUi.sets.forEachIndexed { setIndex, setUi ->
+            SetRow(
+                setUi = setUi,
+                exerciseIndex = exerciseIndex,
+                setIndex = setIndex,
+                onEvent = onEvent,
+            )
+            if (setIndex < exerciseUi.sets.lastIndex) {
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Add set button
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .clickable { onEvent(ActiveWorkoutEvent.AddSet(exerciseIndex)) }
+                .border(1.dp, AccentGreen.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
+                .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Default.Add, contentDescription = null, tint = AccentGreen, modifier = Modifier.size(16.dp))
+            Spacer(modifier = Modifier.width(4.dp))
+            Text("Add Set", color = AccentGreen, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun SetRow(
+    setUi: WorkoutSetUi,
+    exerciseIndex: Int,
+    setIndex: Int,
+    onEvent: (ActiveWorkoutEvent) -> Unit,
+) {
+    val rowBackground = when {
+        setUi.isCompleted -> AccentGreen.copy(alpha = 0.08f)
+        setUi.isWarmup -> AccentAmber.copy(alpha = 0.05f)
+        else -> Color.Transparent
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(rowBackground)
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Set number + warmup indicator
+        Box(
+            modifier = Modifier
+                .width(36.dp)
+                .clickable { onEvent(ActiveWorkoutEvent.ToggleWarmup(exerciseIndex, setIndex)) },
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = if (setUi.isWarmup) "W" else "${setUi.setNumber}",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                color = if (setUi.isWarmup) AccentAmber else Color.White,
+            )
+        }
+
+        // Weight
+        CompactNumberField(
+            value = setUi.weight,
+            onValueChange = { onEvent(ActiveWorkoutEvent.UpdateSetWeight(exerciseIndex, setIndex, it)) },
+            enabled = !setUi.isCompleted,
+            modifier = Modifier.weight(1f),
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        // Reps
+        CompactNumberField(
+            value = setUi.reps,
+            onValueChange = { onEvent(ActiveWorkoutEvent.UpdateSetReps(exerciseIndex, setIndex, it)) },
+            enabled = !setUi.isCompleted,
+            modifier = Modifier.weight(1f),
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        // RPE
+        CompactNumberField(
+            value = setUi.rpe,
+            onValueChange = { onEvent(ActiveWorkoutEvent.UpdateSetRpe(exerciseIndex, setIndex, it)) },
+            enabled = !setUi.isCompleted,
+            modifier = Modifier.width(48.dp),
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        // Complete button
+        if (setUi.isCompleted) {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(AccentGreen),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = "Completed",
+                    tint = Color.Black,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .border(1.5.dp, AccentGreen.copy(alpha = 0.5f), CircleShape)
+                    .clickable { onEvent(ActiveWorkoutEvent.CompleteSet(exerciseIndex, setIndex)) },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = "Complete set",
+                    tint = AccentGreen.copy(alpha = 0.5f),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompactNumberField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    TextField(
+        value = value,
+        onValueChange = { input ->
+            // Allow numbers and one decimal point
+            if (input.isEmpty() || input.matches(Regex("^\\d*\\.?\\d*$"))) {
+                onValueChange(input)
+            }
+        },
+        enabled = enabled,
+        modifier = modifier.height(40.dp),
+        textStyle = MaterialTheme.typography.bodyMedium.copy(
+            textAlign = TextAlign.Center,
+            color = if (enabled) Color.White else Color.White.copy(alpha = 0.5f),
+        ),
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        colors = TextFieldDefaults.colors(
+            focusedContainerColor = Color.White.copy(alpha = 0.08f),
+            unfocusedContainerColor = Color.White.copy(alpha = 0.05f),
+            disabledContainerColor = Color.White.copy(alpha = 0.03f),
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            cursorColor = AccentGreen,
+        ),
+        shape = RoundedCornerShape(6.dp),
+    )
+}
+
+@Composable
+private fun AddExerciseButton(onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = AccentGreen.copy(alpha = 0.12f),
+            contentColor = AccentGreen,
+        ),
+        shape = RoundedCornerShape(12.dp),
+        contentPadding = PaddingValues(vertical = 14.dp),
+    ) {
+        Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.width(8.dp))
+        Text("Add Exercise", fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+private fun RestTimerBar(
+    remainingSeconds: Int,
+    totalSeconds: Int,
+    onSkip: () -> Unit,
+    onAdjust: (Int) -> Unit,
+) {
+    val timerColor = when {
+        remainingSeconds <= 10 -> AccentRed
+        remainingSeconds <= 30 -> AccentAmber
+        else -> AccentCyan
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+            .background(SurfaceCard)
+            .padding(16.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Default.Timer, contentDescription = null, tint = timerColor, modifier = Modifier.size(24.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Rest Timer", color = Color.White, fontWeight = FontWeight.SemiBold)
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = formatDuration(remainingSeconds.toLong()),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = timerColor,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Progress bar
+        val progress = if (totalSeconds > 0) remainingSeconds.toFloat() / totalSeconds else 0f
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(Color.White.copy(alpha = 0.1f)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(progress)
+                    .height(4.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(timerColor),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            OutlinedButton(
+                onClick = { onAdjust(-30) },
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.White),
+            ) {
+                Text("-30s")
+            }
+            OutlinedButton(
+                onClick = { onAdjust(30) },
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.White),
+            ) {
+                Text("+30s")
+            }
+            Button(
+                onClick = onSkip,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AccentGreen,
+                    contentColor = Color.Black,
+                ),
+            ) {
+                Text("Skip", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun setHeaderStyle() = MaterialTheme.typography.labelSmall.copy(
+    color = Color.White.copy(alpha = 0.4f),
+    fontWeight = FontWeight.Bold,
+    letterSpacing = 1.sp,
+)
+
+private fun formatDuration(totalSeconds: Long): String {
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        "%d:%02d:%02d".format(hours, minutes, seconds)
+    } else {
+        "%d:%02d".format(minutes, seconds)
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -1,0 +1,290 @@
+package com.gymbro.feature.workout
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gymbro.core.model.Exercise
+import com.gymbro.core.model.ExerciseSet
+import com.gymbro.core.repository.WorkoutRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class ActiveWorkoutViewModel @Inject constructor(
+    private val workoutRepository: WorkoutRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ActiveWorkoutState())
+    val state: StateFlow<ActiveWorkoutState> = _state.asStateFlow()
+
+    private val _effect = Channel<ActiveWorkoutEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    private var timerJob: Job? = null
+    private var restTimerJob: Job? = null
+
+    init {
+        startWorkout()
+    }
+
+    private fun startWorkout() {
+        viewModelScope.launch {
+            val workout = workoutRepository.startWorkout()
+            _state.update { it.copy(workoutId = workout.id.toString()) }
+            startElapsedTimer()
+        }
+    }
+
+    private fun startElapsedTimer() {
+        timerJob?.cancel()
+        timerJob = viewModelScope.launch {
+            while (true) {
+                delay(1000)
+                _state.update { it.copy(elapsedSeconds = it.elapsedSeconds + 1) }
+            }
+        }
+    }
+
+    fun onEvent(event: ActiveWorkoutEvent) {
+        when (event) {
+            is ActiveWorkoutEvent.AddExerciseClicked -> {
+                viewModelScope.launch {
+                    _effect.send(ActiveWorkoutEffect.ShowExercisePicker)
+                }
+            }
+            is ActiveWorkoutEvent.ExercisePicked -> addExercise(event.exercise)
+            is ActiveWorkoutEvent.AddSet -> addSet(event.exerciseIndex)
+            is ActiveWorkoutEvent.UpdateSetWeight -> updateSetField(event.exerciseIndex, event.setIndex) {
+                it.copy(weight = event.weight)
+            }
+            is ActiveWorkoutEvent.UpdateSetReps -> updateSetField(event.exerciseIndex, event.setIndex) {
+                it.copy(reps = event.reps)
+            }
+            is ActiveWorkoutEvent.UpdateSetRpe -> updateSetField(event.exerciseIndex, event.setIndex) {
+                it.copy(rpe = event.rpe)
+            }
+            is ActiveWorkoutEvent.ToggleWarmup -> updateSetField(event.exerciseIndex, event.setIndex) {
+                it.copy(isWarmup = !it.isWarmup)
+            }
+            is ActiveWorkoutEvent.CompleteSet -> completeSet(event.exerciseIndex, event.setIndex)
+            is ActiveWorkoutEvent.RemoveSet -> removeSet(event.exerciseIndex, event.setIndex)
+            is ActiveWorkoutEvent.RemoveExercise -> removeExercise(event.exerciseIndex)
+            is ActiveWorkoutEvent.StartRestTimer -> startRestTimer()
+            is ActiveWorkoutEvent.SkipRestTimer -> skipRestTimer()
+            is ActiveWorkoutEvent.AdjustRestTimer -> adjustRestTimer(event.deltaSeconds)
+            is ActiveWorkoutEvent.CompleteWorkout -> completeWorkout()
+            is ActiveWorkoutEvent.DiscardWorkout -> discardWorkout()
+        }
+    }
+
+    private fun addExercise(exercise: Exercise) {
+        _state.update { current ->
+            val newExercise = WorkoutExerciseUi(
+                exercise = exercise,
+                sets = listOf(
+                    WorkoutSetUi(
+                        id = UUID.randomUUID().toString(),
+                        setNumber = 1,
+                    ),
+                ),
+            )
+            current.copy(exercises = current.exercises + newExercise)
+        }
+    }
+
+    private fun addSet(exerciseIndex: Int) {
+        _state.update { current ->
+            val exercises = current.exercises.toMutableList()
+            if (exerciseIndex !in exercises.indices) return@update current
+            val exerciseUi = exercises[exerciseIndex]
+
+            // Pre-fill from last set's values
+            val lastSet = exerciseUi.sets.lastOrNull()
+            val newSet = WorkoutSetUi(
+                id = UUID.randomUUID().toString(),
+                setNumber = exerciseUi.sets.size + 1,
+                weight = lastSet?.weight ?: "",
+                reps = lastSet?.reps ?: "",
+            )
+            exercises[exerciseIndex] = exerciseUi.copy(sets = exerciseUi.sets + newSet)
+            current.copy(exercises = exercises)
+        }
+    }
+
+    private fun updateSetField(exerciseIndex: Int, setIndex: Int, transform: (WorkoutSetUi) -> WorkoutSetUi) {
+        _state.update { current ->
+            val exercises = current.exercises.toMutableList()
+            if (exerciseIndex !in exercises.indices) return@update current
+            val exerciseUi = exercises[exerciseIndex]
+            val sets = exerciseUi.sets.toMutableList()
+            if (setIndex !in sets.indices) return@update current
+            sets[setIndex] = transform(sets[setIndex])
+            exercises[exerciseIndex] = exerciseUi.copy(sets = sets)
+            current.copy(exercises = exercises)
+        }
+    }
+
+    private fun completeSet(exerciseIndex: Int, setIndex: Int) {
+        val currentState = _state.value
+        val workoutId = currentState.workoutId ?: return
+        val exercises = currentState.exercises
+        if (exerciseIndex !in exercises.indices) return
+        val exerciseUi = exercises[exerciseIndex]
+        if (setIndex !in exerciseUi.sets.indices) return
+        val setUi = exerciseUi.sets[setIndex]
+
+        if (setUi.isCompleted) return
+
+        val weightKg = setUi.weight.toDoubleOrNull() ?: return
+        val reps = setUi.reps.toIntOrNull() ?: return
+
+        viewModelScope.launch {
+            val exerciseSet = ExerciseSet(
+                id = UUID.fromString(setUi.id),
+                exerciseId = exerciseUi.exercise.id,
+                weightKg = weightKg,
+                reps = reps,
+                rpe = setUi.rpe.toDoubleOrNull(),
+                isWarmup = setUi.isWarmup,
+            )
+            workoutRepository.addSet(workoutId, exerciseSet)
+
+            updateSetField(exerciseIndex, setIndex) { it.copy(isCompleted = true) }
+
+            // Recalculate totals
+            recalculateTotals()
+
+            // Auto-start rest timer
+            startRestTimer()
+        }
+    }
+
+    private fun removeSet(exerciseIndex: Int, setIndex: Int) {
+        _state.update { current ->
+            val exercises = current.exercises.toMutableList()
+            if (exerciseIndex !in exercises.indices) return@update current
+            val exerciseUi = exercises[exerciseIndex]
+            val sets = exerciseUi.sets.toMutableList()
+            if (setIndex !in sets.indices) return@update current
+
+            val removedSet = sets.removeAt(setIndex)
+            // Re-number remaining sets
+            val renumbered = sets.mapIndexed { i, s -> s.copy(setNumber = i + 1) }
+            exercises[exerciseIndex] = exerciseUi.copy(sets = renumbered)
+
+            if (removedSet.isCompleted) {
+                viewModelScope.launch { workoutRepository.removeSet(removedSet.id) }
+            }
+
+            current.copy(exercises = exercises)
+        }
+        recalculateTotals()
+    }
+
+    private fun removeExercise(exerciseIndex: Int) {
+        _state.update { current ->
+            val exercises = current.exercises.toMutableList()
+            if (exerciseIndex !in exercises.indices) return@update current
+            val removed = exercises.removeAt(exerciseIndex)
+            // Remove completed sets from DB
+            removed.sets.filter { it.isCompleted }.forEach { set ->
+                viewModelScope.launch { workoutRepository.removeSet(set.id) }
+            }
+            current.copy(exercises = exercises)
+        }
+        recalculateTotals()
+    }
+
+    private fun recalculateTotals() {
+        _state.update { current ->
+            var totalVolume = 0.0
+            var totalSets = 0
+            current.exercises.forEach { ex ->
+                ex.sets.filter { it.isCompleted && !it.isWarmup }.forEach { set ->
+                    val w = set.weight.toDoubleOrNull() ?: 0.0
+                    val r = set.reps.toIntOrNull() ?: 0
+                    totalVolume += w * r
+                    totalSets++
+                }
+            }
+            current.copy(totalVolume = totalVolume, totalSets = totalSets)
+        }
+    }
+
+    private fun startRestTimer() {
+        restTimerJob?.cancel()
+        _state.update { it.copy(isRestTimerActive = true, restTimerSeconds = it.restTimerTotal) }
+        restTimerJob = viewModelScope.launch {
+            while (_state.value.restTimerSeconds > 0) {
+                delay(1000)
+                _state.update { it.copy(restTimerSeconds = it.restTimerSeconds - 1) }
+            }
+            _state.update { it.copy(isRestTimerActive = false) }
+            _effect.send(ActiveWorkoutEffect.RestTimerFinished)
+        }
+    }
+
+    private fun skipRestTimer() {
+        restTimerJob?.cancel()
+        _state.update { it.copy(isRestTimerActive = false, restTimerSeconds = 0) }
+    }
+
+    private fun adjustRestTimer(deltaSeconds: Int) {
+        _state.update {
+            val newTime = (it.restTimerSeconds + deltaSeconds).coerceAtLeast(0)
+            val newTotal = (it.restTimerTotal + deltaSeconds).coerceIn(30, 300)
+            it.copy(restTimerSeconds = newTime, restTimerTotal = newTotal)
+        }
+    }
+
+    private fun completeWorkout() {
+        val currentState = _state.value
+        val workoutId = currentState.workoutId ?: return
+
+        _state.update { it.copy(isCompleting = true) }
+
+        viewModelScope.launch {
+            workoutRepository.completeWorkout(
+                workoutId = workoutId,
+                durationSeconds = currentState.elapsedSeconds,
+                notes = "",
+            )
+            timerJob?.cancel()
+            restTimerJob?.cancel()
+
+            val exerciseCount = currentState.exercises.size
+            _effect.send(
+                ActiveWorkoutEffect.NavigateToSummary(
+                    durationSeconds = currentState.elapsedSeconds,
+                    totalVolume = currentState.totalVolume,
+                    totalSets = currentState.totalSets,
+                    exerciseCount = exerciseCount,
+                    prsCount = 0, // placeholder
+                ),
+            )
+        }
+    }
+
+    private fun discardWorkout() {
+        timerJob?.cancel()
+        restTimerJob?.cancel()
+        viewModelScope.launch {
+            _effect.send(ActiveWorkoutEffect.NavigateBack)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        timerJob?.cancel()
+        restTimerJob?.cancel()
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/workout/WorkoutSummaryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/WorkoutSummaryScreen.kt
@@ -1,0 +1,207 @@
+package com.gymbro.feature.workout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+private val AccentGreen = Color(0xFF00FF87)
+private val AccentCyan = Color(0xFF00E5FF)
+private val AccentAmber = Color(0xFFFFAB00)
+private val SurfaceCard = Color(0xFF1A1A1A)
+private val SurfaceDark = Color(0xFF0A0A0A)
+
+@Composable
+fun WorkoutSummaryScreen(
+    durationSeconds: Long,
+    totalVolume: Double,
+    totalSets: Int,
+    exerciseCount: Int,
+    prsCount: Int,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SurfaceDark)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        // Checkmark
+        Box(
+            modifier = Modifier
+                .size(80.dp)
+                .clip(CircleShape)
+                .background(AccentGreen),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = null,
+                tint = Color.Black,
+                modifier = Modifier.size(48.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Workout Complete!",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Great session — keep pushing.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.White.copy(alpha = 0.6f),
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Summary cards
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            SummaryCard(
+                icon = Icons.Default.Timer,
+                label = "Duration",
+                value = formatSummaryDuration(durationSeconds),
+                color = AccentCyan,
+                modifier = Modifier.weight(1f),
+            )
+            SummaryCard(
+                icon = Icons.Default.FitnessCenter,
+                label = "Volume",
+                value = "${totalVolume.toInt()} kg",
+                color = AccentGreen,
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            SummaryCard(
+                icon = Icons.Default.BarChart,
+                label = "Sets",
+                value = "$totalSets",
+                color = AccentAmber,
+                modifier = Modifier.weight(1f),
+            )
+            SummaryCard(
+                icon = Icons.Default.Star,
+                label = "Exercises",
+                value = "$exerciseCount",
+                color = AccentGreen,
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        if (prsCount > 0) {
+            Spacer(modifier = Modifier.height(12.dp))
+            SummaryCard(
+                icon = Icons.Default.Star,
+                label = "Personal Records",
+                value = "$prsCount",
+                color = AccentAmber,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(40.dp))
+
+        Button(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = AccentGreen,
+                contentColor = Color.Black,
+            ),
+            shape = RoundedCornerShape(12.dp),
+            contentPadding = PaddingValues(vertical = 16.dp),
+        ) {
+            Text("Done", fontWeight = FontWeight.Bold, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(SurfaceCard)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(28.dp))
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White.copy(alpha = 0.5f),
+        )
+    }
+}
+
+private fun formatSummaryDuration(totalSeconds: Long): String {
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    return if (hours > 0) {
+        "${hours}h ${minutes}m"
+    } else {
+        "${minutes}m"
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/workout/package-info.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/package-info.kt
@@ -1,2 +1,0 @@
-package com.gymbro.feature.workout
-// Workout feature screens, ViewModels, and MVI contracts will be added here.


### PR DESCRIPTION
## What

Ports the iOS ActiveWorkoutView to Android — full workout logging screen with set tracking, rest timer, and workout summary.

### Changes

**Core module (Room + Repository):**
- WorkoutEntity, WorkoutSetEntity with foreign keys
- WorkoutDao — insert/update workout + sets, getWorkoutWithSets, getRecentWorkouts
- WorkoutRepository interface + impl
- GymBroDatabase bumped to v3

**Feature module (MVI):**
- ActiveWorkoutContract — State, Events, Effects
- ActiveWorkoutViewModel — elapsed timer, rest timer, volume tracking
- ActiveWorkoutScreen — exercise cards with set rows (weight/reps/rpe), rest timer bar
- WorkoutSummaryScreen — duration, volume, sets, exercises count

**Navigation:**
- FAB to start workout from Exercise Library
- Exercise picker mode for adding exercises during workout
- Full flow: Library → Active Workout → Picker → Summary → Library

Closes #148

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>