### PR TITLE
Custom Exercise Creation

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -43,6 +43,7 @@ import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.ExerciseCategory
 import com.gymbro.core.model.MuscleGroup
 import com.gymbro.core.preferences.UserPreferences
+import com.gymbro.feature.exerciselibrary.CreateExerciseRoute
 import com.gymbro.feature.exerciselibrary.ExerciseLibraryRoute
 import com.gymbro.feature.history.HistoryDetailRoute
 import com.gymbro.feature.onboarding.OnboardingRoute
@@ -131,12 +132,22 @@ fun GymBroNavGraph(
                         onNavigateToDetail = { exerciseId ->
                             navController.navigate("exercise_detail/$exerciseId")
                         },
+                        onNavigateToCreateExercise = {
+                            navController.navigate("create_exercise")
+                        },
                     )
                 }
             }
         }
         composable("exercise_detail/{exerciseId}") {
             PlaceholderScreen(title = "Exercise Detail")
+        }
+        composable("create_exercise") {
+            CreateExerciseRoute(
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
+            )
         }
         composable("active_workout") { backStackEntry ->
             val savedStateHandle = backStackEntry.savedStateHandle

--- a/android/core/src/main/java/com/gymbro/core/database/dao/package-info.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/dao/package-info.kt
@@ -42,4 +42,7 @@ interface ExerciseDao {
 
     @Query("SELECT COUNT(*) FROM exercises")
     suspend fun count(): Int
+
+    @Query("SELECT COUNT(*) FROM exercises WHERE name = :name")
+    suspend fun countExercisesByName(name: String): Int
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepository.kt
@@ -7,4 +7,6 @@ interface ExerciseRepository {
     fun getAllExercises(): Flow<List<Exercise>>
     fun getFilteredExercises(muscleGroup: String?, query: String?): Flow<List<Exercise>>
     suspend fun getExerciseById(id: String): Exercise?
+    suspend fun addExercise(exercise: Exercise)
+    suspend fun isExerciseNameTaken(name: String): Boolean
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/ExerciseRepositoryImpl.kt
@@ -25,6 +25,13 @@ class ExerciseRepositoryImpl @Inject constructor(
 
     override suspend fun getExerciseById(id: String): Exercise? =
         exerciseDao.getExerciseById(id)?.toDomain()
+
+    override suspend fun addExercise(exercise: Exercise) {
+        exerciseDao.insertExercise(exercise.toEntity())
+    }
+
+    override suspend fun isExerciseNameTaken(name: String): Boolean =
+        exerciseDao.countExercisesByName(name) > 0
 }
 
 private fun ExerciseEntity.toDomain(): Exercise = Exercise(
@@ -33,6 +40,16 @@ private fun ExerciseEntity.toDomain(): Exercise = Exercise(
     muscleGroup = MuscleGroup.entries.find { it.name == muscleGroup } ?: MuscleGroup.FULL_BODY,
     category = ExerciseCategory.entries.find { it.name == category } ?: ExerciseCategory.COMPOUND,
     equipment = Equipment.entries.find { it.name == equipment } ?: Equipment.OTHER,
+    description = description,
+    youtubeUrl = youtubeUrl,
+)
+
+private fun Exercise.toEntity(): ExerciseEntity = ExerciseEntity(
+    id = id.toString(),
+    name = name,
+    muscleGroup = muscleGroup.name,
+    category = category.name,
+    equipment = equipment.name,
     description = description,
     youtubeUrl = youtubeUrl,
 )

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/CreateExerciseContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/CreateExerciseContract.kt
@@ -1,0 +1,31 @@
+package com.gymbro.feature.exerciselibrary
+
+import com.gymbro.core.error.UiError
+import com.gymbro.core.model.ExerciseCategory
+import com.gymbro.core.model.Equipment
+import com.gymbro.core.model.MuscleGroup
+
+data class CreateExerciseState(
+    val exerciseName: String = "",
+    val selectedMuscleGroup: MuscleGroup = MuscleGroup.CHEST,
+    val selectedCategory: ExerciseCategory = ExerciseCategory.COMPOUND,
+    val selectedEquipment: Equipment = Equipment.BARBELL,
+    val description: String = "",
+    val isLoading: Boolean = false,
+    val error: UiError? = null,
+    val nameError: String? = null,
+)
+
+sealed interface CreateExerciseEvent {
+    data class NameChanged(val name: String) : CreateExerciseEvent
+    data class MuscleGroupSelected(val muscleGroup: MuscleGroup) : CreateExerciseEvent
+    data class CategorySelected(val category: ExerciseCategory) : CreateExerciseEvent
+    data class EquipmentSelected(val equipment: Equipment) : CreateExerciseEvent
+    data class DescriptionChanged(val description: String) : CreateExerciseEvent
+    data object SaveClicked : CreateExerciseEvent
+    data object CancelClicked : CreateExerciseEvent
+}
+
+sealed interface CreateExerciseEffect {
+    data object NavigateBack : CreateExerciseEffect
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/CreateExerciseScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/CreateExerciseScreen.kt
@@ -1,0 +1,362 @@
+package com.gymbro.feature.exerciselibrary
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gymbro.core.model.ExerciseCategory
+import com.gymbro.core.model.Equipment
+import com.gymbro.core.model.MuscleGroup
+import com.gymbro.feature.common.FullScreenLoading
+import com.gymbro.feature.common.ObserveErrors
+
+private val AccentGreen = Color(0xFF00FF87)
+
+@Composable
+fun CreateExerciseRoute(
+    viewModel: CreateExerciseViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit = {},
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    ObserveErrors(
+        errorFlow = viewModel.errorEvents,
+        snackbarHostState = snackbarHostState
+    )
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is CreateExerciseEffect.NavigateBack -> {
+                    onNavigateBack()
+                }
+            }
+        }
+    }
+
+    CreateExerciseScreen(
+        state = state.value,
+        onEvent = viewModel::onEvent,
+        snackbarHostState = snackbarHostState,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun CreateExerciseScreen(
+    state: CreateExerciseState,
+    onEvent: (CreateExerciseEvent) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Create Exercise",
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { onEvent(CreateExerciseEvent.CancelClicked) }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { innerPadding ->
+        if (state.isLoading) {
+            FullScreenLoading(message = "Creating exercise...")
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .imePadding()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                ) {
+                    // Exercise Name
+                    Column {
+                        Text(
+                            text = "Exercise Name",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        OutlinedTextField(
+                            value = state.exerciseName,
+                            onValueChange = { onEvent(CreateExerciseEvent.NameChanged(it)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            placeholder = {
+                                Text(
+                                    "e.g. Dumbbell Chest Press",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            },
+                            isError = state.nameError != null,
+                            supportingText = state.nameError?.let { { Text(it) } },
+                            singleLine = true,
+                            shape = RoundedCornerShape(12.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = AccentGreen,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.surfaceVariant,
+                                cursorColor = AccentGreen,
+                                focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                errorBorderColor = Color(0xFFCF6679),
+                            ),
+                        )
+                    }
+
+                    // Muscle Group
+                    Column {
+                        Text(
+                            text = "Muscle Group",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            MuscleGroup.entries.forEach { group ->
+                                val isSelected = state.selectedMuscleGroup == group
+                                FilterChip(
+                                    selected = isSelected,
+                                    onClick = {
+                                        onEvent(CreateExerciseEvent.MuscleGroupSelected(group))
+                                    },
+                                    label = { Text(group.displayName, fontSize = 13.sp) },
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        containerColor = MaterialTheme.colorScheme.surface,
+                                        labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        selectedContainerColor = AccentGreen.copy(alpha = 0.15f),
+                                        selectedLabelColor = AccentGreen,
+                                    ),
+                                    border = FilterChipDefaults.filterChipBorder(
+                                        borderColor = MaterialTheme.colorScheme.surfaceVariant,
+                                        selectedBorderColor = AccentGreen.copy(alpha = 0.5f),
+                                        enabled = true,
+                                        selected = isSelected,
+                                    ),
+                                )
+                            }
+                        }
+                    }
+
+                    // Category
+                    Column {
+                        Text(
+                            text = "Category",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            ExerciseCategory.entries.forEach { category ->
+                                val isSelected = state.selectedCategory == category
+                                FilterChip(
+                                    selected = isSelected,
+                                    onClick = {
+                                        onEvent(CreateExerciseEvent.CategorySelected(category))
+                                    },
+                                    label = { Text(category.displayName, fontSize = 13.sp) },
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        containerColor = MaterialTheme.colorScheme.surface,
+                                        labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        selectedContainerColor = AccentGreen.copy(alpha = 0.15f),
+                                        selectedLabelColor = AccentGreen,
+                                    ),
+                                    border = FilterChipDefaults.filterChipBorder(
+                                        borderColor = MaterialTheme.colorScheme.surfaceVariant,
+                                        selectedBorderColor = AccentGreen.copy(alpha = 0.5f),
+                                        enabled = true,
+                                        selected = isSelected,
+                                    ),
+                                )
+                            }
+                        }
+                    }
+
+                    // Equipment
+                    Column {
+                        Text(
+                            text = "Equipment",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Equipment.entries.forEach { equipment ->
+                                val isSelected = state.selectedEquipment == equipment
+                                FilterChip(
+                                    selected = isSelected,
+                                    onClick = {
+                                        onEvent(CreateExerciseEvent.EquipmentSelected(equipment))
+                                    },
+                                    label = {
+                                        Text(
+                                            equipment.name.lowercase().replaceFirstChar { it.uppercase() },
+                                            fontSize = 13.sp,
+                                        )
+                                    },
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        containerColor = MaterialTheme.colorScheme.surface,
+                                        labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        selectedContainerColor = AccentGreen.copy(alpha = 0.15f),
+                                        selectedLabelColor = AccentGreen,
+                                    ),
+                                    border = FilterChipDefaults.filterChipBorder(
+                                        borderColor = MaterialTheme.colorScheme.surfaceVariant,
+                                        selectedBorderColor = AccentGreen.copy(alpha = 0.5f),
+                                        enabled = true,
+                                        selected = isSelected,
+                                    ),
+                                )
+                            }
+                        }
+                    }
+
+                    // Description (Optional)
+                    Column {
+                        Text(
+                            text = "Description (Optional)",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        OutlinedTextField(
+                            value = state.description,
+                            onValueChange = { onEvent(CreateExerciseEvent.DescriptionChanged(it)) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(120.dp),
+                            placeholder = {
+                                Text(
+                                    "Add notes about form, cues, or variations...",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            },
+                            maxLines = 5,
+                            shape = RoundedCornerShape(12.dp),
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = AccentGreen,
+                                unfocusedBorderColor = MaterialTheme.colorScheme.surfaceVariant,
+                                cursorColor = AccentGreen,
+                                focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                            ),
+                        )
+                    }
+                }
+
+                // Action buttons
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { onEvent(CreateExerciseEvent.CancelClicked) },
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.onSurface,
+                        ),
+                    ) {
+                        Text("Cancel")
+                    }
+
+                    Button(
+                        onClick = { onEvent(CreateExerciseEvent.SaveClicked) },
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = AccentGreen,
+                            contentColor = Color.Black,
+                        ),
+                        enabled = state.exerciseName.isNotBlank(),
+                    ) {
+                        Text("Create Exercise", fontWeight = FontWeight.Bold)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/CreateExerciseViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/CreateExerciseViewModel.kt
@@ -1,0 +1,102 @@
+package com.gymbro.feature.exerciselibrary
+
+import androidx.lifecycle.viewModelScope
+import com.gymbro.core.model.Exercise
+import com.gymbro.core.repository.ExerciseRepository
+import com.gymbro.feature.common.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CreateExerciseViewModel @Inject constructor(
+    private val exerciseRepository: ExerciseRepository,
+) : BaseViewModel() {
+
+    private val _state = MutableStateFlow(CreateExerciseState())
+    val state: StateFlow<CreateExerciseState> = _state.asStateFlow()
+
+    private val _effect = Channel<CreateExerciseEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    fun onEvent(event: CreateExerciseEvent) {
+        when (event) {
+            is CreateExerciseEvent.NameChanged -> {
+                _state.update { it.copy(exerciseName = event.name, nameError = null) }
+            }
+            is CreateExerciseEvent.MuscleGroupSelected -> {
+                _state.update { it.copy(selectedMuscleGroup = event.muscleGroup) }
+            }
+            is CreateExerciseEvent.CategorySelected -> {
+                _state.update { it.copy(selectedCategory = event.category) }
+            }
+            is CreateExerciseEvent.EquipmentSelected -> {
+                _state.update { it.copy(selectedEquipment = event.equipment) }
+            }
+            is CreateExerciseEvent.DescriptionChanged -> {
+                _state.update { it.copy(description = event.description) }
+            }
+            is CreateExerciseEvent.SaveClicked -> {
+                saveExercise()
+            }
+            is CreateExerciseEvent.CancelClicked -> {
+                viewModelScope.launch {
+                    _effect.send(CreateExerciseEffect.NavigateBack)
+                }
+            }
+        }
+    }
+
+    private fun saveExercise() {
+        val currentState = _state.value
+        val name = currentState.exerciseName.trim()
+
+        if (name.isEmpty()) {
+            _state.update { it.copy(nameError = "Exercise name is required") }
+            return
+        }
+
+        safeLaunch(
+            onError = { error ->
+                _state.update { it.copy(isLoading = false) }
+                handleError(error) { saveExercise() }
+            }
+        ) {
+            _state.update { it.copy(isLoading = true) }
+
+            // Check if name already exists
+            if (exerciseRepository.isExerciseNameTaken(name)) {
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        nameError = "An exercise with this name already exists"
+                    )
+                }
+                return@safeLaunch
+            }
+
+            val exercise = Exercise(
+                name = name,
+                muscleGroup = currentState.selectedMuscleGroup,
+                category = currentState.selectedCategory,
+                equipment = currentState.selectedEquipment,
+                description = currentState.description.trim(),
+            )
+
+            exerciseRepository.addExercise(exercise)
+
+            _state.update { it.copy(isLoading = false) }
+            _effect.send(CreateExerciseEffect.NavigateBack)
+        }
+    }
+
+    override fun setLoading(loading: Boolean) {
+        _state.update { it.copy(isLoading = loading) }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -21,12 +21,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Scaffold
@@ -64,6 +66,7 @@ private val AccentRed = Color(0xFFCF6679)
 fun ExerciseLibraryRoute(
     viewModel: ExerciseLibraryViewModel = hiltViewModel(),
     onNavigateToDetail: (String) -> Unit = {},
+    onNavigateToCreateExercise: () -> Unit = {},
     onExercisePicked: ((Exercise) -> Unit)? = null,
     isPickerMode: Boolean = false,
 ) {
@@ -94,6 +97,7 @@ fun ExerciseLibraryRoute(
                 viewModel.onEvent(event)
             }
         },
+        onNavigateToCreateExercise = onNavigateToCreateExercise,
         isPickerMode = isPickerMode,
         snackbarHostState = snackbarHostState,
     )
@@ -104,6 +108,7 @@ fun ExerciseLibraryRoute(
 fun ExerciseLibraryScreen(
     state: ExerciseLibraryState,
     onEvent: (ExerciseLibraryEvent) -> Unit,
+    onNavigateToCreateExercise: () -> Unit = {},
     isPickerMode: Boolean = false,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
@@ -115,6 +120,17 @@ fun ExerciseLibraryScreen(
                         text = if (isPickerMode) "Pick Exercise" else "Exercise Library",
                         style = MaterialTheme.typography.headlineMedium,
                     )
+                },
+                actions = {
+                    if (!isPickerMode) {
+                        IconButton(onClick = onNavigateToCreateExercise) {
+                            Icon(
+                                Icons.Default.Add,
+                                contentDescription = "Create Exercise",
+                                tint = AccentGreen,
+                            )
+                        }
+                    }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,


### PR DESCRIPTION
Closes #168

Allow users to create their own exercises that appear in the exercise library alongside seeded ones.

## Changes

- **Created CreateExerciseContract, ViewModel, and Screen** for custom exercise creation
- **Added ExerciseDao method** countExercisesByName for duplicate checking
- **Enhanced ExerciseRepository** with ddExercise and isExerciseNameTaken methods
- **Created domain/entity conversion methods** for Exercise ↔ ExerciseEntity
- **Integrated navigation** from ExerciseLibrary with + icon in TopAppBar
- **Screen includes:**
  - Exercise name input (required, validated for uniqueness)
  - Muscle group selector (chips for all MuscleGroup enum values)
  - Category selector (Compound/Isolation/Accessory/Cardio)
  - Equipment selector (Barbell/Dumbbell/Cable/Machine/etc.)
  - Description field (optional)
  - Cancel/Create buttons

## Testing

Build successful: ./gradlew assembleDebug --no-daemon

Working as Tank (Backend Dev)