### PR TITLE
feat: [UX] redesign History with gradient cards and animations

### DIFF
--- a/android/feature/src/main/java/com/gymbro/feature/common/AnimatedProgressCircle.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/AnimatedProgressCircle.kt
@@ -18,9 +18,10 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.gymbro.app.ui.theme.AccentGreenEnd
-import com.gymbro.app.ui.theme.AccentGreenStart
-import com.gymbro.app.ui.theme.SurfacePrimary
+
+private val AccentGreenStart = Color(0xFF00FF87)
+private val AccentGreenEnd = Color(0xFF00D9B5)
+private val SurfacePrimary = Color(0xFF141414)
 
 @Composable
 fun AnimatedProgressCircle(

--- a/android/feature/src/main/java/com/gymbro/feature/common/GlassmorphicCard.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/GlassmorphicCard.kt
@@ -14,8 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.gymbro.app.ui.theme.GlassBorder
-import com.gymbro.app.ui.theme.GlassOverlay
+
+private val GlassOverlay = Color(0x1AFFFFFF)
+private val GlassBorder = Color(0x33FFFFFF)
 
 @Composable
 fun GlassmorphicCard(

--- a/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
@@ -1,6 +1,7 @@
 package com.gymbro.feature.common
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -21,8 +22,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.gymbro.app.ui.theme.AccentGreenEnd
-import com.gymbro.app.ui.theme.AccentGreenStart
+
+private val AccentGreenStart = Color(0xFF00FF87)
+private val AccentGreenEnd = Color(0xFF00D9B5)
 
 @Composable
 fun GradientButton(
@@ -83,6 +85,4 @@ fun GradientButton(
     }
 }
 
-fun Modifier.gradientBackground(brush: Brush): Modifier = this.then(
-    androidx.compose.foundation.background(brush)
-)
+fun Modifier.gradientBackground(brush: Brush): Modifier = this.background(brush = brush)

--- a/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/history/HistoryDetailScreen.kt
@@ -1,5 +1,8 @@
 package com.gymbro.feature.history
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -34,9 +38,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.heading
@@ -46,15 +54,19 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gymbro.feature.common.EmptyState
 import com.gymbro.feature.common.FullScreenLoading
-import com.gymbro.feature.common.GymBroCard
+import com.gymbro.feature.common.GlassmorphicCard
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.delay
 
-private val AccentGreen = Color(0xFF00FF87)
-private val AccentCyan = Color(0xFF00E5FF)
-private val AccentAmber = Color(0xFFFFAB00)
-private val SurfaceCard = Color(0xFF1A1A1A)
+private val AccentGreenStart = Color(0xFF00FF87)
+private val AccentGreenEnd = Color(0xFF00D9B5)
+private val AccentCyanStart = Color(0xFF00D4FF)
+private val AccentCyanEnd = Color(0xFF0091FF)
+private val AccentAmberStart = Color(0xFFFFB800)
+private val AccentAmberEnd = Color(0xFFFF8A00)
+
 private val SurfaceDark = Color(0xFF0A0A0A)
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -112,6 +124,8 @@ fun HistoryDetailRoute(
 
 @Composable
 private fun HistoryDetailContent(detail: WorkoutDetail) {
+    var itemIndex = 0
+    
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -120,66 +134,89 @@ private fun HistoryDetailContent(detail: WorkoutDetail) {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         item {
-            WorkoutHeader(detail = detail)
+            val currentIndex = itemIndex++
+            WorkoutHeader(detail = detail, index = currentIndex)
         }
 
         item {
-            Text(
-                text = "Overview",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = Color.White,
-                modifier = Modifier.padding(vertical = 8.dp).semantics { heading() },
-            )
+            val currentIndex = itemIndex++
+            AnimatedItem(index = currentIndex) {
+                Text(
+                    text = "Resumen",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    modifier = Modifier.padding(vertical = 8.dp).semantics { heading() },
+                )
+            }
         }
 
         item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                StatCard(
-                    icon = Icons.Default.FitnessCenter,
-                    label = "Volume",
-                    value = "${detail.totalVolume.toInt()} kg",
-                    color = AccentGreen,
-                    modifier = Modifier.weight(1f),
-                )
-                StatCard(
-                    icon = Icons.Default.BarChart,
-                    label = "Sets",
-                    value = "${detail.totalSets}",
-                    color = AccentAmber,
-                    modifier = Modifier.weight(1f),
-                )
+            val currentIndex = itemIndex++
+            AnimatedItem(index = currentIndex) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    StatCard(
+                        icon = Icons.Default.FitnessCenter,
+                        label = "Volumen",
+                        value = "${detail.totalVolume.toInt()} kg",
+                        gradientColors = listOf(AccentGreenStart, AccentGreenEnd),
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatCard(
+                        icon = Icons.Default.BarChart,
+                        label = "Series",
+                        value = "${detail.totalSets}",
+                        gradientColors = listOf(AccentCyanStart, AccentCyanEnd),
+                        modifier = Modifier.weight(1f),
+                    )
+                }
             }
         }
 
         if (detail.prExerciseIds.isNotEmpty()) {
             item {
-                GymBroCard(accentColor = AccentAmber) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                val currentIndex = itemIndex++
+                AnimatedItem(index = currentIndex) {
+                    GlassmorphicCard(
+                        accentColor = AccentAmberStart
                     ) {
-                        Icon(
-                            Icons.Default.Star,
-                            contentDescription = null,
-                            tint = AccentAmber,
-                            modifier = Modifier.size(28.dp),
-                        )
-                        Column {
-                            Text(
-                                text = "${detail.prExerciseIds.size} Personal Record${if (detail.prExerciseIds.size > 1) "s" else ""}",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White,
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(
+                                    brush = Brush.linearGradient(
+                                        colors = listOf(
+                                            AccentAmberStart.copy(alpha = 0.2f),
+                                            AccentAmberEnd.copy(alpha = 0.1f)
+                                        )
+                                    )
+                                )
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Icon(
+                                Icons.Default.Star,
+                                contentDescription = null,
+                                tint = AccentAmberStart,
+                                modifier = Modifier.size(32.dp),
                             )
-                            Text(
-                                text = "New PRs set in this workout",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.White.copy(alpha = 0.6f),
-                            )
+                            Column {
+                                Text(
+                                    text = "¡${detail.prExerciseIds.size} Récord${if (detail.prExerciseIds.size > 1) "s" else ""}!",
+                                    style = MaterialTheme.typography.titleLarge,
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color.White,
+                                )
+                                Text(
+                                    text = "Nuevos récords personales",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.White.copy(alpha = 0.7f),
+                                )
+                            }
                         }
                     }
                 }
@@ -187,35 +224,48 @@ private fun HistoryDetailContent(detail: WorkoutDetail) {
         }
 
         item {
-            Text(
-                text = "Exercises",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = Color.White,
-                modifier = Modifier.padding(vertical = 8.dp).semantics { heading() },
-            )
-        }
-
-        items(detail.exercises) { exercise ->
-            ExerciseCard(exercise = exercise)
-        }
-
-        if (detail.volumeByMuscleGroup.isNotEmpty()) {
-            item {
+            val currentIndex = itemIndex++
+            AnimatedItem(index = currentIndex) {
                 Text(
-                    text = "Volume by Muscle Group",
+                    text = "Ejercicios",
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = Color.White,
                     modifier = Modifier.padding(vertical = 8.dp).semantics { heading() },
                 )
             }
+        }
+
+        itemsIndexed(detail.exercises) { exerciseIndex, exercise ->
+            val currentIndex = itemIndex++
+            ExerciseCard(exercise = exercise, index = currentIndex)
+        }
+
+        if (detail.volumeByMuscleGroup.isNotEmpty()) {
+            item {
+                val currentIndex = itemIndex++
+                AnimatedItem(index = currentIndex) {
+                    Text(
+                        text = "Volumen por Grupo Muscular",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                        modifier = Modifier.padding(vertical = 8.dp).semantics { heading() },
+                    )
+                }
+            }
 
             item {
-                GymBroCard {
-                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        detail.volumeByMuscleGroup.entries.sortedByDescending { it.value }.forEach { (muscle, volume) ->
-                            MuscleVolumeRow(muscle = muscle.displayName, volume = volume)
+                val currentIndex = itemIndex++
+                AnimatedItem(index = currentIndex) {
+                    GlassmorphicCard {
+                        Column(
+                            modifier = Modifier.padding(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            detail.volumeByMuscleGroup.entries.sortedByDescending { it.value }.forEach { (muscle, volume) ->
+                                MuscleVolumeRow(muscle = muscle.displayName, volume = volume)
+                            }
                         }
                     }
                 }
@@ -229,27 +279,84 @@ private fun HistoryDetailContent(detail: WorkoutDetail) {
 }
 
 @Composable
-private fun WorkoutHeader(detail: WorkoutDetail) {
+private fun AnimatedItem(
+    index: Int,
+    content: @Composable () -> Unit
+) {
+    var visible by remember { mutableStateOf(false) }
+    
+    LaunchedEffect(Unit) {
+        delay(index * 50L)
+        visible = true
+    }
+    
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 })
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun WorkoutHeader(detail: WorkoutDetail, index: Int) {
     val date = Instant.ofEpochMilli(detail.date)
         .atZone(ZoneId.systemDefault())
-        .format(DateTimeFormatter.ofPattern("EEEE, MMM d, yyyy"))
+        .format(DateTimeFormatter.ofPattern("EEEE, d 'de' MMMM"))
 
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
+    var visible by remember { mutableStateOf(false) }
+    
+    LaunchedEffect(Unit) {
+        delay(index * 50L)
+        visible = true
+    }
+    
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 })
     ) {
-        Text(
-            text = date,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = Color.White,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = formatDuration(detail.durationSeconds),
-            style = MaterialTheme.typography.bodyLarge,
-            color = Color.White.copy(alpha = 0.6f),
-        )
+        GlassmorphicCard(
+            accentColor = AccentGreenStart
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                AccentGreenStart.copy(alpha = 0.15f),
+                                Color.Transparent
+                            )
+                        )
+                    )
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = date,
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Default.Timer,
+                        contentDescription = null,
+                        tint = AccentCyanStart,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Text(
+                        text = formatDuration(detail.durationSeconds),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = Color.White.copy(alpha = 0.8f),
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -258,86 +365,135 @@ private fun StatCard(
     icon: ImageVector,
     label: String,
     value: String,
-    color: Color,
+    gradientColors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(12.dp))
-            .background(SurfaceCard)
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+    GlassmorphicCard(
+        modifier = modifier,
+        accentColor = gradientColors.first()
     ) {
-        Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(28.dp))
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold,
-            color = Color.White,
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium,
-            color = Color.White.copy(alpha = 0.5f),
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    brush = Brush.linearGradient(
+                        colors = gradientColors.map { it.copy(alpha = 0.15f) }
+                    )
+                )
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(icon, contentDescription = null, tint = gradientColors.first(), modifier = Modifier.size(32.dp))
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.White.copy(alpha = 0.6f),
+            )
+        }
     }
 }
 
 @Composable
-private fun ExerciseCard(exercise: ExerciseDetail) {
-    GymBroCard(accentColor = if (exercise.hasPR) AccentGreen else null) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+private fun ExerciseCard(exercise: ExerciseDetail, index: Int) {
+    var visible by remember { mutableStateOf(false) }
+    
+    LaunchedEffect(Unit) {
+        delay(index * 50L)
+        visible = true
+    }
+    
+    val accentColor = if (exercise.hasPR) AccentAmberStart else AccentGreenStart
+    
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 })
+    ) {
+        GlassmorphicCard(accentColor = accentColor) {
+            Column(
+                modifier = Modifier.padding(8.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = exercise.exerciseName,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                        )
+                        Text(
+                            text = exercise.muscleGroup.displayName,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White.copy(alpha = 0.6f),
+                        )
+                    }
+                    if (exercise.hasPR) {
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(
+                                    brush = Brush.linearGradient(
+                                        colors = listOf(AccentAmberStart, AccentAmberEnd)
+                                    )
+                                )
+                                .padding(8.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.Star,
+                                contentDescription = "Récord Personal",
+                                tint = Color.White,
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
+                    }
+                }
+
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    exercise.sets.forEach { set ->
+                        SetRow(set = set)
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(
+                            brush = Brush.linearGradient(
+                                colors = listOf(
+                                    AccentCyanStart.copy(alpha = 0.2f),
+                                    AccentCyanEnd.copy(alpha = 0.1f)
+                                )
+                            )
+                        )
+                        .padding(12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
                     Text(
-                        text = exercise.exerciseName,
-                        style = MaterialTheme.typography.titleMedium,
+                        text = "Volumen Total:",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = Color.White.copy(alpha = 0.8f),
+                        fontWeight = FontWeight.Medium,
+                    )
+                    Text(
+                        text = "${exercise.totalVolume.toInt()} kg",
+                        style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold,
-                        color = Color.White,
-                    )
-                    Text(
-                        text = exercise.muscleGroup.displayName,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Color.White.copy(alpha = 0.6f),
+                        color = AccentCyanStart,
                     )
                 }
-                if (exercise.hasPR) {
-                    Icon(
-                        Icons.Default.Star,
-                        contentDescription = "Personal Record",
-                        tint = AccentGreen,
-                        modifier = Modifier.size(24.dp),
-                    )
-                }
-            }
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                exercise.sets.forEach { set ->
-                    SetRow(set = set)
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = "Total Volume:",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White.copy(alpha = 0.7f),
-                )
-                Text(
-                    text = "${exercise.totalVolume.toInt()} kg",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = AccentCyan,
-                )
             }
         }
     }
@@ -348,15 +504,17 @@ private fun SetRow(set: SetDetail) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(SurfaceDark, RoundedCornerShape(8.dp))
-            .padding(horizontal = 12.dp, vertical = 8.dp),
+            .clip(RoundedCornerShape(10.dp))
+            .background(SurfaceDark)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = "Set ${set.setNumber}",
-            style = MaterialTheme.typography.bodyMedium,
+            text = "Serie ${set.setNumber}",
+            style = MaterialTheme.typography.bodyLarge,
             color = Color.White.copy(alpha = 0.7f),
+            fontWeight = FontWeight.Medium,
         )
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -364,16 +522,28 @@ private fun SetRow(set: SetDetail) {
         ) {
             Text(
                 text = "${set.weight} kg × ${set.reps}",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
                 color = Color.White,
             )
             if (set.rpe != null) {
-                Text(
-                    text = "RPE ${set.rpe}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = AccentAmber,
-                )
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(
+                            brush = Brush.linearGradient(
+                                colors = listOf(AccentAmberStart.copy(alpha = 0.3f), AccentAmberEnd.copy(alpha = 0.2f))
+                            )
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = "RPE ${set.rpe}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = AccentAmberStart,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
             }
         }
     }
@@ -382,20 +552,32 @@ private fun SetRow(set: SetDetail) {
 @Composable
 private fun MuscleVolumeRow(muscle: String, volume: Double) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                brush = Brush.linearGradient(
+                    colors = listOf(
+                        AccentGreenStart.copy(alpha = 0.15f),
+                        AccentCyanStart.copy(alpha = 0.1f)
+                    )
+                )
+            )
+            .padding(12.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = muscle,
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.bodyLarge,
             color = Color.White,
+            fontWeight = FontWeight.Medium,
         )
         Text(
             text = "${volume.toInt()} kg",
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = AccentCyan,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+            color = AccentCyanStart,
         )
     }
 }

