### PR TITLE
Add robust error handling and retry logic to Firebase sync

### DIFF
--- a/android/core/src/main/java/com/gymbro/core/sync/ConnectivityObserver.kt
+++ b/android/core/src/main/java/com/gymbro/core/sync/ConnectivityObserver.kt
@@ -1,0 +1,76 @@
+package com.gymbro.core.sync
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConnectivityObserver @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val connectivityManager = 
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+    
+    private val _onConnectivityRestored = MutableStateFlow(0L)
+    val onConnectivityRestored: StateFlow<Long> = _onConnectivityRestored.asStateFlow()
+    
+    init {
+        updateConnectivityState()
+        registerNetworkCallback()
+    }
+    
+    private fun updateConnectivityState() {
+        val activeNetwork = connectivityManager.activeNetwork
+        val capabilities = activeNetwork?.let { connectivityManager.getNetworkCapabilities(it) }
+        _isConnected.value = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+        Log.d(TAG, "Connectivity state: ${_isConnected.value}")
+    }
+    
+    private fun registerNetworkCallback() {
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        
+        connectivityManager.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                val wasOffline = !_isConnected.value
+                _isConnected.value = true
+                if (wasOffline) {
+                    _onConnectivityRestored.value = System.currentTimeMillis()
+                    Log.d(TAG, "Connectivity restored")
+                }
+            }
+            
+            override fun onLost(network: Network) {
+                _isConnected.value = false
+                Log.d(TAG, "Connectivity lost")
+            }
+            
+            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+                val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                val wasOffline = !_isConnected.value
+                _isConnected.value = hasInternet
+                if (hasInternet && wasOffline) {
+                    _onConnectivityRestored.value = System.currentTimeMillis()
+                    Log.d(TAG, "Connectivity restored (capabilities changed)")
+                }
+            }
+        })
+    }
+    
+    companion object {
+        private const val TAG = "ConnectivityObserver"
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/sync/model/SyncStatusModel.kt
+++ b/android/core/src/main/java/com/gymbro/core/sync/model/SyncStatusModel.kt
@@ -1,0 +1,9 @@
+package com.gymbro.core.sync.model
+
+sealed class SyncStatusModel {
+    object Idle : SyncStatusModel()
+    object Syncing : SyncStatusModel()
+    data class Error(val message: String, val retryable: Boolean = true) : SyncStatusModel()
+    data class Success(val lastSyncTimestamp: Long) : SyncStatusModel()
+    object Offline : SyncStatusModel()
+}

--- a/android/core/src/main/java/com/gymbro/core/sync/retry/RetryPolicy.kt
+++ b/android/core/src/main/java/com/gymbro/core/sync/retry/RetryPolicy.kt
@@ -1,0 +1,122 @@
+package com.gymbro.core.sync.retry
+
+import android.util.Log
+import com.google.firebase.FirebaseException
+import com.google.firebase.FirebaseNetworkException
+import com.google.firebase.auth.FirebaseAuthException
+import com.google.firebase.firestore.FirebaseFirestoreException
+import kotlinx.coroutines.delay
+import java.io.IOException
+import java.net.SocketException
+import java.net.UnknownHostException
+import java.util.concurrent.TimeoutException
+import kotlin.math.pow
+
+data class RetryConfig(
+    val maxRetries: Int = 3,
+    val initialDelayMs: Long = 1000L,
+    val maxDelayMs: Long = 8000L,
+    val backoffMultiplier: Double = 2.0
+)
+
+sealed class RetryableError {
+    data class Retryable(val cause: Throwable) : RetryableError()
+    data class Permanent(val cause: Throwable) : RetryableError()
+}
+
+fun Throwable.classifyError(): RetryableError {
+    return when (this) {
+        is UnknownHostException,
+        is SocketException,
+        is TimeoutException,
+        is IOException,
+        is FirebaseNetworkException -> RetryableError.Retryable(this)
+        
+        is FirebaseFirestoreException -> when (code) {
+            FirebaseFirestoreException.Code.UNAVAILABLE,
+            FirebaseFirestoreException.Code.DEADLINE_EXCEEDED,
+            FirebaseFirestoreException.Code.RESOURCE_EXHAUSTED,
+            FirebaseFirestoreException.Code.ABORTED,
+            FirebaseFirestoreException.Code.INTERNAL,
+            FirebaseFirestoreException.Code.UNKNOWN -> RetryableError.Retryable(this)
+            
+            FirebaseFirestoreException.Code.UNAUTHENTICATED,
+            FirebaseFirestoreException.Code.PERMISSION_DENIED,
+            FirebaseFirestoreException.Code.INVALID_ARGUMENT,
+            FirebaseFirestoreException.Code.NOT_FOUND,
+            FirebaseFirestoreException.Code.ALREADY_EXISTS,
+            FirebaseFirestoreException.Code.FAILED_PRECONDITION -> RetryableError.Permanent(this)
+            
+            else -> RetryableError.Permanent(this)
+        }
+        
+        is FirebaseAuthException -> when (errorCode) {
+            "ERROR_NETWORK_REQUEST_FAILED" -> RetryableError.Retryable(this)
+            "ERROR_USER_TOKEN_EXPIRED",
+            "ERROR_INVALID_CUSTOM_TOKEN",
+            "ERROR_CUSTOM_TOKEN_MISMATCH",
+            "ERROR_INVALID_CREDENTIAL" -> RetryableError.Permanent(this)
+            else -> RetryableError.Permanent(this)
+        }
+        
+        is FirebaseException -> {
+            if (message?.contains("network", ignoreCase = true) == true ||
+                message?.contains("timeout", ignoreCase = true) == true) {
+                RetryableError.Retryable(this)
+            } else {
+                RetryableError.Permanent(this)
+            }
+        }
+        
+        else -> {
+            val msg = message ?: ""
+            when {
+                msg.contains("network", ignoreCase = true) ||
+                msg.contains("timeout", ignoreCase = true) ||
+                msg.contains("connection", ignoreCase = true) -> RetryableError.Retryable(this)
+                msg.contains("auth", ignoreCase = true) ||
+                msg.contains("permission", ignoreCase = true) ||
+                msg.contains("invalid", ignoreCase = true) -> RetryableError.Permanent(this)
+                else -> RetryableError.Retryable(this)
+            }
+        }
+    }
+}
+
+suspend fun <T> retryWithBackoff(
+    config: RetryConfig = RetryConfig(),
+    operation: String = "operation",
+    block: suspend () -> T
+): Result<T> {
+    var lastException: Throwable? = null
+    
+    repeat(config.maxRetries + 1) { attempt ->
+        try {
+            return Result.success(block())
+        } catch (e: Exception) {
+            lastException = e
+            
+            val errorType = e.classifyError()
+            if (errorType is RetryableError.Permanent) {
+                Log.w(TAG, "Permanent error for $operation, not retrying: ${e.message}")
+                return Result.failure(e)
+            }
+            
+            if (attempt < config.maxRetries) {
+                val delayMs = (config.initialDelayMs * config.backoffMultiplier.pow(attempt))
+                    .toLong()
+                    .coerceAtMost(config.maxDelayMs)
+                
+                Log.w(TAG, "Retry $operation: attempt ${attempt + 1}/${config.maxRetries + 1} failed, " +
+                        "retrying in ${delayMs}ms: ${e.message}")
+                delay(delayMs)
+            } else {
+                Log.e(TAG, "Retry $operation: all ${config.maxRetries + 1} attempts failed", e)
+            }
+        }
+    }
+    
+    return Result.failure(lastException ?: Exception("Unknown error"))
+}
+
+private const val TAG = "RetryPolicy"

--- a/android/core/src/main/java/com/gymbro/core/sync/service/FirestoreSyncService.kt
+++ b/android/core/src/main/java/com/gymbro/core/sync/service/FirestoreSyncService.kt
@@ -7,9 +7,12 @@ import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.SetOptions
 import com.gymbro.core.database.dao.ExerciseDao
 import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.sync.ConnectivityObserver
 import com.gymbro.core.sync.model.FirestoreUserProfile
 import com.gymbro.core.sync.model.toFirestoreExercise
 import com.gymbro.core.sync.model.toFirestoreWorkout
+import com.gymbro.core.sync.retry.RetryConfig
+import com.gymbro.core.sync.retry.retryWithBackoff
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,6 +28,7 @@ class FirestoreSyncService @Inject constructor(
     private val auth: FirebaseAuth,
     private val workoutDao: WorkoutDao,
     private val exerciseDao: ExerciseDao,
+    private val connectivityObserver: ConnectivityObserver,
 ) : CloudSyncService {
 
     private val _syncStatus = MutableStateFlow(SyncStatus.IDLE)
@@ -33,63 +37,100 @@ class FirestoreSyncService @Inject constructor(
     private val userId: String?
         get() = auth.currentUser?.uid
 
-    override suspend fun syncExercises(): Result<Unit> = runCatching {
-        val uid = userId ?: throw IllegalStateException("User not signed in")
-        _syncStatus.value = SyncStatus.SYNCING
-
-        val exercises = exerciseDao.getAllExercises().first()
-        val batch = firestore.batch()
-
-        exercises.forEach { entity ->
-            val firestoreExercise = entity.toFirestoreExercise(deviceId)
-            val docRef = firestore.collection("users").document(uid)
-                .collection("exercises").document(entity.id)
-            batch.set(docRef, firestoreExercise, SetOptions.merge())
+    override suspend fun syncExercises(): Result<Unit> {
+        if (!connectivityObserver.isConnected.value) {
+            _syncStatus.value = SyncStatus.OFFLINE
+            return Result.failure(Exception("No network connection"))
         }
-
-        batch.commit().await()
-        _syncStatus.value = SyncStatus.SUCCESS
-    }.onFailure {
-        Log.e(TAG, "syncExercises failed", it)
-        _syncStatus.value = SyncStatus.ERROR
-    }
-
-    override suspend fun syncWorkouts(): Result<Unit> = runCatching {
-        val uid = userId ?: throw IllegalStateException("User not signed in")
+        
         _syncStatus.value = SyncStatus.SYNCING
-
-        val workouts = workoutDao.getAllWorkoutsOnce()
-        val batch = firestore.batch()
-
-        workouts.forEach { workout ->
-            val sets = workoutDao.getSetsForWorkout(workout.id)
-            val firestoreWorkout = workout.toFirestoreWorkout(sets, deviceId)
-            val docRef = firestore.collection("users").document(uid)
-                .collection("workouts").document(workout.id)
-            batch.set(docRef, firestoreWorkout, SetOptions.merge())
-        }
-
-        batch.commit().await()
-        _syncStatus.value = SyncStatus.SUCCESS
-    }.onFailure {
-        Log.e(TAG, "syncWorkouts failed", it)
-        _syncStatus.value = SyncStatus.ERROR
-    }
-
-    override suspend fun syncUserProfile(profile: FirestoreUserProfile): Result<Unit> =
-        runCatching {
+        
+        return retryWithBackoff(
+            config = RetryConfig(maxRetries = 3, initialDelayMs = 1000L),
+            operation = "syncExercises"
+        ) {
             val uid = userId ?: throw IllegalStateException("User not signed in")
-            _syncStatus.value = SyncStatus.SYNCING
+            
+            val exercises = exerciseDao.getAllExercises().first()
+            val batch = firestore.batch()
 
+            exercises.forEach { entity ->
+                val firestoreExercise = entity.toFirestoreExercise(deviceId)
+                val docRef = firestore.collection("users").document(uid)
+                    .collection("exercises").document(entity.id)
+                batch.set(docRef, firestoreExercise, SetOptions.merge())
+            }
+
+            batch.commit().await()
+            Unit
+        }.onSuccess {
+            _syncStatus.value = SyncStatus.SUCCESS
+        }.onFailure {
+            Log.e(TAG, "syncExercises failed", it)
+            _syncStatus.value = SyncStatus.ERROR
+        }
+    }
+
+    override suspend fun syncWorkouts(): Result<Unit> {
+        if (!connectivityObserver.isConnected.value) {
+            _syncStatus.value = SyncStatus.OFFLINE
+            return Result.failure(Exception("No network connection"))
+        }
+        
+        _syncStatus.value = SyncStatus.SYNCING
+        
+        return retryWithBackoff(
+            config = RetryConfig(maxRetries = 3, initialDelayMs = 1000L),
+            operation = "syncWorkouts"
+        ) {
+            val uid = userId ?: throw IllegalStateException("User not signed in")
+            
+            val workouts = workoutDao.getAllWorkoutsOnce()
+            val batch = firestore.batch()
+
+            workouts.forEach { workout ->
+                val sets = workoutDao.getSetsForWorkout(workout.id)
+                val firestoreWorkout = workout.toFirestoreWorkout(sets, deviceId)
+                val docRef = firestore.collection("users").document(uid)
+                    .collection("workouts").document(workout.id)
+                batch.set(docRef, firestoreWorkout, SetOptions.merge())
+            }
+
+            batch.commit().await()
+            Unit
+        }.onSuccess {
+            _syncStatus.value = SyncStatus.SUCCESS
+        }.onFailure {
+            Log.e(TAG, "syncWorkouts failed", it)
+            _syncStatus.value = SyncStatus.ERROR
+        }
+    }
+
+    override suspend fun syncUserProfile(profile: FirestoreUserProfile): Result<Unit> {
+        if (!connectivityObserver.isConnected.value) {
+            _syncStatus.value = SyncStatus.OFFLINE
+            return Result.failure(Exception("No network connection"))
+        }
+        
+        _syncStatus.value = SyncStatus.SYNCING
+        
+        return retryWithBackoff(
+            config = RetryConfig(maxRetries = 3, initialDelayMs = 1000L),
+            operation = "syncUserProfile"
+        ) {
+            val uid = userId ?: throw IllegalStateException("User not signed in")
+            
             firestore.collection("users").document(uid)
                 .set(profile, SetOptions.merge())
                 .await()
-
+            Unit
+        }.onSuccess {
             _syncStatus.value = SyncStatus.SUCCESS
         }.onFailure {
             Log.e(TAG, "syncUserProfile failed", it)
             _syncStatus.value = SyncStatus.ERROR
         }
+    }
 
     override suspend fun resolveConflicts() {
         // MVP: last-write-wins based on updatedAt timestamp.

--- a/android/core/src/main/java/com/gymbro/core/sync/service/OfflineSyncManager.kt
+++ b/android/core/src/main/java/com/gymbro/core/sync/service/OfflineSyncManager.kt
@@ -1,23 +1,27 @@
 package com.gymbro.core.sync.service
 
 import android.content.Context
-import android.net.ConnectivityManager
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
+import android.content.SharedPreferences
 import android.util.Log
+import com.gymbro.core.sync.ConnectivityObserver
 import com.gymbro.core.sync.model.FirestoreUserProfile
+import com.gymbro.core.sync.model.SyncStatusModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
+
+sealed class SyncOperation {
+    data object Exercises : SyncOperation()
+    data object Workouts : SyncOperation()
+    data object Profile : SyncOperation()
+}
 
 /**
  * Queues sync operations when offline and flushes them when connectivity resumes.
@@ -27,33 +31,124 @@ import javax.inject.Singleton
 class OfflineSyncManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val cloudSyncService: CloudSyncService,
+    private val connectivityObserver: ConnectivityObserver,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val pendingQueue = Channel<SyncOperation>(Channel.UNLIMITED)
+    private val pendingQueue = mutableListOf<SyncOperation>()
+    private val prefs: SharedPreferences = context.getSharedPreferences("sync_queue", Context.MODE_PRIVATE)
+    
+    @Volatile
+    private var _pendingProfile: FirestoreUserProfile? = null
+    
+    private val _syncStatusModel = MutableStateFlow<SyncStatusModel>(SyncStatusModel.Idle)
+    val syncStatusModel: StateFlow<SyncStatusModel> = _syncStatusModel.asStateFlow()
 
-    private val _isOnline = MutableStateFlow(false)
-    val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+    val isOnline: StateFlow<Boolean> = connectivityObserver.isConnected
 
     private val _syncStatus = MutableStateFlow(SyncStatus.IDLE)
     val syncStatus: StateFlow<SyncStatus> = _syncStatus.asStateFlow()
 
     init {
-        monitorConnectivity()
-        processQueue()
+        loadQueueFromDisk()
+        observeConnectivity()
+    }
+
+    private fun loadQueueFromDisk() {
+        try {
+            val exercises = prefs.getBoolean("queue_exercises", false)
+            val workouts = prefs.getBoolean("queue_workouts", false)
+            val profile = prefs.getBoolean("queue_profile", false)
+            
+            synchronized(pendingQueue) {
+                pendingQueue.clear()
+                if (exercises) pendingQueue.add(SyncOperation.Exercises)
+                if (workouts) pendingQueue.add(SyncOperation.Workouts)
+                if (profile) pendingQueue.add(SyncOperation.Profile)
+            }
+            Log.d(TAG, "Loaded ${pendingQueue.size} operations from disk")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to load queue from disk", e)
+        }
+    }
+
+    private fun saveQueueToDisk() {
+        try {
+            val editor = prefs.edit()
+            var hasExercises = false
+            var hasWorkouts = false
+            var hasProfile = false
+            
+            synchronized(pendingQueue) {
+                pendingQueue.forEach { op ->
+                    when (op) {
+                        is SyncOperation.Exercises -> hasExercises = true
+                        is SyncOperation.Workouts -> hasWorkouts = true
+                        is SyncOperation.Profile -> hasProfile = true
+                    }
+                }
+            }
+            
+            editor.putBoolean("queue_exercises", hasExercises)
+            editor.putBoolean("queue_workouts", hasWorkouts)
+            editor.putBoolean("queue_profile", hasProfile)
+            editor.apply()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save queue to disk", e)
+        }
+    }
+
+    private fun observeConnectivity() {
+        scope.launch {
+            connectivityObserver.onConnectivityRestored.collect { timestamp ->
+                if (timestamp > 0) {
+                    Log.d(TAG, "Connectivity restored, flushing queue")
+                    cloudSyncService.resolveConflicts()
+                    processQueue()
+                }
+            }
+        }
     }
 
     fun queueExerciseSync() {
-        pendingQueue.trySend(SyncOperation.EXERCISES)
+        addToQueue(SyncOperation.Exercises)
     }
 
     fun queueWorkoutSync() {
-        pendingQueue.trySend(SyncOperation.WORKOUTS)
+        addToQueue(SyncOperation.Workouts)
     }
 
     fun queueProfileSync(profile: FirestoreUserProfile) {
-        pendingQueue.trySend(SyncOperation.PROFILE)
-        // Store profile for when we actually process
         _pendingProfile = profile
+        addToQueue(SyncOperation.Profile)
+    }
+
+    private fun addToQueue(operation: SyncOperation) {
+        synchronized(pendingQueue) {
+            val alreadyQueued = pendingQueue.any { existing ->
+                when {
+                    existing is SyncOperation.Exercises && operation is SyncOperation.Exercises -> true
+                    existing is SyncOperation.Workouts && operation is SyncOperation.Workouts -> true
+                    existing is SyncOperation.Profile && operation is SyncOperation.Profile -> true
+                    else -> false
+                }
+            }
+            
+            if (!alreadyQueued) {
+                if (pendingQueue.size >= MAX_QUEUE_SIZE) {
+                    Log.w(TAG, "Queue at max size ($MAX_QUEUE_SIZE), removing oldest operation")
+                    pendingQueue.removeAt(0)
+                }
+                pendingQueue.add(operation)
+                saveQueueToDisk()
+            }
+        }
+        
+        if (connectivityObserver.isConnected.value) {
+            processQueue()
+        } else {
+            _syncStatus.value = SyncStatus.OFFLINE
+            _syncStatusModel.value = SyncStatusModel.Offline
+        }
     }
 
     fun syncNow() {
@@ -61,24 +156,31 @@ class OfflineSyncManager @Inject constructor(
         queueWorkoutSync()
     }
 
-    @Volatile
-    private var _pendingProfile: FirestoreUserProfile? = null
-
     private fun processQueue() {
         scope.launch {
-            for (operation in pendingQueue) {
-                if (!_isOnline.value) {
+            synchronized(pendingQueue) {
+                if (pendingQueue.isEmpty()) return@launch
+            }
+            
+            while (true) {
+                val operation = synchronized(pendingQueue) {
+                    pendingQueue.firstOrNull()
+                } ?: break
+                
+                if (!connectivityObserver.isConnected.value) {
                     _syncStatus.value = SyncStatus.OFFLINE
-                    // Re-queue and wait for connectivity
-                    pendingQueue.trySend(operation)
-                    continue
+                    _syncStatusModel.value = SyncStatusModel.Offline
+                    Log.d(TAG, "No connectivity, pausing queue processing")
+                    break
                 }
 
                 _syncStatus.value = SyncStatus.SYNCING
+                _syncStatusModel.value = SyncStatusModel.Syncing
+                
                 val result = when (operation) {
-                    SyncOperation.EXERCISES -> cloudSyncService.syncExercises()
-                    SyncOperation.WORKOUTS -> cloudSyncService.syncWorkouts()
-                    SyncOperation.PROFILE -> {
+                    is SyncOperation.Exercises -> cloudSyncService.syncExercises()
+                    is SyncOperation.Workouts -> cloudSyncService.syncWorkouts()
+                    is SyncOperation.Profile -> {
                         val profile = _pendingProfile
                         if (profile != null) {
                             cloudSyncService.syncUserProfile(profile)
@@ -88,51 +190,30 @@ class OfflineSyncManager @Inject constructor(
                     }
                 }
 
-                _syncStatus.value = if (result.isSuccess) {
-                    SyncStatus.SUCCESS
+                if (result.isSuccess) {
+                    synchronized(pendingQueue) {
+                        pendingQueue.remove(operation)
+                        saveQueueToDisk()
+                    }
+                    _syncStatus.value = SyncStatus.SUCCESS
+                    _syncStatusModel.value = SyncStatusModel.Success(System.currentTimeMillis())
+                    Log.d(TAG, "Sync operation succeeded: $operation")
                 } else {
-                    Log.e(TAG, "Sync failed for $operation", result.exceptionOrNull())
-                    SyncStatus.ERROR
+                    val error = result.exceptionOrNull()
+                    Log.e(TAG, "Sync failed for $operation", error)
+                    _syncStatus.value = SyncStatus.ERROR
+                    _syncStatusModel.value = SyncStatusModel.Error(
+                        message = error?.message ?: "Unknown error",
+                        retryable = true
+                    )
+                    break
                 }
             }
         }
     }
 
-    private fun monitorConnectivity() {
-        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-
-        // Check current state
-        val activeNetwork = cm.activeNetwork
-        val capabilities = activeNetwork?.let { cm.getNetworkCapabilities(it) }
-        _isOnline.value = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
-
-        val request = NetworkRequest.Builder()
-            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            .build()
-
-        cm.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                _isOnline.value = true
-                // Flush pending operations
-                scope.launch {
-                    cloudSyncService.resolveConflicts()
-                }
-            }
-
-            override fun onLost(network: Network) {
-                _isOnline.value = false
-                _syncStatus.value = SyncStatus.OFFLINE
-            }
-        })
-    }
-
-    private enum class SyncOperation {
-        EXERCISES,
-        WORKOUTS,
-        PROFILE,
-    }
-
     companion object {
         private const val TAG = "OfflineSyncManager"
+        private const val MAX_QUEUE_SIZE = 100
     }
 }


### PR DESCRIPTION
Closes #182

## Summary
Implements robust error handling and retry logic for Firebase sync services with exponential backoff, connectivity awareness, and persistent queue management.

## Changes
- **ConnectivityObserver**: Monitors network state and auto-triggers sync when connectivity is restored
- **RetryPolicy**: Exponential backoff (1s, 2s, 4s, max 3 retries) with error classification
  - Retryable: network timeouts, server errors, unavailable services
  - Permanent: auth expired, permission denied, invalid arguments
- **FirestoreSyncService**: Network checks before sync attempts, retry logic for all sync operations
- **OfflineSyncManager**: Persistent queue using SharedPreferences, survives app restarts, max queue size (100)
- **SyncStatusModel**: Detailed sync status reporting (Idle, Syncing, Error with message, Success with timestamp, Offline)

## Testing
- ✅ Build: \ssembleDebug\ succeeds
- Queue persistence across app restarts
- Auto-retry on transient errors
- Auto-flush on connectivity restore