### PR TITLE
fix: handle missing Firebase gracefully — prevent crash without google-services.json

### DIFF
--- a/android/core/src/main/java/com/gymbro/core/auth/FirebaseAuthService.kt
+++ b/android/core/src/main/java/com/gymbro/core/auth/FirebaseAuthService.kt
@@ -12,11 +12,12 @@ import javax.inject.Singleton
 
 @Singleton
 class FirebaseAuthService @Inject constructor(
-    private val firebaseAuth: FirebaseAuth,
+    private val firebaseAuth: FirebaseAuth?,
 ) : AuthService {
 
     override suspend fun signInAnonymously(): Result<GymBroUser> = runCatching {
-        val result = firebaseAuth.signInAnonymously().await()
+        val auth = firebaseAuth ?: throw IllegalStateException("Firebase is not configured")
+        val result = auth.signInAnonymously().await()
         result.user?.toGymBroUser()
             ?: throw IllegalStateException("Anonymous sign-in returned null user")
     }.onFailure {
@@ -24,15 +25,23 @@ class FirebaseAuthService @Inject constructor(
     }
 
     override suspend fun signOut(): Result<Unit> = runCatching {
-        firebaseAuth.signOut()
+        val auth = firebaseAuth ?: throw IllegalStateException("Firebase is not configured")
+        auth.signOut()
     }
 
     override fun getCurrentUser(): GymBroUser? =
-        firebaseAuth.currentUser?.toGymBroUser()
+        firebaseAuth?.currentUser?.toGymBroUser()
 
     override fun observeAuthState(): Flow<AuthState> = callbackFlow {
-        val listener = FirebaseAuth.AuthStateListener { auth ->
-            val user = auth.currentUser
+        val auth = firebaseAuth
+        if (auth == null) {
+            trySend(AuthState.SignedOut)
+            close()
+            return@callbackFlow
+        }
+
+        val listener = FirebaseAuth.AuthStateListener { firebaseAuth ->
+            val user = firebaseAuth.currentUser
             val state = if (user != null) {
                 AuthState.SignedIn(user.toGymBroUser())
             } else {
@@ -41,10 +50,10 @@ class FirebaseAuthService @Inject constructor(
             trySend(state)
         }
 
-        firebaseAuth.addAuthStateListener(listener)
+        auth.addAuthStateListener(listener)
 
         awaitClose {
-            firebaseAuth.removeAuthStateListener(listener)
+            auth.removeAuthStateListener(listener)
         }
     }
 

--- a/android/core/src/main/java/com/gymbro/core/auth/NoOpAuthService.kt
+++ b/android/core/src/main/java/com/gymbro/core/auth/NoOpAuthService.kt
@@ -1,0 +1,20 @@
+package com.gymbro.core.auth
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NoOpAuthService @Inject constructor() : AuthService {
+
+    override suspend fun signInAnonymously(): Result<GymBroUser> =
+        Result.failure(Exception("Firebase is not configured. Add google-services.json to enable authentication."))
+
+    override suspend fun signOut(): Result<Unit> =
+        Result.failure(Exception("Firebase is not configured."))
+
+    override fun getCurrentUser(): GymBroUser? = null
+
+    override fun observeAuthState(): Flow<AuthState> = flowOf(AuthState.SignedOut)
+}

--- a/android/core/src/main/java/com/gymbro/core/di/FirebaseModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/FirebaseModule.kt
@@ -1,12 +1,18 @@
 package com.gymbro.core.di
 
+import android.util.Log
+import com.google.firebase.Firebase
+import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.firestore
 import com.gymbro.core.auth.AuthService
 import com.gymbro.core.auth.FirebaseAuthService
+import com.gymbro.core.auth.NoOpAuthService
 import com.gymbro.core.sync.service.CloudSyncService
 import com.gymbro.core.sync.service.FirestoreSyncService
-import dagger.Binds
+import com.gymbro.core.sync.service.NoOpCloudSyncService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,22 +23,66 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object FirebaseModule {
 
-    @Provides
-    @Singleton
-    fun provideFirebaseAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+    private const val TAG = "FirebaseModule"
+
+    private fun isFirebaseInitialized(): Boolean = try {
+        FirebaseApp.getInstance()
+        true
+    } catch (e: IllegalStateException) {
+        Log.w(TAG, "Firebase not initialized - running in offline mode")
+        false
+    }
 
     @Provides
     @Singleton
-    fun provideFirebaseFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
-}
+    fun provideFirebaseAuth(): FirebaseAuth? = try {
+        if (isFirebaseInitialized()) {
+            Firebase.auth
+        } else {
+            null
+        }
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to get FirebaseAuth", e)
+        null
+    }
 
-@Module
-@InstallIn(SingletonComponent::class)
-abstract class FirebaseBindingsModule {
+    @Provides
+    @Singleton
+    fun provideFirebaseFirestore(): FirebaseFirestore? = try {
+        if (isFirebaseInitialized()) {
+            Firebase.firestore
+        } else {
+            null
+        }
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to get FirebaseFirestore", e)
+        null
+    }
 
-    @Binds
-    abstract fun bindAuthService(impl: FirebaseAuthService): AuthService
+    @Provides
+    @Singleton
+    fun provideAuthService(
+        firebaseAuth: FirebaseAuth?,
+        firebaseAuthService: FirebaseAuthService,
+        noOpAuthService: NoOpAuthService,
+    ): AuthService = if (firebaseAuth != null) {
+        firebaseAuthService
+    } else {
+        Log.w(TAG, "Using NoOpAuthService - Firebase not configured")
+        noOpAuthService
+    }
 
-    @Binds
-    abstract fun bindCloudSyncService(impl: FirestoreSyncService): CloudSyncService
+    @Provides
+    @Singleton
+    fun provideCloudSyncService(
+        firebaseAuth: FirebaseAuth?,
+        firebaseFirestore: FirebaseFirestore?,
+        firestoreSyncService: FirestoreSyncService,
+        noOpCloudSyncService: NoOpCloudSyncService,
+    ): CloudSyncService = if (firebaseAuth != null && firebaseFirestore != null) {
+        firestoreSyncService
+    } else {
+        Log.w(TAG, "Using NoOpCloudSyncService - Firebase not configured")
+        noOpCloudSyncService
+    }
 }

--- a/android/core/src/main/java/com/gymbro/core/sync/service/FirestoreSyncService.kt
+++ b/android/core/src/main/java/com/gymbro/core/sync/service/FirestoreSyncService.kt
@@ -24,8 +24,8 @@ import javax.inject.Singleton
 
 @Singleton
 class FirestoreSyncService @Inject constructor(
-    private val firestore: FirebaseFirestore,
-    private val auth: FirebaseAuth,
+    private val firestore: FirebaseFirestore?,
+    private val auth: FirebaseAuth?,
     private val workoutDao: WorkoutDao,
     private val exerciseDao: ExerciseDao,
     private val connectivityObserver: ConnectivityObserver,
@@ -35,9 +35,14 @@ class FirestoreSyncService @Inject constructor(
     private val deviceId: String = android.os.Build.MODEL
 
     private val userId: String?
-        get() = auth.currentUser?.uid
+        get() = auth?.currentUser?.uid
 
     override suspend fun syncExercises(): Result<Unit> {
+        if (firestore == null || auth == null) {
+            _syncStatus.value = SyncStatus.DISABLED
+            return Result.failure(Exception("Firebase is not configured"))
+        }
+
         if (!connectivityObserver.isConnected.value) {
             _syncStatus.value = SyncStatus.OFFLINE
             return Result.failure(Exception("No network connection"))
@@ -72,6 +77,11 @@ class FirestoreSyncService @Inject constructor(
     }
 
     override suspend fun syncWorkouts(): Result<Unit> {
+        if (firestore == null || auth == null) {
+            _syncStatus.value = SyncStatus.DISABLED
+            return Result.failure(Exception("Firebase is not configured"))
+        }
+
         if (!connectivityObserver.isConnected.value) {
             _syncStatus.value = SyncStatus.OFFLINE
             return Result.failure(Exception("No network connection"))
@@ -107,6 +117,11 @@ class FirestoreSyncService @Inject constructor(
     }
 
     override suspend fun syncUserProfile(profile: FirestoreUserProfile): Result<Unit> {
+        if (firestore == null || auth == null) {
+            _syncStatus.value = SyncStatus.DISABLED
+            return Result.failure(Exception("Firebase is not configured"))
+        }
+
         if (!connectivityObserver.isConnected.value) {
             _syncStatus.value = SyncStatus.OFFLINE
             return Result.failure(Exception("No network connection"))
@@ -140,6 +155,12 @@ class FirestoreSyncService @Inject constructor(
     }
 
     override fun observeChanges(): Flow<SyncStatus> = callbackFlow {
+        if (firestore == null || auth == null) {
+            trySend(SyncStatus.DISABLED)
+            close()
+            return@callbackFlow
+        }
+
         val uid = userId
         if (uid == null) {
             trySend(SyncStatus.DISABLED)

--- a/android/core/src/main/java/com/gymbro/core/sync/service/NoOpCloudSyncService.kt
+++ b/android/core/src/main/java/com/gymbro/core/sync/service/NoOpCloudSyncService.kt
@@ -1,0 +1,26 @@
+package com.gymbro.core.sync.service
+
+import com.gymbro.core.sync.model.FirestoreUserProfile
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NoOpCloudSyncService @Inject constructor() : CloudSyncService {
+
+    override suspend fun syncExercises(): Result<Unit> =
+        Result.failure(Exception("Firebase is not configured. Cloud sync is disabled."))
+
+    override suspend fun syncWorkouts(): Result<Unit> =
+        Result.failure(Exception("Firebase is not configured. Cloud sync is disabled."))
+
+    override suspend fun syncUserProfile(profile: FirestoreUserProfile): Result<Unit> =
+        Result.failure(Exception("Firebase is not configured. Cloud sync is disabled."))
+
+    override suspend fun resolveConflicts() {
+        // No-op when Firebase is disabled
+    }
+
+    override fun observeChanges(): Flow<SyncStatus> = flowOf(SyncStatus.DISABLED)
+}


### PR DESCRIPTION
## Summary
Fixes the crash that occurred when opening the Profile tab without a google-services.json file configured.

## Changes
- Made FirebaseAuth and FirebaseFirestore nullable in FirebaseModule
- Added check for Firebase initialization before providing dependencies
- Created NoOpAuthService and NoOpCloudSyncService for offline mode
- Updated FirebaseAuthService and FirestoreSyncService to handle null Firebase instances
- App now gracefully handles missing Firebase configuration

## Testing
- ✅ Built successfully with gradlew assembleDebug
- ✅ Installed on emulator with gradlew installDebug
- ✅ App no longer crashes on Profile tab when Firebase is not configured

## Notes
The app's README states it should work without Firebase. This fix ensures that promise is kept. When Firebase is not available, auth and sync operations return appropriate error messages instead of crashing.

Working as Tank (Backend Dev)