### PR TITLE
refactor: add error handling pattern with BaseViewModel

### DIFF
--- a/android/core/src/main/java/com/gymbro/core/error/ErrorHandler.kt
+++ b/android/core/src/main/java/com/gymbro/core/error/ErrorHandler.kt
@@ -1,0 +1,47 @@
+package com.gymbro.core.error
+
+import java.io.IOException
+import java.net.SocketException
+import java.net.UnknownHostException
+import java.util.concurrent.TimeoutException
+import javax.net.ssl.SSLException
+
+sealed class AppError(val message: String, val retryable: Boolean = false) {
+    data class NetworkError(val cause: String) : AppError(
+        message = "Network connection failed: $cause",
+        retryable = true
+    )
+    
+    data class DatabaseError(val cause: String) : AppError(
+        message = "Database error: $cause",
+        retryable = false
+    )
+    
+    data class AuthError(val cause: String) : AppError(
+        message = "Authentication failed: $cause",
+        retryable = true
+    )
+    
+    data class Unknown(val cause: String) : AppError(
+        message = "An unexpected error occurred: $cause",
+        retryable = true
+    )
+}
+
+fun Throwable.toAppError(): AppError = when (this) {
+    is UnknownHostException -> AppError.NetworkError("No internet connection")
+    is SocketException -> AppError.NetworkError("Connection lost")
+    is TimeoutException -> AppError.NetworkError("Request timed out")
+    is SSLException -> AppError.NetworkError("Secure connection failed")
+    is IOException -> AppError.NetworkError("Network error")
+    else -> {
+        val message = this.message ?: this.javaClass.simpleName
+        when {
+            message.contains("auth", ignoreCase = true) -> AppError.AuthError(message)
+            message.contains("database", ignoreCase = true) -> AppError.DatabaseError(message)
+            else -> AppError.Unknown(message)
+        }
+    }
+}
+
+fun Throwable.toUserMessage(): String = this.toAppError().message