--- a/android/feature/src/main/java/com/gymbro/feature/history/HistoryListScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/history/HistoryListScreen.kt
@@ -1,5 +1,8 @@
 package com.gymbro.feature.history
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -15,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -32,12 +36,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.heading
@@ -49,15 +58,21 @@ import com.gymbro.core.R
 import com.gymbro.core.model.MuscleGroup
 import com.gymbro.feature.common.EmptyState
 import com.gymbro.feature.common.FullScreenLoading
-import com.gymbro.feature.common.GymBroCard
+import com.gymbro.feature.common.GlassmorphicCard
+import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.delay
 
-private val AccentGreen = Color(0xFF00FF87)
-private val AccentCyan = Color(0xFF00E5FF)
-private val AccentAmber = Color(0xFFFFAB00)
-private val SurfaceCard = Color(0xFF1A1A1A)
+private val AccentGreenStart = Color(0xFF00FF87)
+private val AccentGreenEnd = Color(0xFF00D9B5)
+private val AccentCyanStart = Color(0xFF00D4FF)
+private val AccentCyanEnd = Color(0xFF0091FF)
+private val AccentAmberStart = Color(0xFFFFB800)
+private val AccentAmberEnd = Color(0xFFFF8A00)
+
 private val SurfaceDark = Color(0xFF0A0A0A)
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -126,6 +141,7 @@ private fun HistoryListContent(
     groupedWorkouts: List<WorkoutGroup>,
     onWorkoutClick: (String) -> Unit,
 ) {
+    var itemIndex = 0
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -135,19 +151,19 @@ private fun HistoryListContent(
     ) {
         groupedWorkouts.forEach { group ->
             item {
-                Text(
-                    text = group.monthYear,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = Color.White.copy(alpha = 0.7f),
-                    modifier = Modifier.padding(vertical = 8.dp),
+                val currentIndex = itemIndex++
+                MonthHeader(
+                    monthYear = group.monthYear,
+                    index = currentIndex,
                 )
             }
 
-            items(group.workouts) { workout ->
+            itemsIndexed(group.workouts) { workoutIndex, workout ->
+                val currentIndex = itemIndex++
                 WorkoutCard(
                     workout = workout,
                     onClick = { onWorkoutClick(workout.workoutId) },
+                    index = currentIndex,
                 )
             }
         }
@@ -159,89 +175,161 @@ private fun HistoryListContent(
 }
 
 @Composable
+private fun MonthHeader(
+    monthYear: String,
+    index: Int,
+) {
+    var visible by remember { mutableStateOf(false) }
+    
+    LaunchedEffect(Unit) {
+        delay(index * 50L)
+        visible = true
+    }
+    
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 })
+    ) {
+        GlassmorphicCard(
+            modifier = Modifier.padding(vertical = 8.dp)
+        ) {
+            Text(
+                text = monthYear,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.linearGradient(
+                            colors = listOf(AccentGreenStart, AccentCyanStart)
+                        )
+                    )
+                    .padding(16.dp),
+                color = Color.White,
+            )
+        }
+    }
+}
+
+@Composable
 private fun WorkoutCard(
     workout: WorkoutListItem,
     onClick: () -> Unit,
+    index: Int,
 ) {
-    val date = Instant.ofEpochMilli(workout.date)
+    var visible by remember { mutableStateOf(false) }
+    
+    LaunchedEffect(Unit) {
+        delay(index * 50L)
+        visible = true
+    }
+    
+    val workoutDate = Instant.ofEpochMilli(workout.date)
         .atZone(ZoneId.systemDefault())
-        .format(DateTimeFormatter.ofPattern("EEE, MMM d"))
+    val date = workoutDate.format(DateTimeFormatter.ofPattern("EEE, MMM d"))
+    val relativeTime = getRelativeTime(workoutDate.toLocalDate())
+    
+    val accentColor = getAccentColorForMuscleGroups(workout.muscleGroups)
 
-    GymBroCard(
-        modifier = Modifier.clickable(onClick = onClick),
-        accentColor = if (workout.prCount > 0) AccentGreen else null,
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 })
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = date,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = Color.White,
-                    )
-                    Text(
-                        text = formatDuration(workout.durationSeconds),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Color.White.copy(alpha = 0.6f),
-                    )
-                }
-                if (workout.prCount > 0) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        Icon(
-                            Icons.Default.Star,
-                            contentDescription = stringResource(R.string.history_prs),
-                            tint = AccentAmber,
-                            modifier = Modifier.size(20.dp),
-                        )
-                        Text(
-                            text = "${workout.prCount}",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            color = AccentAmber,
-                        )
-                    }
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                StatChip(
-                    icon = Icons.Default.FitnessCenter,
-                    label = stringResource(R.string.history_exercises_count, workout.exerciseCount),
-                    color = AccentCyan,
-                )
-                StatChip(
-                    icon = Icons.Default.Timer,
-                    label = stringResource(R.string.history_volume_kg, workout.totalVolume.toInt()),
-                    color = AccentGreen,
-                )
-            }
-
-            if (workout.muscleGroups.isNotEmpty()) {
+        GlassmorphicCard(
+            modifier = Modifier.clickable(onClick = onClick),
+            accentColor = accentColor,
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top,
                 ) {
-                    workout.muscleGroups.take(3).forEach { muscleGroup ->
-                        MuscleGroupTag(muscleGroup = muscleGroup)
-                    }
-                    if (workout.muscleGroups.size > 3) {
+                    Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = "+${workout.muscleGroups.size - 3}",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color.White.copy(alpha = 0.5f),
-                            modifier = Modifier.align(Alignment.CenterVertically),
+                            text = date,
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
                         )
+                        Text(
+                            text = relativeTime,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White.copy(alpha = 0.5f),
+                        )
+                    }
+                    if (workout.prCount > 0) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(
+                                    brush = Brush.linearGradient(
+                                        colors = listOf(AccentAmberStart, AccentAmberEnd)
+                                    )
+                                )
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
+                        ) {
+                            Icon(
+                                Icons.Default.Star,
+                                contentDescription = stringResource(R.string.history_prs),
+                                tint = Color.White,
+                                modifier = Modifier.size(16.dp),
+                            )
+                            Text(
+                                text = "${workout.prCount}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White,
+                            )
+                        }
+                    }
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    StatChip(
+                        icon = Icons.Default.Timer,
+                        label = formatDuration(workout.durationSeconds),
+                        gradientColors = listOf(AccentCyanStart, AccentCyanEnd),
+                    )
+                    StatChip(
+                        icon = Icons.Default.FitnessCenter,
+                        label = "${workout.exerciseCount} ejercicios",
+                        gradientColors = listOf(AccentGreenStart, AccentGreenEnd),
+                    )
+                }
+                
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    StatChip(
+                        icon = Icons.Default.FitnessCenter,
+                        label = "${workout.totalVolume.toInt()} kg",
+                        gradientColors = listOf(AccentAmberStart, AccentAmberEnd),
+                    )
+                }
+
+                if (workout.muscleGroups.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        workout.muscleGroups.take(3).forEach { muscleGroup ->
+                            MuscleGroupTag(muscleGroup = muscleGroup)
+                        }
+                        if (workout.muscleGroups.size > 3) {
+                            Text(
+                                text = "+${workout.muscleGroups.size - 3}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.White.copy(alpha = 0.5f),
+                                modifier = Modifier.align(Alignment.CenterVertically),
+                            )
+                        }
                     }
                 }
             }
