### PR TITLE
feat: add Progress tracking with E1RM charts and PR detection

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -6,20 +6,32 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.automirrored.outlined.ShowChart
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.outlined.FitnessCenter
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.gymbro.core.model.Equipment
@@ -27,14 +39,29 @@ import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.ExerciseCategory
 import com.gymbro.core.model.MuscleGroup
 import com.gymbro.feature.exerciselibrary.ExerciseLibraryRoute
+import com.gymbro.feature.progress.ProgressRoute
 import com.gymbro.feature.workout.ActiveWorkoutRoute
 import com.gymbro.feature.workout.WorkoutSummaryScreen
 
 private val AccentGreen = Color(0xFF00FF87)
 
+private enum class BottomNavTab(
+    val route: String,
+    val label: String,
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector,
+) {
+    LIBRARY("exercise_library", "Library", Icons.Filled.FitnessCenter, Icons.Outlined.FitnessCenter),
+    PROGRESS("progress", "Progress", Icons.AutoMirrored.Filled.ShowChart, Icons.AutoMirrored.Outlined.ShowChart),
+}
+
 @Composable
 fun GymBroNavGraph() {
     val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    val showBottomBar = currentDestination?.route in BottomNavTab.entries.map { it.route }
 
     NavHost(
         navController = navController,
@@ -42,6 +69,22 @@ fun GymBroNavGraph() {
     ) {
         composable("exercise_library") {
             Scaffold(
+                bottomBar = {
+                    if (showBottomBar) {
+                        GymBroBottomNavBar(
+                            currentRoute = currentDestination?.route,
+                            onTabSelected = { tab ->
+                                navController.navigate(tab.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                        )
+                    }
+                },
                 floatingActionButton = {
                     FloatingActionButton(
                         onClick = { navController.navigate("active_workout") },
@@ -162,6 +205,31 @@ fun GymBroNavGraph() {
         composable("history") {
             PlaceholderScreen(title = "History")
         }
+        composable("progress") {
+            Scaffold(
+                bottomBar = {
+                    if (showBottomBar) {
+                        GymBroBottomNavBar(
+                            currentRoute = currentDestination?.route,
+                            onTabSelected = { tab ->
+                                navController.navigate(tab.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                        )
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.background,
+            ) { innerPadding ->
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    ProgressRoute()
+                }
+            }
+        }
         composable("programs") {
             PlaceholderScreen(title = "Programs")
         }
@@ -185,5 +253,43 @@ private fun PlaceholderScreen(title: String) {
             style = MaterialTheme.typography.headlineLarge,
             color = MaterialTheme.colorScheme.onBackground,
         )
+    }
+}
+
+@Composable
+private fun GymBroBottomNavBar(
+    currentRoute: String?,
+    onTabSelected: (BottomNavTab) -> Unit,
+) {
+    NavigationBar(
+        containerColor = Color(0xFF1A1A1A),
+        contentColor = Color.White,
+    ) {
+        BottomNavTab.entries.forEach { tab ->
+            val selected = currentRoute == tab.route
+            NavigationBarItem(
+                selected = selected,
+                onClick = { onTabSelected(tab) },
+                icon = {
+                    Icon(
+                        if (selected) tab.selectedIcon else tab.unselectedIcon,
+                        contentDescription = tab.label,
+                    )
+                },
+                label = {
+                    Text(
+                        text = tab.label,
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = AccentGreen,
+                    selectedTextColor = AccentGreen,
+                    unselectedIconColor = Color(0xFF9E9E9E),
+                    unselectedTextColor = Color(0xFF9E9E9E),
+                    indicatorColor = AccentGreen.copy(alpha = 0.12f),
+                ),
+            )
+        }
     }
 }

--- a/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
@@ -52,4 +52,27 @@ interface WorkoutDao {
 
     @Query("SELECT MAX(weight) FROM workout_sets WHERE exerciseId = :exerciseId AND reps >= :reps")
     suspend fun getBestWeight(exerciseId: String, reps: Int): Double?
+
+    @Query(
+        """
+        SELECT ws.* FROM workout_sets ws
+        INNER JOIN workouts w ON ws.workoutId = w.id
+        WHERE ws.exerciseId = :exerciseId AND w.completed = 1 AND ws.isWarmup = 0
+        ORDER BY ws.completedAt ASC
+        """
+    )
+    suspend fun getSetsByExercise(exerciseId: String): List<WorkoutSetEntity>
+
+    @Query(
+        """
+        SELECT DISTINCT ws.exerciseId FROM workout_sets ws
+        INNER JOIN workouts w ON ws.workoutId = w.id
+        WHERE w.completed = 1 AND ws.isWarmup = 0
+        """
+    )
+    suspend fun getExerciseIdsWithHistory(): List<String>
+
+    @Transaction
+    @Query("SELECT * FROM workouts WHERE completed = 1 ORDER BY startedAt DESC")
+    suspend fun getAllCompletedWorkouts(): List<WorkoutWithSets>
 }

--- a/android/core/src/main/java/com/gymbro/core/model/E1RMDataPoint.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/E1RMDataPoint.kt
@@ -1,0 +1,10 @@
+package com.gymbro.core.model
+
+import java.time.Instant
+
+data class E1RMDataPoint(
+    val date: Instant,
+    val e1rm: Double,
+    val weight: Double,
+    val reps: Int,
+)

--- a/android/core/src/main/java/com/gymbro/core/model/PersonalRecord.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/PersonalRecord.kt
@@ -1,0 +1,19 @@
+package com.gymbro.core.model
+
+import java.time.Instant
+
+data class PersonalRecord(
+    val exerciseId: String,
+    val exerciseName: String,
+    val type: RecordType,
+    val value: Double,
+    val date: Instant,
+    val previousValue: Double?,
+)
+
+enum class RecordType(val displayName: String, val emoji: String) {
+    MAX_WEIGHT("Max Weight", "🏋️"),
+    MAX_REPS("Max Reps", "🔁"),
+    MAX_VOLUME("Max Volume", "📦"),
+    MAX_E1RM("Est. 1RM", "🏆"),
+}

--- a/android/core/src/main/java/com/gymbro/core/model/WorkoutHistoryItem.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/WorkoutHistoryItem.kt
@@ -1,0 +1,13 @@
+package com.gymbro.core.model
+
+import java.time.Instant
+
+data class WorkoutHistoryItem(
+    val workoutId: String,
+    val date: Instant,
+    val exerciseCount: Int,
+    val totalVolume: Double,
+    val durationSeconds: Long,
+    val exerciseNames: List<String>,
+    val prCount: Int = 0,
+)

--- a/android/core/src/main/java/com/gymbro/core/service/PersonalRecordService.kt
+++ b/android/core/src/main/java/com/gymbro/core/service/PersonalRecordService.kt
@@ -1,0 +1,132 @@
+package com.gymbro.core.service
+
+import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.model.E1RMDataPoint
+import com.gymbro.core.model.PersonalRecord
+import com.gymbro.core.model.RecordType
+import com.gymbro.core.model.WorkoutHistoryItem
+import java.time.Instant
+import javax.inject.Inject
+
+class PersonalRecordService @Inject constructor(
+    private val workoutDao: WorkoutDao,
+) {
+
+    /** Brzycki formula: weight * (36 / (37 - reps)) */
+    fun calculateE1RM(weight: Double, reps: Int): Double {
+        if (weight <= 0 || reps <= 0) return 0.0
+        if (reps == 1) return weight
+        val denominator = 37.0 - reps
+        if (denominator <= 0) return weight * 2.0
+        return weight * (36.0 / denominator)
+    }
+
+    suspend fun getPersonalRecords(exerciseId: String, exerciseName: String): List<PersonalRecord> {
+        val sets = workoutDao.getSetsByExercise(exerciseId)
+        if (sets.isEmpty()) return emptyList()
+
+        val records = mutableListOf<PersonalRecord>()
+
+        val maxWeightSet = sets.maxByOrNull { it.weight }
+        if (maxWeightSet != null) {
+            val previousBest = sets
+                .filter { it.completedAt < maxWeightSet.completedAt }
+                .maxByOrNull { it.weight }
+            records += PersonalRecord(
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                type = RecordType.MAX_WEIGHT,
+                value = maxWeightSet.weight,
+                date = Instant.ofEpochMilli(maxWeightSet.completedAt),
+                previousValue = previousBest?.weight,
+            )
+        }
+
+        val maxRepsSet = sets.maxByOrNull { it.reps }
+        if (maxRepsSet != null) {
+            val previousBest = sets
+                .filter { it.completedAt < maxRepsSet.completedAt }
+                .maxByOrNull { it.reps }
+            records += PersonalRecord(
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                type = RecordType.MAX_REPS,
+                value = maxRepsSet.reps.toDouble(),
+                date = Instant.ofEpochMilli(maxRepsSet.completedAt),
+                previousValue = previousBest?.reps?.toDouble(),
+            )
+        }
+
+        val maxVolumeSet = sets.maxByOrNull { it.weight * it.reps }
+        if (maxVolumeSet != null) {
+            val volume = maxVolumeSet.weight * maxVolumeSet.reps
+            val previousBest = sets
+                .filter { it.completedAt < maxVolumeSet.completedAt }
+                .maxByOrNull { it.weight * it.reps }
+            records += PersonalRecord(
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                type = RecordType.MAX_VOLUME,
+                value = volume,
+                date = Instant.ofEpochMilli(maxVolumeSet.completedAt),
+                previousValue = previousBest?.let { it.weight * it.reps },
+            )
+        }
+
+        val maxE1RMSet = sets.maxByOrNull { calculateE1RM(it.weight, it.reps) }
+        if (maxE1RMSet != null) {
+            val e1rm = calculateE1RM(maxE1RMSet.weight, maxE1RMSet.reps)
+            val previousBest = sets
+                .filter { it.completedAt < maxE1RMSet.completedAt }
+                .maxByOrNull { calculateE1RM(it.weight, it.reps) }
+            records += PersonalRecord(
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                type = RecordType.MAX_E1RM,
+                value = e1rm,
+                date = Instant.ofEpochMilli(maxE1RMSet.completedAt),
+                previousValue = previousBest?.let { calculateE1RM(it.weight, it.reps) },
+            )
+        }
+
+        return records
+    }
+
+    suspend fun getE1RMHistory(exerciseId: String): List<E1RMDataPoint> {
+        val sets = workoutDao.getSetsByExercise(exerciseId)
+        if (sets.isEmpty()) return emptyList()
+
+        return sets
+            .groupBy { Instant.ofEpochMilli(it.completedAt).epochSecond / 86400 }
+            .map { (_, daySets) ->
+                val best = daySets.maxByOrNull { calculateE1RM(it.weight, it.reps) }!!
+                E1RMDataPoint(
+                    date = Instant.ofEpochMilli(best.completedAt),
+                    e1rm = calculateE1RM(best.weight, best.reps),
+                    weight = best.weight,
+                    reps = best.reps,
+                )
+            }
+            .sortedBy { it.date }
+    }
+
+    suspend fun getWorkoutHistory(): List<WorkoutHistoryItem> {
+        val workouts = workoutDao.getAllCompletedWorkouts()
+        return workouts.map { wws ->
+            val workingSets = wws.sets.filter { !it.isWarmup }
+            val exerciseIds = workingSets.map { it.exerciseId }.distinct()
+            WorkoutHistoryItem(
+                workoutId = wws.workout.id,
+                date = Instant.ofEpochMilli(wws.workout.startedAt),
+                exerciseCount = exerciseIds.size,
+                totalVolume = workingSets.sumOf { it.weight * it.reps },
+                durationSeconds = wws.workout.durationSeconds,
+                exerciseNames = emptyList(),
+            )
+        }
+    }
+
+    suspend fun getExerciseIdsWithHistory(): List<String> {
+        return workoutDao.getExerciseIdsWithHistory()
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressContract.kt
@@ -1,0 +1,29 @@
+package com.gymbro.feature.progress
+
+import com.gymbro.core.model.E1RMDataPoint
+import com.gymbro.core.model.PersonalRecord
+import com.gymbro.core.model.WorkoutHistoryItem
+
+data class ProgressState(
+    val workoutHistory: List<WorkoutHistoryItem> = emptyList(),
+    val personalRecords: List<PersonalRecord> = emptyList(),
+    val exerciseOptions: List<ExerciseOption> = emptyList(),
+    val selectedExerciseId: String? = null,
+    val chartData: List<E1RMDataPoint> = emptyList(),
+    val isLoading: Boolean = true,
+)
+
+data class ExerciseOption(
+    val id: String,
+    val name: String,
+)
+
+sealed interface ProgressEvent {
+    data class SelectExercise(val exerciseId: String) : ProgressEvent
+    data object RefreshData : ProgressEvent
+    data class ViewWorkoutDetail(val workoutId: String) : ProgressEvent
+}
+
+sealed interface ProgressEffect {
+    data class NavigateToWorkoutDetail(val workoutId: String) : ProgressEffect
+}

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
@@ -1,0 +1,611 @@
+package com.gymbro.feature.progress
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gymbro.core.model.E1RMDataPoint
+import com.gymbro.core.model.PersonalRecord
+import com.gymbro.core.model.RecordType
+import com.gymbro.core.model.WorkoutHistoryItem
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val AccentGreen = Color(0xFF00FF87)
+private val AccentAmber = Color(0xFFFFAB00)
+private val AccentCyan = Color(0xFF00E5FF)
+private val SurfaceColor = Color(0xFF1A1A1A)
+private val SurfaceVariantColor = Color(0xFF2A2A2A)
+
+private val dateFormatter = DateTimeFormatter.ofPattern("MMM d")
+private val fullDateFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy")
+
+@Composable
+fun ProgressRoute(
+    onNavigateToWorkoutDetail: (String) -> Unit = {},
+) {
+    val viewModel: ProgressViewModel = hiltViewModel()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is ProgressEffect.NavigateToWorkoutDetail ->
+                    onNavigateToWorkoutDetail(effect.workoutId)
+            }
+        }
+    }
+
+    ProgressScreen(
+        state = state,
+        onEvent = viewModel::onEvent,
+    )
+}
+
+@Composable
+private fun ProgressScreen(
+    state: ProgressState,
+    onEvent: (ProgressEvent) -> Unit,
+) {
+    if (state.isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Loading progress...",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    if (state.workoutHistory.isEmpty() && state.personalRecords.isEmpty()) {
+        EmptyProgressState()
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // Section: Personal Records
+        if (state.personalRecords.isNotEmpty()) {
+            item {
+                SectionHeader(title = "Personal Records", icon = "🏆")
+            }
+
+            val selectedRecords = if (state.selectedExerciseId != null) {
+                state.personalRecords.filter { it.exerciseId == state.selectedExerciseId }
+            } else {
+                state.personalRecords
+            }
+
+            item {
+                PRGrid(records = selectedRecords)
+            }
+        }
+
+        // Section: E1RM Chart
+        if (state.exerciseOptions.isNotEmpty()) {
+            item {
+                SectionHeader(title = "Estimated 1RM Trend", icon = "📈")
+            }
+
+            item {
+                ExerciseChipRow(
+                    options = state.exerciseOptions,
+                    selectedId = state.selectedExerciseId,
+                    onSelect = { onEvent(ProgressEvent.SelectExercise(it)) },
+                )
+            }
+
+            if (state.chartData.isNotEmpty()) {
+                item {
+                    E1RMChart(data = state.chartData)
+                }
+            } else {
+                item {
+                    Card(
+                        colors = CardDefaults.cardColors(containerColor = SurfaceColor),
+                        shape = RoundedCornerShape(12.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(32.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = "No data for this exercise yet",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Section: Workout History
+        if (state.workoutHistory.isNotEmpty()) {
+            item {
+                SectionHeader(title = "Workout History", icon = "📋")
+            }
+
+            items(state.workoutHistory, key = { it.workoutId }) { workout ->
+                WorkoutHistoryRow(
+                    item = workout,
+                    onClick = { onEvent(ProgressEvent.ViewWorkoutDetail(workout.workoutId)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyProgressState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.AutoMirrored.Filled.ShowChart,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "No Progress Data Yet",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Complete a few workouts to see your\nprogress trends and personal records here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 32.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String, icon: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 4.dp),
+    ) {
+        Text(
+            text = icon,
+            fontSize = 20.sp,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun PRGrid(records: List<PersonalRecord>) {
+    val grouped = records.groupBy { it.type }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // Show 2 cards per row
+        grouped.entries.chunked(2).forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                row.forEach { (_, prs) ->
+                    val pr = prs.maxByOrNull { it.value } ?: return@forEach
+                    PRCard(
+                        record = pr,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                if (row.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PRCard(record: PersonalRecord, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = SurfaceColor),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = record.type.emoji,
+                    fontSize = 16.sp,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = record.type.displayName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = formatPRValue(record),
+                style = MaterialTheme.typography.headlineSmall,
+                color = AccentGreen,
+                fontWeight = FontWeight.Bold,
+            )
+            if (record.exerciseName.isNotEmpty()) {
+                Text(
+                    text = record.exerciseName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+            val prev = record.previousValue
+            if (prev != null) {
+                val improvement = record.value - prev
+                if (improvement > 0) {
+                    Text(
+                        text = "+${formatNumber(improvement)}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = AccentGreen,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExerciseChipRow(
+    options: List<ExerciseOption>,
+    selectedId: String?,
+    onSelect: (String) -> Unit,
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(options) { option ->
+            FilterChip(
+                selected = option.id == selectedId,
+                onClick = { onSelect(option.id) },
+                label = {
+                    Text(
+                        text = option.name,
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = AccentAmber.copy(alpha = 0.2f),
+                    selectedLabelColor = AccentAmber,
+                    containerColor = SurfaceVariantColor,
+                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun E1RMChart(data: List<E1RMDataPoint>) {
+    val textMeasurer = rememberTextMeasurer()
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = SurfaceColor),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Current E1RM value
+            val latest = data.lastOrNull()
+            if (latest != null) {
+                Text(
+                    text = "${formatNumber(latest.e1rm)} kg",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = AccentAmber,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "Current Est. 1RM (${latest.weight}kg × ${latest.reps})",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(180.dp),
+            ) {
+                if (data.size < 2) {
+                    // Single point — draw a dot
+                    val cx = size.width / 2
+                    val cy = size.height / 2
+                    drawCircle(
+                        color = AccentAmber,
+                        radius = 6.dp.toPx(),
+                        center = Offset(cx, cy),
+                    )
+                    return@Canvas
+                }
+
+                val paddingLeft = 48.dp.toPx()
+                val paddingBottom = 28.dp.toPx()
+                val paddingTop = 8.dp.toPx()
+                val paddingRight = 8.dp.toPx()
+
+                val chartWidth = size.width - paddingLeft - paddingRight
+                val chartHeight = size.height - paddingTop - paddingBottom
+
+                val minE1RM = data.minOf { it.e1rm } * 0.95
+                val maxE1RM = data.maxOf { it.e1rm } * 1.05
+                val range = (maxE1RM - minE1RM).coerceAtLeast(1.0)
+
+                fun xForIndex(i: Int): Float =
+                    paddingLeft + (i.toFloat() / (data.size - 1)) * chartWidth
+
+                fun yForValue(v: Double): Float =
+                    paddingTop + ((maxE1RM - v) / range).toFloat() * chartHeight
+
+                // Grid lines (3 horizontal)
+                val gridCount = 3
+                for (i in 0..gridCount) {
+                    val v = minE1RM + (range * i / gridCount)
+                    val y = yForValue(v)
+                    drawLine(
+                        color = Color.White.copy(alpha = 0.1f),
+                        start = Offset(paddingLeft, y),
+                        end = Offset(size.width - paddingRight, y),
+                        strokeWidth = 1.dp.toPx(),
+                    )
+                    // Y-axis label
+                    val label = "${v.toInt()}"
+                    val textResult = textMeasurer.measure(
+                        text = label,
+                        style = TextStyle(
+                            color = Color.White.copy(alpha = 0.5f),
+                            fontSize = 10.sp,
+                        ),
+                    )
+                    drawText(
+                        textLayoutResult = textResult,
+                        topLeft = Offset(
+                            paddingLeft - textResult.size.width - 4.dp.toPx(),
+                            y - textResult.size.height / 2,
+                        ),
+                    )
+                }
+
+                // Line path
+                val path = Path()
+                data.forEachIndexed { i, point ->
+                    val x = xForIndex(i)
+                    val y = yForValue(point.e1rm)
+                    if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+                }
+
+                drawPath(
+                    path = path,
+                    color = AccentAmber,
+                    style = Stroke(
+                        width = 2.5.dp.toPx(),
+                        cap = StrokeCap.Round,
+                        join = StrokeJoin.Round,
+                    ),
+                )
+
+                // Data points
+                data.forEachIndexed { i, point ->
+                    val x = xForIndex(i)
+                    val y = yForValue(point.e1rm)
+                    drawCircle(
+                        color = AccentAmber,
+                        radius = 4.dp.toPx(),
+                        center = Offset(x, y),
+                    )
+                    drawCircle(
+                        color = SurfaceColor,
+                        radius = 2.dp.toPx(),
+                        center = Offset(x, y),
+                    )
+                }
+
+                // X-axis date labels (first and last)
+                val zone = ZoneId.systemDefault()
+                listOf(0, data.size - 1).forEach { i ->
+                    val point = data[i]
+                    val label = point.date.atZone(zone).format(dateFormatter)
+                    val textResult = textMeasurer.measure(
+                        text = label,
+                        style = TextStyle(
+                            color = Color.White.copy(alpha = 0.5f),
+                            fontSize = 10.sp,
+                        ),
+                    )
+                    val x = xForIndex(i)
+                    drawText(
+                        textLayoutResult = textResult,
+                        topLeft = Offset(
+                            (x - textResult.size.width / 2)
+                                .coerceIn(paddingLeft, size.width - paddingRight - textResult.size.width),
+                            size.height - paddingBottom + 4.dp.toPx(),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkoutHistoryRow(
+    item: WorkoutHistoryItem,
+    onClick: () -> Unit,
+) {
+    val zone = ZoneId.systemDefault()
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = SurfaceColor),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.FitnessCenter,
+                contentDescription = null,
+                tint = AccentCyan,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.date.atZone(zone).format(fullDateFormatter),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    StatChip(
+                        icon = Icons.Default.FitnessCenter,
+                        text = "${item.exerciseCount} exercises",
+                    )
+                    StatChip(
+                        icon = Icons.AutoMirrored.Filled.ShowChart,
+                        text = "${formatNumber(item.totalVolume)} kg",
+                    )
+                    if (item.durationSeconds > 0) {
+                        StatChip(
+                            icon = Icons.Default.Timer,
+                            text = formatDuration(item.durationSeconds),
+                        )
+                    }
+                }
+            }
+
+            if (item.prCount > 0) {
+                Icon(
+                    Icons.Default.EmojiEvents,
+                    contentDescription = "${item.prCount} PRs",
+                    tint = AccentGreen,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatChip(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    text: String,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(12.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.width(2.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun formatPRValue(record: PersonalRecord): String {
+    return when (record.type) {
+        RecordType.MAX_WEIGHT -> "${formatNumber(record.value)} kg"
+        RecordType.MAX_REPS -> "${record.value.toInt()} reps"
+        RecordType.MAX_VOLUME -> "${formatNumber(record.value)} kg"
+        RecordType.MAX_E1RM -> "${formatNumber(record.value)} kg"
+    }
+}
+
+private fun formatNumber(value: Double): String {
+    return if (value == value.toLong().toDouble()) {
+        value.toLong().toString()
+    } else {
+        "%.1f".format(value)
+    }
+}
+
+private fun formatDuration(seconds: Long): String {
+    val h = seconds / 3600
+    val m = (seconds % 3600) / 60
+    return if (h > 0) "${h}h ${m}m" else "${m}m"
+}

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressViewModel.kt
@@ -1,0 +1,100 @@
+package com.gymbro.feature.progress
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gymbro.core.repository.ExerciseRepository
+import com.gymbro.core.service.PersonalRecordService
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ProgressViewModel @Inject constructor(
+    private val prService: PersonalRecordService,
+    private val exerciseRepository: ExerciseRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ProgressState())
+    val state: StateFlow<ProgressState> = _state.asStateFlow()
+
+    private val _effects = Channel<ProgressEffect>(Channel.BUFFERED)
+    val effects = _effects.receiveAsFlow()
+
+    init {
+        loadData()
+    }
+
+    fun onEvent(event: ProgressEvent) {
+        when (event) {
+            is ProgressEvent.SelectExercise -> selectExercise(event.exerciseId)
+            is ProgressEvent.RefreshData -> loadData()
+            is ProgressEvent.ViewWorkoutDetail -> {
+                viewModelScope.launch {
+                    _effects.send(ProgressEffect.NavigateToWorkoutDetail(event.workoutId))
+                }
+            }
+        }
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true) }
+
+            val history = prService.getWorkoutHistory()
+            val exerciseIds = prService.getExerciseIdsWithHistory()
+
+            val exerciseOptions = exerciseIds.mapNotNull { id ->
+                val exercise = exerciseRepository.getExerciseById(id)
+                exercise?.let { ExerciseOption(id = id, name = it.name) }
+            }.sortedBy { it.name }
+
+            val allRecords = exerciseIds.flatMap { id ->
+                val exercise = exerciseRepository.getExerciseById(id)
+                if (exercise != null) {
+                    prService.getPersonalRecords(id, exercise.name)
+                } else emptyList()
+            }
+
+            val selectedId = _state.value.selectedExerciseId ?: exerciseOptions.firstOrNull()?.id
+            val chartData = if (selectedId != null) {
+                prService.getE1RMHistory(selectedId)
+            } else emptyList()
+
+            _state.update {
+                it.copy(
+                    workoutHistory = history,
+                    personalRecords = allRecords,
+                    exerciseOptions = exerciseOptions,
+                    selectedExerciseId = selectedId,
+                    chartData = chartData,
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    private fun selectExercise(exerciseId: String) {
+        viewModelScope.launch {
+            _state.update { it.copy(selectedExerciseId = exerciseId) }
+            val chartData = prService.getE1RMHistory(exerciseId)
+            val exercise = exerciseRepository.getExerciseById(exerciseId)
+            val records = if (exercise != null) {
+                prService.getPersonalRecords(exerciseId, exercise.name)
+            } else emptyList()
+
+            _state.update {
+                it.copy(
+                    chartData = chartData,
+                    personalRecords = it.personalRecords
+                        .filter { pr -> pr.exerciseId != exerciseId } + records,
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports iOS progress tracking to Android. Adds PR detection service, E1RM charts, workout history, and bottom navigation.

### What's included:

**Core module:**
- `PersonalRecordService` — detects 4 PR types (maxWeight, maxReps, maxVolume, maxE1RM) using Brzycki formula
- `PersonalRecord`, `WorkoutHistoryItem`, `E1RMDataPoint` domain models
- New DAO queries: `getSetsByExercise`, `getExerciseIdsWithHistory`, `getAllCompletedWorkouts`

**Feature module:**
- `ProgressScreen` — PR grid, E1RM line chart (Compose Canvas, no external libs), workout history
- `ProgressViewModel` — MVI pattern with State/Event/Effect
- Exercise selector chips for chart drill-down

**Navigation:**
- Bottom nav bar with Library and Progress tabs
- GymBro theme colors (AccentGreen for PRs, AccentAmber for charts)

### Verification
- `assembleDebug` passes with zero warnings

Closes #147

Working as Tank (Backend Developer)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>