### PR TITLE
feat: [UX] create GradientButton, GlassmorphicCard, AnimatedProgressCircle

### DIFF
--- a/android/feature/src/main/java/com/gymbro/feature/common/AnimatedProgressCircle.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/AnimatedProgressCircle.kt
@@ -1,0 +1,86 @@
+package com.gymbro.feature.common
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.gymbro.app.ui.theme.AccentGreenEnd
+import com.gymbro.app.ui.theme.AccentGreenStart
+import com.gymbro.app.ui.theme.SurfacePrimary
+
+@Composable
+fun AnimatedProgressCircle(
+    progress: Float,
+    modifier: Modifier = Modifier,
+    size: Dp = 120.dp,
+    strokeWidth: Dp = 12.dp,
+    gradientColors: List<Color> = listOf(AccentGreenStart, AccentGreenEnd),
+    backgroundTrackColor: Color = SurfacePrimary,
+    content: @Composable () -> Unit = {},
+) {
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress.coerceIn(0f, 1f),
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "progress_animation"
+    )
+
+    Box(
+        modifier = modifier.size(size),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.size(size)) {
+            val canvasSize = this.size
+            val radius = (canvasSize.minDimension - strokeWidth.toPx()) / 2
+            val topLeft = Offset(
+                x = (canvasSize.width - radius * 2) / 2,
+                y = (canvasSize.height - radius * 2) / 2
+            )
+            val arcSize = Size(radius * 2, radius * 2)
+
+            // Background track
+            drawArc(
+                color = backgroundTrackColor,
+                startAngle = -90f,
+                sweepAngle = 360f,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
+            )
+
+            // Gradient progress arc
+            val sweepAngle = animatedProgress * 360f
+            drawArc(
+                brush = Brush.sweepGradient(
+                    colors = gradientColors,
+                    center = Offset(canvasSize.width / 2, canvasSize.height / 2)
+                ),
+                startAngle = -90f,
+                sweepAngle = sweepAngle,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
+            )
+        }
+
+        content()
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/common/GlassmorphicCard.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/GlassmorphicCard.kt
@@ -1,0 +1,54 @@
+package com.gymbro.feature.common
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.gymbro.app.ui.theme.GlassBorder
+import com.gymbro.app.ui.theme.GlassOverlay
+
+@Composable
+fun GlassmorphicCard(
+    modifier: Modifier = Modifier,
+    accentColor: Color? = null,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = GlassOverlay,
+        ),
+        border = BorderStroke(1.dp, GlassBorder),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 0.dp,
+        ),
+    ) {
+        Column {
+            if (accentColor != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(4.dp)
+                        .background(accentColor)
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .padding(16.dp)
+            ) {
+                content()
+            }
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
@@ -1,0 +1,88 @@
+package com.gymbro.feature.common
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.gymbro.app.ui.theme.AccentGreenEnd
+import com.gymbro.app.ui.theme.AccentGreenStart
+
+@Composable
+fun GradientButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    gradientColors: List<Color> = listOf(AccentGreenStart, AccentGreenEnd),
+    enabled: Boolean = true,
+) {
+    var isPressed by remember { mutableStateOf(false) }
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1f,
+        label = "button_scale"
+    )
+
+    Box(
+        modifier = modifier
+            .scale(scale)
+            .pointerInput(enabled) {
+                if (enabled) {
+                    detectTapGestures(
+                        onPress = {
+                            isPressed = true
+                            tryAwaitRelease()
+                            isPressed = false
+                        }
+                    )
+                }
+            }
+    ) {
+        Button(
+            onClick = onClick,
+            modifier = Modifier,
+            enabled = enabled,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.Transparent,
+                disabledContainerColor = Color.Transparent,
+            ),
+            contentPadding = PaddingValues(0.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .gradientBackground(
+                        Brush.horizontalGradient(
+                            colors = if (enabled) gradientColors else gradientColors.map { it.copy(alpha = 0.5f) }
+                        )
+                    )
+                    .padding(horizontal = 24.dp, vertical = 12.dp)
+            ) {
+                Text(
+                    text = text,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+    }
+}
+
+fun Modifier.gradientBackground(brush: Brush): Modifier = this.then(
+    androidx.compose.foundation.background(brush)
+)


### PR DESCRIPTION
Closes #211

## Summary
Created three new design components for the UX sprint:
- **GradientButton** — Button with gradient background (AccentGreenStart → AccentGreenEnd), 12dp rounded corners, pressed animation (scale 0.95)
- **GlassmorphicCard** — Modern card with semi-transparent background (GlassOverlay), subtle border (GlassBorder), optional accent glow strip
- **AnimatedProgressCircle** — Canvas-based circular progress indicator with gradient sweep, spring animation, configurable size

## Components Details
### GradientButton
- Accepts gradient colors list (default: AccentGreenStart → AccentGreenEnd)
- 12dp rounded corners
- Bold white text
- Pressed state animation (scale down 0.95)

### GlassmorphicCard
- Semi-transparent background (GlassOverlay = 0x1AFFFFFF)
- Subtle white border (GlassBorder = 0x33FFFFFF)
- 20dp rounded corners
- Optional accent color glow strip at top
- 16dp padding

### AnimatedProgressCircle
- Canvas-based circular progress indicator
- Gradient sweep from AccentGreenStart to AccentGreenEnd
- Spring animation for progress changes
- Configurable size (default 120dp)
- Center slot for content (text, icon)
- Background track in SurfacePrimary

All components follow the new color system defined in Color.kt and Gradients.kt.