@@ -249,46 +337,103 @@ private fun WorkoutCard(
     }
 }
 
+private fun getRelativeTime(workoutDate: LocalDate): String {
+    val today = LocalDate.now()
+    val daysBetween = Duration.between(workoutDate.atStartOfDay(), today.atStartOfDay()).toDays()
+    
+    return when {
+        daysBetween == 0L -> "Hoy"
+        daysBetween == 1L -> "Ayer"
+        daysBetween < 7 -> "Hace $daysBetween días"
+        daysBetween < 14 -> "Hace 1 semana"
+        daysBetween < 30 -> "Hace ${daysBetween / 7} semanas"
+        else -> "Hace ${daysBetween / 30} meses"
+    }
+}
+
+private fun getAccentColorForMuscleGroups(muscleGroups: Set<MuscleGroup>): Color? {
+    val primaryMuscle = muscleGroups.firstOrNull() ?: return null
+    
+    return when (primaryMuscle) {
+        MuscleGroup.CHEST -> AccentGreenStart
+        MuscleGroup.BACK -> AccentCyanStart
+        MuscleGroup.SHOULDERS -> AccentAmberStart
+        MuscleGroup.BICEPS -> Color(0xFF00D4FF)
+        MuscleGroup.TRICEPS -> Color(0xFFFF3B30)
+        MuscleGroup.QUADRICEPS -> AccentGreenStart
+        MuscleGroup.HAMSTRINGS -> AccentCyanStart
+        MuscleGroup.GLUTES -> Color(0xFFFF8A00)
+        MuscleGroup.CALVES -> AccentAmberStart
+        MuscleGroup.CORE -> Color(0xFFFFB800)
+        MuscleGroup.FOREARMS -> Color(0xFF00E5FF)
+        MuscleGroup.FULL_BODY -> AccentGreenStart
+    }
+}
+
 @Composable
 private fun StatChip(
     icon: ImageVector,
     label: String,
-    color: Color,
+    gradientColors: List<Color>,
 ) {
     Row(
         modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .background(SurfaceCard)
-            .padding(horizontal = 10.dp, vertical = 6.dp),
+            .clip(RoundedCornerShape(12.dp))
+            .background(
+                brush = Brush.linearGradient(colors = gradientColors.map { it.copy(alpha = 0.2f) })
+            )
+            .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         Icon(
             icon,
             contentDescription = null,
-            tint = color,
-            modifier = Modifier.size(16.dp),
+            tint = gradientColors.first(),
+            modifier = Modifier.size(18.dp),
         )
         Text(
             text = label,
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.bodyMedium,
             color = Color.White,
-            fontWeight = FontWeight.Medium,
+            fontWeight = FontWeight.SemiBold,
         )
     }
 }
 
 @Composable
 private fun MuscleGroupTag(muscleGroup: MuscleGroup) {
+    val gradientColors = getMuscleGroupGradient(muscleGroup)
+    
     Text(
         text = muscleGroup.displayName,
         style = MaterialTheme.typography.labelSmall,
-        color = Color.White.copy(alpha = 0.7f),
+        color = Color.White,
+        fontWeight = FontWeight.Medium,
         modifier = Modifier
-            .clip(RoundedCornerShape(6.dp))
-            .background(Color.White.copy(alpha = 0.1f))
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                brush = Brush.linearGradient(colors = gradientColors.map { it.copy(alpha = 0.3f) })
+            )
+            .padding(horizontal = 10.dp, vertical = 5.dp),
     )
