### PR TITLE
Workout History Detail Screen

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -44,6 +44,7 @@ import com.gymbro.core.model.ExerciseCategory
 import com.gymbro.core.model.MuscleGroup
 import com.gymbro.core.preferences.UserPreferences
 import com.gymbro.feature.exerciselibrary.ExerciseLibraryRoute
+import com.gymbro.feature.history.HistoryDetailRoute
 import com.gymbro.feature.onboarding.OnboardingRoute
 import com.gymbro.feature.profile.ProfileRoute
 import com.gymbro.feature.progress.ProgressRoute
@@ -228,6 +229,18 @@ fun GymBroNavGraph(
                         popUpTo("exercise_library") { inclusive = true }
                     }
                 },
+            )
+        }
+        composable(
+            route = "history/{workoutId}",
+            arguments = listOf(
+                navArgument("workoutId") { type = NavType.StringType },
+            ),
+        ) { backStackEntry ->
+            val workoutId = backStackEntry.arguments?.getString("workoutId") ?: ""
+            HistoryDetailRoute(
+                workoutId = workoutId,
+                onNavigateBack = { navController.popBackStack() },
             )
         }
         composable("history") {

--- a/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailContract.kt
@@ -1,0 +1,43 @@
+package com.gymbro.feature.history
+
+import com.gymbro.core.model.MuscleGroup
+
+data class HistoryDetailState(
+    val isLoading: Boolean = true,
+    val error: String? = null,
+    val workoutDetail: WorkoutDetail? = null,
+)
+
+data class WorkoutDetail(
+    val workoutId: String,
+    val date: Long,
+    val durationSeconds: Long,
+    val totalVolume: Double,
+    val totalSets: Int,
+    val totalReps: Int,
+    val exercises: List<ExerciseDetail>,
+    val prExerciseIds: Set<String>,
+    val volumeByMuscleGroup: Map<MuscleGroup, Double>,
+)
+
+data class ExerciseDetail(
+    val exerciseId: String,
+    val exerciseName: String,
+    val muscleGroup: MuscleGroup,
+    val sets: List<SetDetail>,
+    val totalVolume: Double,
+    val hasPR: Boolean,
+)
+
+data class SetDetail(
+    val setNumber: Int,
+    val weight: Double,
+    val reps: Int,
+    val rpe: Double?,
+    val isWarmup: Boolean,
+)
+
+sealed interface HistoryDetailIntent {
+    data class LoadWorkout(val workoutId: String) : HistoryDetailIntent
+    object Retry : HistoryDetailIntent
+}

--- a/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailScreen.kt
@@ -1,0 +1,409 @@
+package com.gymbro.feature.history
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.gymbro.feature.common.EmptyState
+import com.gymbro.feature.common.FullScreenLoading
+import com.gymbro.feature.common.GymBroCard
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val AccentGreen = Color(0xFF00FF87)
+private val AccentCyan = Color(0xFF00E5FF)
+private val AccentAmber = Color(0xFFFFAB00)
+private val SurfaceCard = Color(0xFF1A1A1A)
+private val SurfaceDark = Color(0xFF0A0A0A)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HistoryDetailRoute(
+    workoutId: String,
+    onNavigateBack: () -> Unit,
+    viewModel: HistoryDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(workoutId) {
+        viewModel.onIntent(HistoryDetailIntent.LoadWorkout(workoutId))
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Workout Details", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = Color.White,
+                    navigationIconContentColor = Color.White,
+                ),
+            )
+        },
+        containerColor = SurfaceDark,
+    ) { paddingValues ->
+        Box(modifier = Modifier.padding(paddingValues)) {
+            when {
+                state.isLoading -> {
+                    FullScreenLoading(message = "Loading workout...")
+                }
+                state.error != null -> {
+                    EmptyState(
+                        icon = Icons.Default.Close,
+                        title = "Error",
+                        subtitle = state.error ?: "Unknown error",
+                        actionText = "Retry",
+                        onActionClick = { viewModel.onIntent(HistoryDetailIntent.Retry) },
+                    )
+                }
+                state.workoutDetail != null -> {
+                    HistoryDetailContent(detail = state.workoutDetail!!)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryDetailContent(detail: WorkoutDetail) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SurfaceDark)
+            .padding(horizontal = 16.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            WorkoutHeader(detail = detail)
+        }
+
+        item {
+            Text(
+                text = "Overview",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                StatCard(
+                    icon = Icons.Default.FitnessCenter,
+                    label = "Volume",
+                    value = "${detail.totalVolume.toInt()} kg",
+                    color = AccentGreen,
+                    modifier = Modifier.weight(1f),
+                )
+                StatCard(
+                    icon = Icons.Default.BarChart,
+                    label = "Sets",
+                    value = "${detail.totalSets}",
+                    color = AccentAmber,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+
+        if (detail.prExerciseIds.isNotEmpty()) {
+            item {
+                GymBroCard(accentColor = AccentAmber) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Icon(
+                            Icons.Default.Star,
+                            contentDescription = null,
+                            tint = AccentAmber,
+                            modifier = Modifier.size(28.dp),
+                        )
+                        Column {
+                            Text(
+                                text = "${detail.prExerciseIds.size} Personal Record${if (detail.prExerciseIds.size > 1) "s" else ""}",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White,
+                            )
+                            Text(
+                                text = "New PRs set in this workout",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = 0.6f),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Text(
+                text = "Exercises",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        }
+
+        items(detail.exercises) { exercise ->
+            ExerciseCard(exercise = exercise)
+        }
+
+        if (detail.volumeByMuscleGroup.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Volume by Muscle Group",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+
+            item {
+                GymBroCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        detail.volumeByMuscleGroup.entries.sortedByDescending { it.value }.forEach { (muscle, volume) ->
+                            MuscleVolumeRow(muscle = muscle.displayName, volume = volume)
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun WorkoutHeader(detail: WorkoutDetail) {
+    val date = Instant.ofEpochMilli(detail.date)
+        .atZone(ZoneId.systemDefault())
+        .format(DateTimeFormatter.ofPattern("EEEE, MMM d, yyyy"))
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = date,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = formatDuration(detail.durationSeconds),
+            style = MaterialTheme.typography.bodyLarge,
+            color = Color.White.copy(alpha = 0.6f),
+        )
+    }
+}
+
+@Composable
+private fun StatCard(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(SurfaceCard)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(28.dp))
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White.copy(alpha = 0.5f),
+        )
+    }
+}
+
+@Composable
+private fun ExerciseCard(exercise: ExerciseDetail) {
+    GymBroCard(accentColor = if (exercise.hasPR) AccentGreen else null) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = exercise.exerciseName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                    )
+                    Text(
+                        text = exercise.muscleGroup.displayName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.6f),
+                    )
+                }
+                if (exercise.hasPR) {
+                    Icon(
+                        Icons.Default.Star,
+                        contentDescription = "Personal Record",
+                        tint = AccentGreen,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                exercise.sets.forEach { set ->
+                    SetRow(set = set)
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Total Volume:",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.7f),
+                )
+                Text(
+                    text = "${exercise.totalVolume.toInt()} kg",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = AccentCyan,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SetRow(set: SetDetail) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(SurfaceDark, RoundedCornerShape(8.dp))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Set ${set.setNumber}",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.White.copy(alpha = 0.7f),
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "${set.weight} kg × ${set.reps}",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = Color.White,
+            )
+            if (set.rpe != null) {
+                Text(
+                    text = "RPE ${set.rpe}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = AccentAmber,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MuscleVolumeRow(muscle: String, volume: Double) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = muscle,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.White,
+        )
+        Text(
+            text = "${volume.toInt()} kg",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = AccentCyan,
+        )
+    }
+}
+
+private fun formatDuration(totalSeconds: Long): String {
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    return if (hours > 0) {
+        "${hours}h ${minutes}m"
+    } else {
+        "${minutes}m"
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailViewModel.kt
@@ -1,0 +1,131 @@
+package com.gymbro.feature.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gymbro.core.model.MuscleGroup
+import com.gymbro.core.repository.ExerciseRepository
+import com.gymbro.core.repository.WorkoutRepository
+import com.gymbro.core.service.PersonalRecordService
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HistoryDetailViewModel @Inject constructor(
+    private val workoutRepository: WorkoutRepository,
+    private val exerciseRepository: ExerciseRepository,
+    private val personalRecordService: PersonalRecordService,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(HistoryDetailState())
+    val state: StateFlow<HistoryDetailState> = _state.asStateFlow()
+
+    fun onIntent(intent: HistoryDetailIntent) {
+        when (intent) {
+            is HistoryDetailIntent.LoadWorkout -> loadWorkout(intent.workoutId)
+            is HistoryDetailIntent.Retry -> {
+                state.value.workoutDetail?.workoutId?.let { loadWorkout(it) }
+            }
+        }
+    }
+
+    private fun loadWorkout(workoutId: String) {
+        viewModelScope.launch {
+            _state.value = HistoryDetailState(isLoading = true, error = null)
+            try {
+                val workout = workoutRepository.getWorkout(workoutId)
+                if (workout == null) {
+                    _state.value = HistoryDetailState(
+                        isLoading = false,
+                        error = "Workout not found"
+                    )
+                    return@launch
+                }
+
+                val sets = workout.sets.filter { !it.isWarmup }
+                val totalSets = sets.size
+                val totalReps = sets.sumOf { it.reps }
+                val totalVolume = sets.sumOf { it.weightKg * it.reps }
+
+                val exerciseIds = sets.map { it.exerciseId }.distinct()
+                val prExerciseIds = mutableSetOf<String>()
+                
+                for (exerciseId in exerciseIds) {
+                    val exercise = exerciseRepository.getExerciseById(exerciseId.toString())
+                    if (exercise != null) {
+                        val records = personalRecordService.getPersonalRecords(
+                            exerciseId.toString(),
+                            exercise.name
+                        )
+                        records.forEach { record ->
+                            val recordDate = record.date.toEpochMilli()
+                            val workoutDate = workout.startedAt.toEpochMilli()
+                            if (kotlin.math.abs(recordDate - workoutDate) < 1000) {
+                                prExerciseIds.add(exerciseId.toString())
+                            }
+                        }
+                    }
+                }
+
+                val exercises = exerciseIds.mapNotNull { exerciseId ->
+                    val exercise = exerciseRepository.getExerciseById(exerciseId.toString())
+                    if (exercise != null) {
+                        val exerciseSets = sets
+                            .filter { it.exerciseId == exerciseId }
+                            .sortedBy { it.completedAt }
+                            .mapIndexed { index, set ->
+                                SetDetail(
+                                    setNumber = index + 1,
+                                    weight = set.weightKg,
+                                    reps = set.reps,
+                                    rpe = set.rpe,
+                                    isWarmup = set.isWarmup,
+                                )
+                            }
+                        val exerciseVolume = exerciseSets.sumOf { it.weight * it.reps }
+                        ExerciseDetail(
+                            exerciseId = exerciseId.toString(),
+                            exerciseName = exercise.name,
+                            muscleGroup = exercise.muscleGroup,
+                            sets = exerciseSets,
+                            totalVolume = exerciseVolume,
+                            hasPR = prExerciseIds.contains(exerciseId.toString()),
+                        )
+                    } else null
+                }
+
+                val volumeByMuscleGroup = exercises
+                    .groupBy { it.muscleGroup }
+                    .mapValues { (_, exs) -> exs.sumOf { it.totalVolume } }
+
+                val detail = WorkoutDetail(
+                    workoutId = workoutId,
+                    date = workout.startedAt.toEpochMilli(),
+                    durationSeconds = workout.completedAt?.let {
+                        (it.toEpochMilli() - workout.startedAt.toEpochMilli()) / 1000
+                    } ?: 0L,
+                    totalVolume = totalVolume,
+                    totalSets = totalSets,
+                    totalReps = totalReps,
+                    exercises = exercises,
+                    prExerciseIds = prExerciseIds,
+                    volumeByMuscleGroup = volumeByMuscleGroup,
+                )
+
+                _state.value = HistoryDetailState(
+                    isLoading = false,
+                    error = null,
+                    workoutDetail = detail
+                )
+            } catch (e: Exception) {
+                _state.value = HistoryDetailState(
+                    isLoading = false,
+                    error = e.message ?: "Failed to load workout"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #167

## Summary
Created a detail screen showing full workout breakdown when a user taps a past workout from the history list.

## What Changed
### New Files
- **HistoryDetailContract.kt** - State and intent definitions for the history detail screen
- **HistoryDetailViewModel.kt** - Loads workout details, calculates stats, checks PRs via PersonalRecordService
- **HistoryDetailScreen.kt** - Full UI implementation with workout details, exercise breakdown, and stats

### Modified Files  
- **GymBroNavGraph.kt** - Added \history/{workoutId}\ route for navigation to workout detail screen

## Screen Features
- **Header:** Date, duration formatted (hours/minutes)
- **Overview Cards:** Total volume, total sets with GymBro stat cards
- **PR Indicator:** Shows count of personal records set in this workout with accent amber
- **Exercise List:** Each exercise shows:
  - Exercise name and muscle group
  - All sets with weight × reps format
  - RPE displayed if set
  - PR badge (green accent) if records were set
  - Total volume per exercise
- **Volume Breakdown:** Shows volume distribution across muscle groups
- **Design System:** Uses GymBroCard, dark theme, accent colors (green for PRs, cyan for stats, amber for highlights)

## Technical Details
- ViewModel loads workout via \WorkoutRepository.getWorkout()\
- Maps exercise IDs to names using \ExerciseRepository.getExerciseById()\
- Checks for PRs using \PersonalRecordService.getPersonalRecords()\ and matches dates
- Loading and error states with retry functionality
- Navigation with back button support

## Build Status
✅ Build successful (\ssembleDebug\) with no errors

## Screenshots
(To be added during review)

## Testing Notes  
- Navigate to history screen (placeholder currently)
- Tap a workout to see detail screen
- Should show all workout data, highlight PRs with green accent
- Back button should return to history list