### PR TITLE
Home Screen Widgets

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -109,6 +109,10 @@ dependencies {
     // Background work
     implementation(libs.workmanager)
 
+    // Glance (Widgets)
+    implementation(libs.glance.appwidget)
+    implementation(libs.glance.material3)
+
     // Coroutines
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.android)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,30 @@
                 android:name="health_permissions"
                 android:resource="@array/health_permissions" />
         </activity>
+
+        <!-- Quick Start Widget -->
+        <receiver
+            android:name=".widget.QuickStartWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/quick_start_widget_info" />
+        </receiver>
+
+        <!-- Stats Widget -->
+        <receiver
+            android:name=".widget.StatsWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/stats_widget_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/gymbro/app/widget/QuickStartWidget.kt
+++ b/android/app/src/main/java/com/gymbro/app/widget/QuickStartWidget.kt
@@ -1,0 +1,123 @@
+package com.gymbro.app.widget
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.glance.ColorFilter
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.currentState
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.gymbro.app.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+class QuickStartWidget : GlanceAppWidget() {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            GlanceTheme {
+                QuickStartContent()
+            }
+        }
+    }
+
+    @Composable
+    private fun QuickStartContent() {
+        val daysSinceLastWorkout = currentState(DAYS_SINCE_KEY) ?: 0
+
+        Column(
+            modifier = GlanceModifier.fillMaxSize()
+        ) {
+            Box(
+                modifier = GlanceModifier
+                    .fillMaxWidth()
+                    .defaultWeight()
+                    .background(androidx.compose.ui.graphics.Color(0xFF141414))
+                    .cornerRadius(16.dp)
+                    .padding(16.dp)
+                    .clickable(
+                        onClick = actionStartActivity(
+                            Intent(
+                                Intent.ACTION_VIEW,
+                                null,
+                                null,
+                                MainActivity::class.java
+                            ).apply {
+                                putExtra("destination", "active_workout")
+                            }
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = GlanceModifier.fillMaxSize()
+                ) {
+                    // Title
+                    Text(
+                        text = "Start Workout",
+                        style = TextStyle(
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = ColorProvider(androidx.compose.ui.graphics.Color.White)
+                        )
+                    )
+
+                    Spacer(modifier = GlanceModifier.height(4.dp))
+
+                    // Days since last workout
+                    if (daysSinceLastWorkout > 0) {
+                        Text(
+                            text = "$daysSinceLastWorkout ${if (daysSinceLastWorkout == 1) "day" else "days"} since last workout",
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                color = ColorProvider(androidx.compose.ui.graphics.Color(0xFF9E9E9E))
+                            )
+                        )
+                    }
+                }
+            }
+
+            // Accent bar at bottom
+            Box(
+                modifier = GlanceModifier
+                    .fillMaxWidth()
+                    .height(4.dp)
+                    .background(androidx.compose.ui.graphics.Color(0xFF00FF87))
+            ) {}
+        }
+    }
+
+    companion object {
+        val DAYS_SINCE_KEY = intPreferencesKey("days_since_last_workout")
+    }
+}
+
+@AndroidEntryPoint
+class QuickStartWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = QuickStartWidget()
+}