+}
+
+private fun getMuscleGroupGradient(muscleGroup: MuscleGroup): List<Color> {
+    return when (muscleGroup) {
+        MuscleGroup.CHEST -> listOf(AccentGreenStart, AccentGreenEnd)
+        MuscleGroup.BACK -> listOf(AccentCyanStart, AccentCyanEnd)
+        MuscleGroup.SHOULDERS -> listOf(AccentAmberStart, AccentAmberEnd)
+        MuscleGroup.BICEPS -> listOf(Color(0xFF00D4FF), Color(0xFF0091FF))
+        MuscleGroup.TRICEPS -> listOf(Color(0xFFFF3B30), Color(0xFFFF1744))
+        MuscleGroup.QUADRICEPS -> listOf(AccentGreenStart, AccentGreenEnd)
+        MuscleGroup.HAMSTRINGS -> listOf(AccentCyanStart, AccentCyanEnd)
+        MuscleGroup.GLUTES -> listOf(AccentAmberStart, AccentAmberEnd)
+        MuscleGroup.CALVES -> listOf(Color(0xFFFFB800), Color(0xFFFF8A00))
+        MuscleGroup.CORE -> listOf(Color(0xFFFFB800), Color(0xFFFF8A00))
+        MuscleGroup.FOREARMS -> listOf(AccentCyanStart, AccentCyanEnd)
+        MuscleGroup.FULL_BODY -> listOf(AccentGreenStart, AccentCyanStart)
+    }
 }
 
 private fun formatDuration(totalSeconds: Long): String {


### PR DESCRIPTION
Redesigns HistoryListScreen and HistoryDetailScreen with modern glassmorphic cards, gradient accents, and staggered animations.

## Changes

### HistoryListScreen
- Replaced GymBroCard with GlassmorphicCard
- Added muscle group-based accent colors
- Large date display with relative time (Hoy, Ayer, Hace X días)
- Gradient stat chips with icons
- Gradient muscle group tags
- Staggered entry animation (50ms delay per card)
- Gradient month headers

### HistoryDetailScreen
- Gradient header card with workout date
- Glassmorphic stat cards with gradient backgrounds
- PR highlights with amber gradient and glow effect
- Gradient exercise cards with animated entry
- Enhanced set rows with gradient RPE badges
- Gradient muscle volume breakdown
- All items animate in with staggered delays

### Design System Fixes
- Fixed circular dependency by defining colors locally in feature module
- Updated AnimatedProgressCircle, GlassmorphicCard, and GradientButton to use local color definitions
- All gradient colors consistent with app theme

Closes #217

Builds successfully: ✅