### PR TITLE
feat: add loading states for all screens

### DIFF
--- a/android/feature/src/main/java/com/gymbro/feature/common/LoadingIndicator.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/LoadingIndicator.kt
@@ -1,0 +1,186 @@
+package com.gymbro.feature.common
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val AccentGreen = Color(0xFF00FF87)
+private val SurfaceColor = Color(0xFF1A1A1A)
+private val BackgroundColor = Color(0xFF0A0A0A)
+
+/**
+ * Full screen loading indicator with subtle animation and text.
+ * Use this when the entire screen is loading initial data.
+ */
+@Composable
+fun FullScreenLoading(
+    message: String = "Loading...",
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(BackgroundColor),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            CircularProgressIndicator(
+                color = AccentGreen,
+                strokeWidth = 3.dp,
+                modifier = Modifier.size(48.dp),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF9E9E9E),
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+/**
+ * Inline loading indicator for partial screen refreshes.
+ * Use this for smaller loading states within a screen.
+ */
+@Composable
+fun InlineLoading(
+    message: String = "Loading...",
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(
+            color = AccentGreen,
+            strokeWidth = 2.dp,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color(0xFF9E9E9E),
+        )
+    }
+}
+
+/**
+ * Shimmer/skeleton placeholder for list items.
+ * Use this when showing loading state for list content.
+ */
+@Composable
+fun ShimmerListItem(
+    modifier: Modifier = Modifier,
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "shimmer")
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.3f,
+        targetValue = 0.6f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "shimmerAlpha",
+    )
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Avatar placeholder
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .background(SurfaceColor.copy(alpha = alpha), RoundedCornerShape(8.dp)),
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            // Title placeholder
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .height(16.dp)
+                    .background(SurfaceColor.copy(alpha = alpha), RoundedCornerShape(4.dp)),
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Subtitle placeholder
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(12.dp)
+                    .background(SurfaceColor.copy(alpha = alpha), RoundedCornerShape(4.dp)),
+            )
+        }
+    }
+}
+
+/**
+ * Loading card placeholder with shimmer effect.
+ * Use this for card-based content loading.
+ */
+@Composable
+fun ShimmerCard(
+    modifier: Modifier = Modifier,
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "shimmer")
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.3f,
+        targetValue = 0.6f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "shimmerAlpha",
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(120.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .background(SurfaceColor.copy(alpha = alpha), RoundedCornerShape(16.dp)),
+    )
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -48,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.ExerciseCategory
 import com.gymbro.core.model.MuscleGroup
+import com.gymbro.feature.common.FullScreenLoading
 
 private val AccentGreen = Color(0xFF00FF87)
 private val AccentCyan = Color(0xFF00E5FF)
@@ -190,12 +191,7 @@ fun ExerciseLibraryScreen(
             // Content
             when {
                 state.isLoading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator(color = AccentGreen)
-                    }
+                    FullScreenLoading(message = "Loading exercises...")
                 }
                 state.exercises.isEmpty() -> {
                     EmptyExercisesView()

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
@@ -54,6 +54,7 @@ class ExerciseLibraryViewModel @Inject constructor(
     private fun loadExercises() {
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
+            _state.update { it.copy(isLoading = true) }
             val currentState = _state.value
             val muscleGroup = currentState.selectedMuscleGroup?.name
             val query = currentState.searchQuery.takeIf { it.isNotBlank() }

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
@@ -54,6 +54,7 @@ import com.gymbro.core.model.E1RMDataPoint
 import com.gymbro.core.model.PersonalRecord
 import com.gymbro.core.model.RecordType
 import com.gymbro.core.model.WorkoutHistoryItem
+import com.gymbro.feature.common.FullScreenLoading
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -94,16 +95,7 @@ private fun ProgressScreen(
     onEvent: (ProgressEvent) -> Unit,
 ) {
     if (state.isLoading) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = "Loading progress...",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        FullScreenLoading(message = "Loading progress...")
         return
     }
 

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gymbro.core.model.SleepData
+import com.gymbro.feature.common.FullScreenLoading
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -126,12 +127,7 @@ internal fun RecoveryScreen(
                 })
             }
             state.isLoading -> {
-                Box(
-                    modifier = Modifier.fillMaxWidth().height(300.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator(color = AccentGreen)
-                }
+                FullScreenLoading(message = "Loading recovery data...")
             }
             else -> {
                 // Readiness Score Card

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -12,6 +12,7 @@ data class ActiveWorkoutState(
     val restTimerTotal: Int = 90,
     val isRestTimerActive: Boolean = false,
     val isCompleting: Boolean = false,
+    val isLoading: Boolean = true,
 )
 
 data class WorkoutExerciseUi(

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gymbro.core.model.Exercise
+import com.gymbro.feature.common.FullScreenLoading
 
 private val AccentGreen = Color(0xFF00FF87)
 private val AccentCyan = Color(0xFF00E5FF)
@@ -113,6 +114,11 @@ fun ActiveWorkoutScreen(
     state: ActiveWorkoutState,
     onEvent: (ActiveWorkoutEvent) -> Unit,
 ) {
+    if (state.isLoading) {
+        FullScreenLoading(message = "Starting workout...")
+        return
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             topBar = {

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -39,7 +39,7 @@ class ActiveWorkoutViewModel @Inject constructor(
     private fun startWorkout() {
         viewModelScope.launch {
             val workout = workoutRepository.startWorkout()
-            _state.update { it.copy(workoutId = workout.id.toString()) }
+            _state.update { it.copy(workoutId = workout.id.toString(), isLoading = false) }
             startElapsedTimer()
         }
     }


### PR DESCRIPTION
Closes #162

## Summary
Added proper loading states to all feature screens with reusable, Material 3 styled loading components.

## Changes
- ✅ Created reusable LoadingIndicator.kt with multiple loading variants:
  - FullScreenLoading: For initial screen loads (used in all screens)
  - InlineLoading: For partial refreshes
  - ShimmerListItem and ShimmerCard: For skeleton placeholders
- ✅ Updated all screens to use FullScreenLoading:
  - ExerciseLibraryScreen
  - ProgressScreen
  - RecoveryScreen
  - ActiveWorkoutScreen (newly added)
  - ProfileScreen (already had inline loading in UserCard)
- ✅ Added isLoading to ActiveWorkoutState
- ✅ Updated ViewModels to properly set loading states during data fetches
- ✅ All loading indicators match GymBro dark theme (dark backgrounds, green accents)

## Build Status
✅ Build successful: ./gradlew.bat assembleDebug --no-daemon

## Testing Notes
Loading states now display consistently across all screens during initial data load, providing better UX feedback to users.