### PR TITLE
feat: Health Connect integration with recovery tracking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,10 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.health.READ_SLEEP" />
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
     <uses-permission android:name="android.permission.health.WRITE_EXERCISE" />
-    <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
-    <uses-permission android:name="android.permission.health.READ_SLEEP" />
 
     <application
         android:name=".GymBroApplication"
@@ -21,6 +22,13 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Health Connect permissions request handler -->
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+            <meta-data
+                android:name="health_permissions"
+                android:resource="@array/health_permissions" />
         </activity>
     </application>
 

--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -10,7 +10,9 @@ import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.automirrored.outlined.ShowChart
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.outlined.FitnessCenter
+import androidx.compose.material.icons.outlined.MonitorHeart
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -40,6 +42,7 @@ import com.gymbro.core.model.ExerciseCategory
 import com.gymbro.core.model.MuscleGroup
 import com.gymbro.feature.exerciselibrary.ExerciseLibraryRoute
 import com.gymbro.feature.progress.ProgressRoute
+import com.gymbro.feature.recovery.RecoveryRoute
 import com.gymbro.feature.workout.ActiveWorkoutRoute
 import com.gymbro.feature.workout.WorkoutSummaryScreen
 
@@ -53,6 +56,7 @@ private enum class BottomNavTab(
 ) {
     LIBRARY("exercise_library", "Library", Icons.Filled.FitnessCenter, Icons.Outlined.FitnessCenter),
     PROGRESS("progress", "Progress", Icons.AutoMirrored.Filled.ShowChart, Icons.AutoMirrored.Outlined.ShowChart),
+    RECOVERY("recovery", "Recovery", Icons.Filled.MonitorHeart, Icons.Outlined.MonitorHeart),
 }
 
 @Composable
@@ -227,6 +231,31 @@ fun GymBroNavGraph() {
             ) { innerPadding ->
                 Box(modifier = Modifier.padding(innerPadding)) {
                     ProgressRoute()
+                }
+            }
+        }
+        composable("recovery") {
+            Scaffold(
+                bottomBar = {
+                    if (showBottomBar) {
+                        GymBroBottomNavBar(
+                            currentRoute = currentDestination?.route,
+                            onTabSelected = { tab ->
+                                navController.navigate(tab.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                        )
+                    }
+                },
+                containerColor = MaterialTheme.colorScheme.background,
+            ) { innerPadding ->
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    RecoveryRoute()
                 }
             }
         }

--- a/android/app/src/main/res/values/health_permissions.xml
+++ b/android/app/src/main/res/values/health_permissions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <array name="health_permissions">
+        <item>android.permission.health.READ_SLEEP</item>
+        <item>android.permission.health.READ_HEART_RATE</item>
+        <item>android.permission.health.READ_STEPS</item>
+        <item>android.permission.health.READ_EXERCISE</item>
+        <item>android.permission.health.WRITE_EXERCISE</item>
+    </array>
+</resources>

--- a/android/core/build.gradle.kts
+++ b/android/core/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
+    // Health Connect
+    implementation(libs.health.connect)
+
     // Coroutines
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.android)

--- a/android/core/src/main/AndroidManifest.xml
+++ b/android/core/src/main/AndroidManifest.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Health Connect permissions -->
+    <uses-permission android:name="android.permission.health.READ_SLEEP" />
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+    <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <uses-permission android:name="android.permission.health.WRITE_EXERCISE" />
+
 </manifest>

--- a/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
@@ -75,4 +75,7 @@ interface WorkoutDao {
     @Transaction
     @Query("SELECT * FROM workouts WHERE completed = 1 ORDER BY startedAt DESC")
     suspend fun getAllCompletedWorkouts(): List<WorkoutWithSets>
+
+    @Query("SELECT MAX(completedAt) FROM workouts WHERE completed = 1")
+    suspend fun getLastCompletedTimestamp(): Long?
 }

--- a/android/core/src/main/java/com/gymbro/core/di/HealthConnectModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/HealthConnectModule.kt
@@ -1,0 +1,18 @@
+package com.gymbro.core.di
+
+import com.gymbro.core.health.HealthConnectRepository
+import com.gymbro.core.health.HealthConnectRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class HealthConnectModule {
+
+    @Binds
+    abstract fun bindHealthConnectRepository(
+        impl: HealthConnectRepositoryImpl,
+    ): HealthConnectRepository
+}