--- a/android/app/src/main/java/com/gymbro/app/widget/StatsWidget.kt
+++ b/android/app/src/main/java/com/gymbro/app/widget/StatsWidget.kt
@@ -1,0 +1,173 @@
+package com.gymbro.app.widget
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.currentState
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextAlign
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.gymbro.app.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+class StatsWidget : GlanceAppWidget() {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            GlanceTheme {
+                StatsContent()
+            }
+        }
+    }
+
+    @Composable
+    private fun StatsContent() {
+        val workoutsThisWeek = currentState(WORKOUTS_WEEK_KEY) ?: 0
+        val totalVolume = currentState(TOTAL_VOLUME_KEY) ?: 0.0
+        val streakCount = currentState(STREAK_KEY) ?: 0
+
+        Box(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(androidx.compose.ui.graphics.Color(0xFF141414))
+                .cornerRadius(16.dp)
+                .padding(16.dp)
+                .clickable(
+                    onClick = actionStartActivity(
+                        Intent(
+                            Intent.ACTION_VIEW,
+                            null,
+                            null,
+                            MainActivity::class.java
+                        ).apply {
+                            putExtra("destination", "history")
+                        }
+                    )
+                )
+        ) {
+            Column(
+                modifier = GlanceModifier.fillMaxSize()
+            ) {
+                // Header
+                Text(
+                    text = "Weekly Stats",
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = ColorProvider(androidx.compose.ui.graphics.Color.White)
+                    )
+                )
+
+                Spacer(modifier = GlanceModifier.height(12.dp))
+
+                // Stats Grid
+                Row(
+                    modifier = GlanceModifier.fillMaxWidth()
+                ) {
+                    StatItem(
+                        label = "Workouts",
+                        value = "$workoutsThisWeek",
+                        accentColor = ColorProvider(androidx.compose.ui.graphics.Color(0xFF00FF87)),
+                        modifier = GlanceModifier.defaultWeight()
+                    )
+
+                    Spacer(modifier = GlanceModifier.width(8.dp))
+
+                    StatItem(
+                        label = "Volume (kg)",
+                        value = "${totalVolume.toInt()}",
+                        accentColor = ColorProvider(androidx.compose.ui.graphics.Color(0xFF00D4FF)),
+                        modifier = GlanceModifier.defaultWeight()
+                    )
+                }
+
+                Spacer(modifier = GlanceModifier.height(8.dp))
+
+                // Streak
+                Row(
+                    modifier = GlanceModifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    StatItem(
+                        label = "Streak",
+                        value = "$streakCount days",
+                        accentColor = ColorProvider(androidx.compose.ui.graphics.Color(0xFFFFB800)),
+                        modifier = GlanceModifier.defaultWeight()
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun StatItem(
+        label: String,
+        value: String,
+        accentColor: ColorProvider,
+        modifier: GlanceModifier = GlanceModifier
+    ) {
+        Column(
+            modifier = modifier
+                .background(androidx.compose.ui.graphics.Color(0xFF1C1C1E))
+                .cornerRadius(12.dp)
+                .padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = label,
+                style = TextStyle(
+                    fontSize = 11.sp,
+                    color = ColorProvider(androidx.compose.ui.graphics.Color(0xFF9E9E9E))
+                )
+            )
+
+            Spacer(modifier = GlanceModifier.height(4.dp))
+
+            Text(
+                text = value,
+                style = TextStyle(
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = accentColor
+                )
+            )
+        }
+    }
+
+    companion object {
+        val WORKOUTS_WEEK_KEY = intPreferencesKey("workouts_this_week")
+        val TOTAL_VOLUME_KEY = doublePreferencesKey("total_volume")
+        val STREAK_KEY = intPreferencesKey("streak_count")
+    }
+}
+
+@AndroidEntryPoint
+class StatsWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = StatsWidget()
+}

--- a/android/app/src/main/res/layout/quick_start_widget.xml
+++ b/android/app/src/main/res/layout/quick_start_widget.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#141414">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="GymBro"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp" />
+
+</FrameLayout>

--- a/android/app/src/main/res/layout/stats_widget.xml
+++ b/android/app/src/main/res/layout/stats_widget.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#141414">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="Stats"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp" />
+
+</FrameLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">GymBro</string>
+    <string name="quick_start_widget_description">Quick access to start a workout</string>
+    <string name="stats_widget_description">View your weekly workout stats</string>
 </resources>

--- a/android/app/src/main/res/xml/quick_start_widget_info.xml
+++ b/android/app/src/main/res/xml/quick_start_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/quick_start_widget_description"
+    android:initialKeyguardLayout="@layout/quick_start_widget"
+    android:initialLayout="@layout/quick_start_widget"
+    android:minWidth="110dp"
+    android:minHeight="40dp"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen" />

--- a/android/app/src/main/res/xml/stats_widget_info.xml
+++ b/android/app/src/main/res/xml/stats_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/stats_widget_description"
+    android:initialKeyguardLayout="@layout/stats_widget"
+    android:initialLayout="@layout/stats_widget"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen" />

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ workmanager = "2.10.1"
 hilt-navigation-compose = "1.2.0"
 core-ktx = "1.16.0"
 datastore = "1.1.1"
+glance = "1.1.1"
 firebase-bom = "33.15.0"
 google-services = "4.4.2"
 junit = "4.13.2"
@@ -79,6 +80,10 @@ workmanager = { group = "androidx.work", name = "work-runtime-ktx", version.ref 
 
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+
+# Glance
+glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glance" }
+glance-material3 = { group = "androidx.glance", name = "glance-material3", version.ref = "glance" }
 
 # Coroutines
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
Closes #178

## Summary
Created Android home screen widgets using Glance (Jetpack Compose for widgets).

## Changes
- Added Glance dependencies (androidx.glance 1.1.1)
- Created QuickStartWidget (2x1): Shows 'Start Workout' button with days since last workout
- Created StatsWidget (3x2): Shows weekly summary - workouts, volume, streak
- Registered widget receivers in AndroidManifest.xml
- Used GymBro dark theme colors (#141414 background, #00FF87 accent green)
- Widgets tap to open app at active_workout/history screens

## Testing
- Build succeeds: \ssembleDebug\ completed successfully
- Widgets follow GymBro visual design
- Navigation intents configured for MainActivity deep links