--- a/android/core/src/main/java/com/gymbro/core/error/UiError.kt
+++ b/android/core/src/main/java/com/gymbro/core/error/UiError.kt
@@ -1,0 +1,21 @@
+package com.gymbro.core.error
+
+data class UiError(
+    val message: String,
+    val retryable: Boolean = false,
+    val action: (() -> Unit)? = null
+) {
+    companion object {
+        fun from(appError: AppError, retryAction: (() -> Unit)? = null): UiError {
+            return UiError(
+                message = appError.message,
+                retryable = appError.retryable,
+                action = if (appError.retryable) retryAction else null
+            )
+        }
+        
+        fun from(throwable: Throwable, retryAction: (() -> Unit)? = null): UiError {
+            return from(throwable.toAppError(), retryAction)
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/common/BaseViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/BaseViewModel.kt
@@ -1,0 +1,47 @@
+package com.gymbro.feature.common
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gymbro.core.error.UiError
+import com.gymbro.core.error.toAppError
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+abstract class BaseViewModel : ViewModel() {
+    
+    private val _errorEvents = Channel<UiError>(Channel.BUFFERED)
+    val errorEvents = _errorEvents.receiveAsFlow()
+    
+    protected fun handleError(throwable: Throwable, retryAction: (() -> Unit)? = null): UiError {
+        val uiError = UiError.from(throwable, retryAction)
+        viewModelScope.launch {
+            _errorEvents.send(uiError)
+        }
+        return uiError
+    }
+    
+    protected fun safeLaunch(
+        onError: ((Throwable) -> Unit)? = null,
+        block: suspend CoroutineScope.() -> Unit
+    ): Job {
+        val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+            onError?.invoke(throwable) ?: handleError(throwable)
+        }
+        
+        return viewModelScope.launch(exceptionHandler) {
+            try {
+                block()
+            } catch (e: Exception) {
+                onError?.invoke(e) ?: handleError(e)
+            }
+        }
+    }
+    
+    protected open fun setLoading(loading: Boolean) {
+        // Override in subclass to update loading state
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/common/ErrorSnackbar.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/ErrorSnackbar.kt
@@ -1,0 +1,29 @@
+package com.gymbro.feature.common
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.gymbro.core.error.UiError
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun ObserveErrors(
+    errorFlow: Flow<UiError>,
+    snackbarHostState: SnackbarHostState
+) {
+    LaunchedEffect(errorFlow) {
+        errorFlow.collect { error ->
+            val result = snackbarHostState.showSnackbar(
+                message = error.message,
+                actionLabel = if (error.retryable) "Retry" else null,
+                duration = if (error.retryable) SnackbarDuration.Long else SnackbarDuration.Short
+            )
+            
+            if (result == SnackbarResult.ActionPerformed) {
+                error.action?.invoke()
+            }
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryContract.kt
@@ -1,5 +1,6 @@
 package com.gymbro.feature.exerciselibrary
 
+import com.gymbro.core.error.UiError
 import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.MuscleGroup
 
@@ -8,6 +9,7 @@ data class ExerciseLibraryState(
     val searchQuery: String = "",
     val selectedMuscleGroup: MuscleGroup? = null,
     val isLoading: Boolean = true,
+    val error: UiError? = null,
 )
 
 sealed interface ExerciseLibraryEvent {

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -28,7 +28,9 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -36,6 +38,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,6 +52,7 @@ import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.ExerciseCategory
 import com.gymbro.core.model.MuscleGroup
 import com.gymbro.feature.common.FullScreenLoading
+import com.gymbro.feature.common.ObserveErrors
 
 private val AccentGreen = Color(0xFF00FF87)
 private val AccentCyan = Color(0xFF00E5FF)
@@ -63,6 +67,12 @@ fun ExerciseLibraryRoute(
     isPickerMode: Boolean = false,
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    ObserveErrors(
+        errorFlow = viewModel.errorEvents,
+        snackbarHostState = snackbarHostState
+    )
 
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
@@ -84,6 +94,7 @@ fun ExerciseLibraryRoute(
             }
         },
         isPickerMode = isPickerMode,
+        snackbarHostState = snackbarHostState,
     )
 }
 
@@ -93,6 +104,7 @@ fun ExerciseLibraryScreen(
     state: ExerciseLibraryState,
     onEvent: (ExerciseLibraryEvent) -> Unit,
     isPickerMode: Boolean = false,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         topBar = {
@@ -109,6 +121,7 @@ fun ExerciseLibraryScreen(
                 ),
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background,
     ) { innerPadding ->
         Column(

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
@@ -1,8 +1,8 @@
 package com.gymbro.feature.exerciselibrary
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gymbro.core.repository.ExerciseRepository
+import com.gymbro.feature.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -17,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ExerciseLibraryViewModel @Inject constructor(
     private val exerciseRepository: ExerciseRepository,
-) : ViewModel() {
+) : BaseViewModel() {
 
     private val _state = MutableStateFlow(ExerciseLibraryState())
     val state: StateFlow<ExerciseLibraryState> = _state.asStateFlow()
@@ -53,7 +53,12 @@ class ExerciseLibraryViewModel @Inject constructor(
 
     private fun loadExercises() {
         loadJob?.cancel()
-        loadJob = viewModelScope.launch {
+        loadJob = safeLaunch(
+            onError = { error ->
+                _state.update { it.copy(isLoading = false) }
+                handleError(error) { loadExercises() }
+            }
+        ) {
             _state.update { it.copy(isLoading = true) }
             val currentState = _state.value
             val muscleGroup = currentState.selectedMuscleGroup?.name
@@ -62,9 +67,13 @@ class ExerciseLibraryViewModel @Inject constructor(
             exerciseRepository.getFilteredExercises(muscleGroup, query)
                 .collect { exercises ->
                     _state.update {
-                        it.copy(exercises = exercises, isLoading = false)
+                        it.copy(exercises = exercises, isLoading = false, error = null)
                     }
                 }
         }
+    }
+    
+    override fun setLoading(loading: Boolean) {
+        _state.update { it.copy(isLoading = loading) }
     }
 }


### PR DESCRIPTION
Closes #163

Adds:
- AppError sealed class for typed errors (NetworkError, DatabaseError, AuthError, Unknown)
- ErrorHandler.kt with toAppError() extension to map exceptions to user-friendly errors
- UiError data class for UI-level error representation with retry support
- BaseViewModel with safeLaunch and error handling helpers
- ObserveErrors composable for snackbar error display
- ExerciseLibraryViewModel updated as reference implementation

All error types map to user-friendly messages. Network errors are retryable. Build passes cleanly.