--- a/android/core/src/main/java/com/gymbro/core/health/HealthConnectRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/health/HealthConnectRepository.kt
@@ -1,0 +1,16 @@
+package com.gymbro.core.health
+
+import com.gymbro.core.model.RecoveryMetrics
+import com.gymbro.core.model.SleepData
+
+interface HealthConnectRepository {
+    suspend fun isAvailable(): Boolean
+    suspend fun hasPermissions(): Boolean
+    suspend fun getSleepHistory(days: Int = 7): List<SleepData>
+    suspend fun getRecoveryMetrics(): RecoveryMetrics
+    suspend fun writeWorkoutSession(
+        title: String,
+        startTimeMillis: Long,
+        endTimeMillis: Long,
+    ): Boolean
+}

--- a/android/core/src/main/java/com/gymbro/core/health/HealthConnectRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/health/HealthConnectRepositoryImpl.kt
@@ -1,0 +1,66 @@
+package com.gymbro.core.health
+
+import com.gymbro.core.model.RecoveryMetrics
+import com.gymbro.core.model.SleepData
+import com.gymbro.core.repository.WorkoutRepository
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class HealthConnectRepositoryImpl @Inject constructor(
+    private val healthConnectService: HealthConnectService,
+    private val workoutRepository: WorkoutRepository,
+) : HealthConnectRepository {
+
+    override suspend fun isAvailable(): Boolean {
+        return healthConnectService.isAvailable()
+    }
+
+    override suspend fun hasPermissions(): Boolean {
+        return healthConnectService.hasAllPermissions()
+    }
+
+    override suspend fun getSleepHistory(days: Int): List<SleepData> {
+        return healthConnectService.readSleepData(days)
+    }
+
+    override suspend fun getRecoveryMetrics(): RecoveryMetrics {
+        val sleepData = healthConnectService.readSleepData(1)
+        val lastNightSleep = sleepData.firstOrNull()
+        val sleepHours = lastNightSleep?.durationHours ?: 0.0
+
+        val restingHR = healthConnectService.getRestingHeartRate()
+        val hrv = healthConnectService.getHRV()
+        val steps = healthConnectService.readStepsToday()
+
+        val daysSinceWorkout = workoutRepository.getDaysSinceLastWorkout()
+
+        val readinessScore = RecoveryMetrics.calculateReadiness(
+            sleepHours = sleepHours,
+            hrv = hrv,
+            daysSinceLastWorkout = daysSinceWorkout,
+        )
+
+        return RecoveryMetrics(
+            sleepHours = sleepHours,
+            restingHR = restingHR,
+            hrv = hrv,
+            steps = steps,
+            daysSinceLastWorkout = daysSinceWorkout,
+            readinessScore = readinessScore,
+        )
+    }
+
+    override suspend fun writeWorkoutSession(
+        title: String,
+        startTimeMillis: Long,
+        endTimeMillis: Long,
+    ): Boolean {
+        return healthConnectService.writeWorkoutSession(
+            title = title,
+            startTime = Instant.ofEpochMilli(startTimeMillis),
+            endTime = Instant.ofEpochMilli(endTimeMillis),
+        )
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/health/HealthConnectService.kt
+++ b/android/core/src/main/java/com/gymbro/core/health/HealthConnectService.kt
@@ -1,0 +1,206 @@
+package com.gymbro.core.health
+
+import android.content.Context
+import android.util.Log
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import com.gymbro.core.model.SleepData
+import com.gymbro.core.model.SleepQuality
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class HealthConnectService @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    companion object {
+        private const val TAG = "HealthConnectService"
+
+        val REQUIRED_PERMISSIONS = setOf(
+            HealthPermission.getReadPermission(SleepSessionRecord::class),
+            HealthPermission.getReadPermission(HeartRateRecord::class),
+            HealthPermission.getReadPermission(StepsRecord::class),
+            HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+            HealthPermission.getWritePermission(ExerciseSessionRecord::class),
+        )
+    }
+
+    private val healthConnectClient: HealthConnectClient? by lazy {
+        try {
+            HealthConnectClient.getOrCreate(context)
+        } catch (e: Exception) {
+            Log.w(TAG, "Health Connect not available", e)
+            null
+        }
+    }
+
+    fun isAvailable(): Boolean {
+        return HealthConnectClient.getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE
+    }
+
+    fun isInstalled(): Boolean {
+        val status = HealthConnectClient.getSdkStatus(context)
+        return status != HealthConnectClient.SDK_UNAVAILABLE
+    }
+
+    suspend fun hasAllPermissions(): Boolean {
+        val client = healthConnectClient ?: return false
+        val granted = client.permissionController.getGrantedPermissions()
+        return REQUIRED_PERMISSIONS.all { it in granted }
+    }
+
+    // --- Sleep Data (last 7 days) ---
+
+    suspend fun readSleepData(days: Int = 7): List<SleepData> {
+        val client = healthConnectClient ?: return emptyList()
+        val now = Instant.now()
+        val start = now.minus(Duration.ofDays(days.toLong()))
+
+        return try {
+            val response = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = SleepSessionRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(start, now),
+                ),
+            )
+
+            response.records.map { session ->
+                val duration = Duration.between(session.startTime, session.endTime)
+                val durationMinutes = duration.toMinutes().toDouble()
+
+                var deep = 0.0
+                var rem = 0.0
+                var light = 0.0
+                var awake = 0.0
+
+                session.stages.forEach { stage ->
+                    val stageMinutes = Duration.between(stage.startTime, stage.endTime)
+                        .toMinutes().toDouble()
+                    when (stage.stage) {
+                        SleepSessionRecord.STAGE_TYPE_DEEP -> deep += stageMinutes
+                        SleepSessionRecord.STAGE_TYPE_REM -> rem += stageMinutes
+                        SleepSessionRecord.STAGE_TYPE_LIGHT -> light += stageMinutes
+                        SleepSessionRecord.STAGE_TYPE_AWAKE -> awake += stageMinutes
+                    }
+                }
+
+                SleepData(
+                    durationMinutes = durationMinutes,
+                    quality = SleepQuality.fromDurationHours(durationMinutes / 60.0),
+                    startTime = session.startTime,
+                    endTime = session.endTime,
+                    deepSleepMinutes = deep,
+                    remSleepMinutes = rem,
+                    lightSleepMinutes = light,
+                    awakeMinutes = awake,
+                )
+            }.sortedByDescending { it.startTime }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read sleep data", e)
+            emptyList()
+        }
+    }
+
+    // --- Heart Rate / HRV (today) ---
+
+    suspend fun readHeartRateToday(): List<Double> {
+        val client = healthConnectClient ?: return emptyList()
+        val todayStart = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant()
+        val now = Instant.now()
+
+        return try {
+            val response = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = HeartRateRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(todayStart, now),
+                ),
+            )
+
+            response.records.flatMap { record ->
+                record.samples.map { it.beatsPerMinute.toDouble() }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read heart rate", e)
+            emptyList()
+        }
+    }
+
+    suspend fun getRestingHeartRate(): Double? {
+        val rates = readHeartRateToday()
+        if (rates.isEmpty()) return null
+        // Approximate resting HR as lowest 10th percentile
+        val sorted = rates.sorted()
+        val cutoff = (sorted.size * 0.1).toInt().coerceAtLeast(1)
+        return sorted.take(cutoff).average()
+    }
+
+    suspend fun getHRV(): Double? {
+        // HRV approximation from heart rate variability in samples
+        val rates = readHeartRateToday()
+        if (rates.size < 2) return null
+        // RMSSD-style approximation from BPM differences
+        val diffs = rates.zipWithNext { a, b -> (b - a) * (b - a) }
+        return kotlin.math.sqrt(diffs.average())
+    }
+
+    // --- Steps (today) ---
+
+    suspend fun readStepsToday(): Long {
+        val client = healthConnectClient ?: return 0
+        val todayStart = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant()
+        val now = Instant.now()
+
+        return try {
+            val response = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = StepsRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(todayStart, now),
+                ),
+            )
+
+            response.records.sumOf { it.count }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read steps", e)
+            0
+        }
+    }
+
+    // --- Write workout session ---
+
+    suspend fun writeWorkoutSession(
+        title: String,
+        startTime: Instant,
+        endTime: Instant,
+        exerciseType: Int = ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING,
+    ): Boolean {
+        val client = healthConnectClient ?: return false
+
+        return try {
+            val record = ExerciseSessionRecord(
+                startTime = startTime,
+                startZoneOffset = ZoneId.systemDefault().rules.getOffset(startTime),
+                endTime = endTime,
+                endZoneOffset = ZoneId.systemDefault().rules.getOffset(endTime),
+                exerciseType = exerciseType,
+                title = title,
+            )
+            client.insertRecords(listOf(record))
+            Log.i(TAG, "Workout session written to Health Connect")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to write workout session", e)
+            false
+        }
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/model/RecoveryMetrics.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/RecoveryMetrics.kt
@@ -1,0 +1,50 @@
+package com.gymbro.core.model
+
+data class RecoveryMetrics(
+    val sleepHours: Double = 0.0,
+    val restingHR: Double? = null,
+    val hrv: Double? = null,
+    val steps: Long = 0,
+    val daysSinceLastWorkout: Int? = null,
+    val readinessScore: Int = 0,
+) {
+    val readinessLabel: String
+        get() = when {
+            readinessScore >= 80 -> "Ready to Train"
+            readinessScore >= 60 -> "Moderate"
+            readinessScore >= 40 -> "Light Day"
+            else -> "Rest Recommended"
+        }
+
+    companion object {
+        /**
+         * Calculate readiness score (0–100) as weighted combo of:
+         * - Sleep quality (40%): 8h = 100, linear down to 0 at 4h
+         * - HRV (30%): higher is better, normalized to personal baseline
+         * - Rest days (30%): 1 rest day = 80, 2+ = 100, 0 = 50
+         */
+        fun calculateReadiness(
+            sleepHours: Double,
+            hrv: Double?,
+            daysSinceLastWorkout: Int?,
+        ): Int {
+            val sleepScore = ((sleepHours - 4.0) / 4.0 * 100.0).coerceIn(0.0, 100.0)
+
+            // HRV: use 50ms as "average" baseline — above is better
+            val hrvScore = if (hrv != null) {
+                ((hrv - 20.0) / 60.0 * 100.0).coerceIn(0.0, 100.0)
+            } else {
+                50.0 // neutral when unavailable
+            }
+
+            val restScore = when (daysSinceLastWorkout) {
+                null -> 60.0
+                0 -> 50.0
+                1 -> 80.0
+                else -> 100.0
+            }
+
+            return (sleepScore * 0.4 + hrvScore * 0.3 + restScore * 0.3).toInt().coerceIn(0, 100)
+        }
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/model/SleepData.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/SleepData.kt
@@ -1,0 +1,32 @@
+package com.gymbro.core.model
+
+import java.time.Instant
+
+data class SleepData(
+    val durationMinutes: Double,
+    val quality: SleepQuality,
+    val startTime: Instant,
+    val endTime: Instant,
+    val deepSleepMinutes: Double = 0.0,
+    val remSleepMinutes: Double = 0.0,
+    val lightSleepMinutes: Double = 0.0,
+    val awakeMinutes: Double = 0.0,
+) {
+    val durationHours: Double get() = durationMinutes / 60.0
+}
+
+enum class SleepQuality {
+    POOR,
+    FAIR,
+    GOOD,
+    EXCELLENT;
+
+    companion object {
+        fun fromDurationHours(hours: Double): SleepQuality = when {
+            hours >= 8.0 -> EXCELLENT
+            hours >= 7.0 -> GOOD
+            hours >= 6.0 -> FAIR
+            else -> POOR
+        }
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
@@ -13,4 +13,5 @@ interface WorkoutRepository {
     fun observeWorkout(workoutId: String): Flow<Workout?>
     fun getRecentWorkouts(limit: Int = 20): Flow<List<Workout>>
     suspend fun getBestWeight(exerciseId: String, reps: Int): Double?
+    suspend fun getDaysSinceLastWorkout(): Int?
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
@@ -78,6 +78,13 @@ class WorkoutRepositoryImpl @Inject constructor(
     override suspend fun getBestWeight(exerciseId: String, reps: Int): Double? {
         return workoutDao.getBestWeight(exerciseId, reps)
     }
+
+    override suspend fun getDaysSinceLastWorkout(): Int? {
+        val lastTimestamp = workoutDao.getLastCompletedTimestamp() ?: return null
+        val lastInstant = Instant.ofEpochMilli(lastTimestamp)
+        val now = Instant.now()
+        return java.time.Duration.between(lastInstant, now).toDays().toInt()
+    }
 }
 
 private fun WorkoutWithSets.toDomain(): Workout {

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryContract.kt
@@ -1,0 +1,23 @@
+package com.gymbro.feature.recovery
+
+import com.gymbro.core.model.RecoveryMetrics
+import com.gymbro.core.model.SleepData
+
+data class RecoveryState(
+    val recoveryMetrics: RecoveryMetrics = RecoveryMetrics(),
+    val sleepHistory: List<SleepData> = emptyList(),
+    val healthConnectAvailable: Boolean = false,
+    val permissionsGranted: Boolean = false,
+    val isLoading: Boolean = true,
+    val error: String? = null,
+)
+
+sealed interface RecoveryEvent {
+    data object RequestPermissions : RecoveryEvent
+    data object RefreshData : RecoveryEvent
+}
+
+sealed interface RecoveryEffect {
+    data object LaunchPermissionRequest : RecoveryEffect
+    data class ShowError(val message: String) : RecoveryEffect
+}

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
@@ -1,0 +1,525 @@
+package com.gymbro.feature.recovery
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.DirectionsWalk
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.MonitorHeart
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gymbro.core.model.SleepData
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val AccentGreen = Color(0xFF00FF87)
+private val CardBackground = Color(0xFF1E1E1E)
+private val SurfaceDark = Color(0xFF121212)
+
+@Composable
+fun RecoveryRoute(
+    onRequestPermissions: () -> Unit = {},
+    viewModel: RecoveryViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is RecoveryEffect.LaunchPermissionRequest -> onRequestPermissions()
+                is RecoveryEffect.ShowError -> { /* handled via state.error */ }
+            }
+        }
+    }
+
+    RecoveryScreen(
+        state = state,
+        onEvent = viewModel::onEvent,
+    )
+}
+
+@Composable
+internal fun RecoveryScreen(
+    state: RecoveryState,
+    onEvent: (RecoveryEvent) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SurfaceDark)
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        // Header
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Recovery",
+                style = MaterialTheme.typography.headlineMedium,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+            )
+            if (state.permissionsGranted) {
+                IconButton(onClick = { onEvent(RecoveryEvent.RefreshData) }) {
+                    Icon(
+                        Icons.Default.Refresh,
+                        contentDescription = "Refresh",
+                        tint = AccentGreen,
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        when {
+            !state.healthConnectAvailable -> {
+                HealthConnectUnavailableCard()
+            }
+            !state.permissionsGranted -> {
+                PermissionRequestCard(onRequestPermissions = {
+                    onEvent(RecoveryEvent.RequestPermissions)
+                })
+            }
+            state.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(300.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(color = AccentGreen)
+                }
+            }
+            else -> {
+                // Readiness Score Card
+                ReadinessScoreCard(
+                    score = state.recoveryMetrics.readinessScore,
+                    label = state.recoveryMetrics.readinessLabel,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Metrics Row
+                MetricsGrid(
+                    sleepHours = state.recoveryMetrics.sleepHours,
+                    restingHR = state.recoveryMetrics.restingHR,
+                    hrv = state.recoveryMetrics.hrv,
+                    steps = state.recoveryMetrics.steps,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Sleep Chart (last 7 days)
+                if (state.sleepHistory.isNotEmpty()) {
+                    SleepChartCard(sleepHistory = state.sleepHistory)
+                }
+
+                if (state.error != null) {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Card(
+                        colors = CardDefaults.cardColors(containerColor = Color(0xFF2D1F1F)),
+                        shape = RoundedCornerShape(16.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = state.error,
+                            color = Color(0xFFFF6B6B),
+                            modifier = Modifier.padding(16.dp),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReadinessScoreCard(score: Int, label: String) {
+    val scoreColor = when {
+        score >= 80 -> AccentGreen
+        score >= 60 -> Color(0xFFFFD600)
+        score >= 40 -> Color(0xFFFF9100)
+        else -> Color(0xFFFF5252)
+    }
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = CardBackground),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Readiness Score",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color(0xFF9E9E9E),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Circular score indicator
+            Box(contentAlignment = Alignment.Center) {
+                Canvas(modifier = Modifier.size(140.dp)) {
+                    // Background arc
+                    drawArc(
+                        color = Color(0xFF2A2A2A),
+                        startAngle = 135f,
+                        sweepAngle = 270f,
+                        useCenter = false,
+                        style = Stroke(width = 12.dp.toPx()),
+                        topLeft = Offset(12.dp.toPx(), 12.dp.toPx()),
+                        size = Size(
+                            size.width - 24.dp.toPx(),
+                            size.height - 24.dp.toPx(),
+                        ),
+                    )
+                    // Score arc
+                    drawArc(
+                        color = scoreColor,
+                        startAngle = 135f,
+                        sweepAngle = 270f * (score / 100f),
+                        useCenter = false,
+                        style = Stroke(width = 12.dp.toPx()),
+                        topLeft = Offset(12.dp.toPx(), 12.dp.toPx()),
+                        size = Size(
+                            size.width - 24.dp.toPx(),
+                            size.height - 24.dp.toPx(),
+                        ),
+                    )
+                }
+
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "$score",
+                        fontSize = 48.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = scoreColor,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = label,
+                style = MaterialTheme.typography.titleLarge,
+                color = scoreColor,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MetricsGrid(
+    sleepHours: Double,
+    restingHR: Double?,
+    hrv: Double?,
+    steps: Long,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            MetricCard(
+                modifier = Modifier.weight(1f),
+                icon = Icons.Default.Bedtime,
+                label = "Sleep",
+                value = String.format("%.1fh", sleepHours),
+                iconTint = Color(0xFF7C4DFF),
+            )
+            MetricCard(
+                modifier = Modifier.weight(1f),
+                icon = Icons.Default.Favorite,
+                label = "Resting HR",
+                value = restingHR?.let { String.format("%.0f bpm", it) } ?: "—",
+                iconTint = Color(0xFFFF5252),
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            MetricCard(
+                modifier = Modifier.weight(1f),
+                icon = Icons.Default.MonitorHeart,
+                label = "HRV",
+                value = hrv?.let { String.format("%.0f ms", it) } ?: "—",
+                iconTint = Color(0xFF00BCD4),
+            )
+            MetricCard(
+                modifier = Modifier.weight(1f),
+                icon = Icons.Default.DirectionsWalk,
+                label = "Steps",
+                value = String.format("%,d", steps),
+                iconTint = AccentGreen,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MetricCard(
+    modifier: Modifier = Modifier,
+    icon: ImageVector,
+    label: String,
+    value: String,
+    iconTint: Color,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = CardBackground),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .background(iconTint.copy(alpha = 0.15f), CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = label,
+                    tint = iconTint,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+            )
+
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFF9E9E9E),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SleepChartCard(sleepHistory: List<SleepData>) {
+    val dayFormatter = DateTimeFormatter.ofPattern("EEE")
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = CardBackground),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = "Sleep — Last 7 Days",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Bar chart
+            val maxHours = 10f
+            val barColor = Color(0xFF7C4DFF)
+            val sorted = sleepHistory.sortedBy { it.startTime }.takeLast(7)
+
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
+            ) {
+                val barCount = sorted.size.coerceAtLeast(1)
+                val barWidth = (size.width / barCount) * 0.6f
+                val spacing = (size.width / barCount) * 0.4f
+
+                sorted.forEachIndexed { index, sleep ->
+                    val height = (sleep.durationHours.toFloat() / maxHours) * size.height
+                    val x = index * (barWidth + spacing) + spacing / 2
+
+                    // Bar
+                    drawRoundRect(
+                        color = barColor,
+                        topLeft = Offset(x, size.height - height),
+                        size = Size(barWidth, height),
+                        cornerRadius = CornerRadius(4.dp.toPx()),
+                    )
+                }
+            }
+
+            // Day labels
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                sorted.forEach { sleep ->
+                    val dayLabel = sleep.startTime
+                        .atZone(ZoneId.systemDefault())
+                        .format(dayFormatter)
+                    Text(
+                        text = dayLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color(0xFF9E9E9E),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.width(40.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HealthConnectUnavailableCard() {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = CardBackground),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                Icons.Default.MonitorHeart,
+                contentDescription = null,
+                tint = Color(0xFF9E9E9E),
+                modifier = Modifier.size(48.dp),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Health Connect Not Available",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "Install Health Connect from the Play Store to track your recovery metrics.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF9E9E9E),
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PermissionRequestCard(onRequestPermissions: () -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = CardBackground),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                Icons.Default.MonitorHeart,
+                contentDescription = null,
+                tint = AccentGreen,
+                modifier = Modifier.size(48.dp),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Connect Your Health Data",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "GymBro uses sleep, heart rate, and step data to calculate your recovery readiness and optimize training.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF9E9E9E),
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Button(
+                onClick = onRequestPermissions,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AccentGreen,
+                    contentColor = Color.Black,
+                ),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = "Grant Permissions",
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(vertical = 4.dp),
+                )
+            }
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryViewModel.kt
@@ -1,0 +1,94 @@
+package com.gymbro.feature.recovery
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gymbro.core.health.HealthConnectRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RecoveryViewModel @Inject constructor(
+    private val healthConnectRepository: HealthConnectRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(RecoveryState())
+    val state: StateFlow<RecoveryState> = _state.asStateFlow()
+
+    private val _effects = Channel<RecoveryEffect>(Channel.BUFFERED)
+    val effects = _effects.receiveAsFlow()
+
+    init {
+        checkAvailabilityAndLoad()
+    }
+
+    fun onEvent(event: RecoveryEvent) {
+        when (event) {
+            is RecoveryEvent.RequestPermissions -> {
+                viewModelScope.launch {
+                    _effects.send(RecoveryEffect.LaunchPermissionRequest)
+                }
+            }
+            is RecoveryEvent.RefreshData -> loadData()
+        }
+    }
+
+    fun onPermissionsResult(granted: Boolean) {
+        _state.update { it.copy(permissionsGranted = granted) }
+        if (granted) loadData()
+    }
+
+    private fun checkAvailabilityAndLoad() {
+        viewModelScope.launch {
+            val available = healthConnectRepository.isAvailable()
+            val hasPermissions = if (available) {
+                healthConnectRepository.hasPermissions()
+            } else false
+
+            _state.update {
+                it.copy(
+                    healthConnectAvailable = available,
+                    permissionsGranted = hasPermissions,
+                )
+            }
+
+            if (available && hasPermissions) {
+                loadData()
+            } else {
+                _state.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, error = null) }
+
+            try {
+                val metrics = healthConnectRepository.getRecoveryMetrics()
+                val sleep = healthConnectRepository.getSleepHistory(7)
+
+                _state.update {
+                    it.copy(
+                        recoveryMetrics = metrics,
+                        sleepHistory = sleep,
+                        isLoading = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "Failed to load recovery data",
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ coroutines = "1.10.2"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
 coil = "3.2.0"
+health-connect = "1.1.0-alpha11"
 workmanager = "2.10.1"
 hilt-navigation-compose = "1.2.0"
 core-ktx = "1.16.0"
@@ -62,6 +63,9 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor",
 # Image loading
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+
+# Health Connect
+health-connect = { group = "androidx.health.connect", name = "connect-client", version.ref = "health-connect" }
 
 # Background work
 workmanager = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workmanager" }


### PR DESCRIPTION
## Summary

Integrates Google Health Connect (Android's HealthKit equivalent) for recovery-aware training. Mirrors the iOS HealthKit pattern from \ios/Packages/GymBroCore/Sources/GymBroCore/Services/HealthKit/\.

### What's included

**Core module:**
- \HealthConnectService\ — availability check, permission management, read sleep/HR/HRV/steps, write workout sessions
- \HealthConnectRepository\ interface + \HealthConnectRepositoryImpl\ with Hilt DI
- \SleepData\ model — duration, quality, stage breakdown (deep/REM/light/awake)
- \RecoveryMetrics\ model — weighted readiness score from sleep (40%) + HRV (30%) + rest days (30%)
- \getDaysSinceLastWorkout()\ added to WorkoutRepository
- Health Connect permissions declared in AndroidManifest

**Feature module:**
- \RecoveryScreen\ — readiness score gauge, metrics grid (sleep/HR/HRV/steps), 7-day sleep bar chart
- \RecoveryViewModel\ — MVI pattern matching existing codebase conventions
- Permission request and Health Connect unavailable states
- Recovery tab added to bottom navigation

### Technical notes
- Uses \ndroidx.health.connect:connect-client:1.1.0-alpha11\
- Follows existing MVI + Hilt + Compose patterns
- Readiness formula: \