### PR TITLE
Workout Reminders and Notifications (WorkManager)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.hilt.work)
 
     // Firebase
     implementation(platform(libs.firebase.bom))

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />

--- a/android/app/src/main/java/com/gymbro/app/GymBroApplication.kt
+++ b/android/app/src/main/java/com/gymbro/app/GymBroApplication.kt
@@ -1,7 +1,51 @@
 package com.gymbro.app
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import com.gymbro.core.notification.NotificationHelper
+import com.gymbro.core.notification.ReminderScheduler
+import com.gymbro.core.preferences.UserPreferences
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltAndroidApp
-class GymBroApplication : Application()
+class GymBroApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject
+    lateinit var notificationHelper: NotificationHelper
+
+    @Inject
+    lateinit var reminderScheduler: ReminderScheduler
+
+    @Inject
+    lateinit var userPreferences: UserPreferences
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    override fun onCreate() {
+        super.onCreate()
+        
+        notificationHelper.createNotificationChannels()
+        
+        applicationScope.launch {
+            val notificationsEnabled = userPreferences.notificationsEnabled.first()
+            if (notificationsEnabled) {
+                reminderScheduler.scheduleWorkoutReminders()
+            }
+        }
+    }
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+}

--- a/android/core/build.gradle.kts
+++ b/android/core/build.gradle.kts
@@ -40,6 +40,11 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
+    // WorkManager with Hilt
+    implementation(libs.workmanager)
+    implementation(libs.hilt.work)
+    ksp(libs.hilt.compiler)
+
     // Room
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
@@ -59,6 +64,9 @@ dependencies {
 
     // DataStore
     implementation(libs.datastore.preferences)
+
+    // WorkManager
+    implementation(libs.workmanager)
 
     // Testing
     testImplementation(libs.junit)

--- a/android/core/src/main/java/com/gymbro/core/notification/NotificationHelper.kt
+++ b/android/core/src/main/java/com/gymbro/core/notification/NotificationHelper.kt
@@ -1,0 +1,78 @@
+package com.gymbro.core.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationHelper @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    companion object {
+        const val CHANNEL_WORKOUT_REMINDERS = "workout_reminders"
+        const val CHANNEL_PR_CELEBRATIONS = "pr_celebrations"
+        const val NOTIFICATION_ID_WORKOUT_REMINDER = 1001
+        private const val ACCENT_GREEN = 0xFF00FF87.toInt()
+    }
+
+    fun createNotificationChannels() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val workoutChannel = NotificationChannel(
+                CHANNEL_WORKOUT_REMINDERS,
+                "Workout Reminders",
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Get reminded to train and stay consistent"
+                enableLights(true)
+                lightColor = ACCENT_GREEN
+            }
+
+            val prChannel = NotificationChannel(
+                CHANNEL_PR_CELEBRATIONS,
+                "PR Celebrations",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Celebrate your personal records!"
+                enableLights(true)
+                lightColor = ACCENT_GREEN
+            }
+
+            notificationManager.createNotificationChannels(listOf(workoutChannel, prChannel))
+        }
+    }
+
+    fun showWorkoutReminder(title: String, message: String) {
+        val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_WORKOUT_REMINDERS)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setColor(ACCENT_GREEN)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_ID_WORKOUT_REMINDER, notification)
+    }
+
+    fun cancelWorkoutReminder() {
+        notificationManager.cancel(NOTIFICATION_ID_WORKOUT_REMINDER)
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/notification/ReminderScheduler.kt
+++ b/android/core/src/main/java/com/gymbro/core/notification/ReminderScheduler.kt
@@ -1,0 +1,47 @@
+package com.gymbro.core.notification
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReminderScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val workManager = WorkManager.getInstance(context)
+
+    companion object {
+        private const val WORK_NAME_WORKOUT_REMINDER = "workout_reminder_periodic"
+        private const val REPEAT_INTERVAL_HOURS = 24L
+    }
+
+    fun scheduleWorkoutReminders() {
+        val constraints = Constraints.Builder()
+            .setRequiresBatteryNotLow(false)
+            .build()
+
+        val workRequest = PeriodicWorkRequestBuilder<WorkoutReminderWorker>(
+            REPEAT_INTERVAL_HOURS,
+            TimeUnit.HOURS
+        )
+            .setConstraints(constraints)
+            .setInitialDelay(REPEAT_INTERVAL_HOURS, TimeUnit.HOURS)
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            WORK_NAME_WORKOUT_REMINDER,
+            ExistingPeriodicWorkPolicy.KEEP,
+            workRequest
+        )
+    }
+
+    fun cancelWorkoutReminders() {
+        workManager.cancelUniqueWork(WORK_NAME_WORKOUT_REMINDER)
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/notification/WorkoutReminderWorker.kt
+++ b/android/core/src/main/java/com/gymbro/core/notification/WorkoutReminderWorker.kt
@@ -1,0 +1,46 @@
+package com.gymbro.core.notification
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.gymbro.core.preferences.UserPreferences
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+
+@HiltWorker
+class WorkoutReminderWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val notificationHelper: NotificationHelper,
+    private val userPreferences: UserPreferences,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val notificationsEnabled = userPreferences.notificationsEnabled.first()
+            
+            if (!notificationsEnabled) {
+                return Result.success()
+            }
+
+            val motivationalMessages = listOf(
+                "Time to hit the gym! 💪",
+                "Your muscles are waiting for you!",
+                "Don't skip leg day bro! 🦵",
+                "Gains don't come from the couch!",
+                "Let's get those PRs! 🔥",
+                "The iron is calling! ⚡",
+                "Consistency is key! Let's train!",
+            )
+
+            val message = motivationalMessages.random()
+            notificationHelper.showWorkoutReminder("GymBro Reminder", message)
+
+            Result.success()
+        } catch (e: Exception) {
+            Result.failure()
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/settings/SettingsViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gymbro.core.notification.ReminderScheduler
 import com.gymbro.core.preferences.UserPreferences
 import com.gymbro.core.preferences.UserPreferences.WeightUnit
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,6 +23,7 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val userPreferences: UserPreferences,
+    private val reminderScheduler: ReminderScheduler,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SettingsState())
@@ -120,6 +122,11 @@ class SettingsViewModel @Inject constructor(
     private fun setNotifications(enabled: Boolean) {
         viewModelScope.launch {
             userPreferences.setNotificationsEnabled(enabled)
+            if (enabled) {
+                reminderScheduler.scheduleWorkoutReminders()
+            } else {
+                reminderScheduler.cancelWorkoutReminders()
+            }
         }
     }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "8.10.1"
 kotlin = "2.1.21"
 ksp = "2.1.21-2.0.1"
 hilt = "2.56.2"
+hilt-work = "1.2.0"
 room = "2.7.1"
 compose-bom = "2025.05.01"
 activity-compose = "1.10.1"
@@ -53,6 +54,7 @@ lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt-work" }
 
 # Room
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
Implements workout reminder notifications using WorkManager.

## Changes
- Added WorkManager and Hilt Work dependencies to version catalog and build files
- Created NotificationHelper for managing notification channels (workout reminders, PR celebrations) and displaying notifications with GymBro accent green
- Created WorkoutReminderWorker as a periodic worker that sends motivational reminder notifications
- Created ReminderScheduler to manage WorkManager periodic work scheduling (every 24 hours)
- Updated GymBroApplication to initialize notification channels on app startup and schedule initial reminders if notifications are enabled
- Wired SettingsViewModel to start/stop WorkManager reminders when user toggles notification preference
- Added POST_NOTIFICATIONS permission to AndroidManifest

## Testing
- Build successful: gradlew assembleDebug
- Notifications respect user preference toggle from Settings screen
- WorkManager uses unique work name to prevent duplicate scheduling

Closes #177