### PR TITLE
fix: [UX] fix onboarding routing - show on fresh install

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -62,6 +62,7 @@ import com.gymbro.feature.workout.SmartWorkoutRoute
 import com.gymbro.feature.workout.WorkoutSummaryScreen
 import com.gymbro.core.model.PersonalRecord
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 private val AccentGreen = Color(0xFF00FF87)
 
@@ -88,8 +89,8 @@ fun GymBroNavGraph(
 
     val showBottomBar = currentDestination?.route in BottomNavTab.entries.map { it.route }
 
-    // TODO: Implement onboarding completion tracking
-    val startDestination = "exercise_library"
+    val hasCompletedOnboarding by userPreferences.hasCompletedOnboarding.collectAsStateWithLifecycle(initialValue = false)
+    val startDestination = if (hasCompletedOnboarding) "exercise_library" else "onboarding"
 
     NavHost(
         navController = navController,

--- a/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
+++ b/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
@@ -54,14 +54,8 @@ class UserPreferences @Inject constructor(
         preferences[NOTIFICATIONS_ENABLED] ?: false
     }
 
-    fun hasCompletedOnboarding(): Boolean {
-        // Synchronously check onboarding status - returns false for first launch
-        return try {
-            val preferences = context.dataStore.data.map { it[ONBOARDING_COMPLETE] ?: false }
-            false // Default to false initially
-        } catch (e: Exception) {
-            false
-        }
+    val hasCompletedOnboarding: Flow<Boolean> = dataStore.data.map { preferences ->
+        preferences[ONBOARDING_COMPLETE] ?: false
     }
 
     suspend fun setWeightUnit(unit: WeightUnit) {


### PR DESCRIPTION
## Summary
Fixed the onboarding routing bug where the app would skip onboarding and go straight to the Exercise Library after clearing app data.

## Changes
- **UserPreferences.kt**: Converted hasCompletedOnboarding() from a broken synchronous function to a proper Flow<Boolean> property that correctly reads from DataStore
- **GymBroNavGraph.kt**: Updated navigation graph to observe the onboarding preference and dynamically set start destination (onboarding vs main app)

## Testing
Built and installed successfully on emulator. The fix ensures:
- ✅ Fresh install → shows onboarding
- ✅ After completing onboarding → shows main app
- ✅ After \db shell pm clear com.gymbro.app\ → shows onboarding again

## Root Cause
The original \hasCompletedOnboarding()\ function attempted to synchronously read from DataStore (which is async-only) and always returned \alse\. The navigation graph also had the start destination hardcoded to \xercise_library\ with a TODO comment.

Closes #213