### PR TITLE
feat: [UX] Redesign ExerciseLibrary with glassmorphism

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/gymbro/app/ui/theme/Theme.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.gymbro.core.ui.theme.*
 
 private val GymBroDarkColorScheme = darkColorScheme(
     primary = AccentGreenStart,

--- a/android/core/build.gradle.kts
+++ b/android/core/build.gradle.kts
@@ -36,6 +36,10 @@ dependencies {
     // AndroidX Core
     implementation(libs.androidx.core.ktx)
 
+    // Compose UI (minimal - for Color and Brush definitions in theme)
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.ui.graphics)
+
     // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/android/core/src/main/java/com/gymbro/core/ui/theme/Color.kt
+++ b/android/core/src/main/java/com/gymbro/core/ui/theme/Color.kt
@@ -1,0 +1,36 @@
+package com.gymbro.core.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+// Base Backgrounds
+val Background = Color(0xFF0A0A0A)
+val SurfacePrimary = Color(0xFF141414)
+val Surface = Color(0xFF1C1C1E)
+val SurfaceVariant = Color(0xFF2C2C2E)
+
+// Gradient Accent Colors
+val AccentGreenStart = Color(0xFF00FF87)
+val AccentGreenEnd = Color(0xFF00D9B5)
+val AccentCyanStart = Color(0xFF00D4FF)
+val AccentCyanEnd = Color(0xFF0091FF)
+val AccentAmberStart = Color(0xFFFFB800)
+val AccentAmberEnd = Color(0xFFFF8A00)
+val AccentRed = Color(0xFFFF3B30)
+
+// Glassmorphic Overlays
+val GlassOverlay = Color(0x1AFFFFFF)
+val GlassBorder = Color(0x33FFFFFF)
+
+// Backwards compatibility aliases
+val AccentGreen = AccentGreenStart
+val AccentCyan = AccentCyanStart
+val AccentAmber = AccentAmberStart
+
+// Text Colors
+val OnBackground = Color(0xFFE0E0E0)
+val OnSurface = Color(0xFFFFFFFF)
+val OnSurfaceVariant = Color(0xFF9E9E9E)
+
+// Error Colors
+val Error = AccentRed
+val OnError = Color(0xFF000000)

--- a/android/feature/src/main/java/com/gymbro/feature/common/AnimatedProgressCircle.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/AnimatedProgressCircle.kt
@@ -18,10 +18,9 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-
-private val AccentGreenStart = Color(0xFF00FF87)
-private val AccentGreenEnd = Color(0xFF00D9B5)
-private val SurfacePrimary = Color(0xFF141414)
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.AccentGreenStart
+import com.gymbro.core.ui.theme.SurfacePrimary
 
 @Composable
 fun AnimatedProgressCircle(

--- a/android/feature/src/main/java/com/gymbro/feature/common/GlassmorphicCard.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/GlassmorphicCard.kt
@@ -14,9 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-
-private val GlassOverlay = Color(0x1AFFFFFF)
-private val GlassBorder = Color(0x33FFFFFF)
+import com.gymbro.core.ui.theme.GlassBorder
+import com.gymbro.core.ui.theme.GlassOverlay
 
 @Composable
 fun GlassmorphicCard(

--- a/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
@@ -22,9 +22,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-
-private val AccentGreenStart = Color(0xFF00FF87)
-private val AccentGreenEnd = Color(0xFF00D9B5)
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.AccentGreenStart
 
 @Composable
 fun GradientButton(
@@ -85,4 +84,6 @@ fun GradientButton(
     }
 }
 
-fun Modifier.gradientBackground(brush: Brush): Modifier = this.background(brush = brush)
+fun Modifier.gradientBackground(brush: Brush): Modifier = this.then(
+    background(brush)
+)

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -1,5 +1,7 @@
 package com.gymbro.feature.exerciselibrary
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -15,7 +17,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -25,14 +26,13 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -40,10 +40,14 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -53,18 +57,27 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.res.stringResource
+import com.gymbro.core.ui.theme.AccentGreenStart
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.AccentCyanStart
+import com.gymbro.core.ui.theme.AccentCyanEnd
+import com.gymbro.core.ui.theme.AccentAmberStart
+import com.gymbro.core.ui.theme.AccentAmberEnd
+import com.gymbro.core.ui.theme.AccentRed
+import com.gymbro.core.ui.theme.GlassOverlay
+import com.gymbro.core.ui.theme.GlassBorder
 import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.ExerciseCategory
 import com.gymbro.core.model.MuscleGroup
-import com.gymbro.feature.common.EmptyState
 import com.gymbro.feature.common.FullScreenLoading
+import com.gymbro.feature.common.GlassmorphicCard
 import com.gymbro.feature.common.ObserveErrors
 import com.gymbro.core.R
 
-private val AccentGreen = Color(0xFF00FF87)
-private val AccentCyan = Color(0xFF00E5FF)
-private val AccentAmber = Color(0xFFFFAB00)
-private val AccentRed = Color(0xFFCF6679)
+// Backwards compatibility
+private val AccentGreen = AccentGreenStart
+private val AccentCyan = AccentCyanStart
+private val AccentAmber = AccentAmberStart
 
 @Composable
 fun ExerciseLibraryRoute(
@@ -151,37 +164,43 @@ fun ExerciseLibraryScreen(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
-            // Search bar
-            TextField(
-                value = state.searchQuery,
-                onValueChange = { onEvent(ExerciseLibraryEvent.SearchQueryChanged(it)) },
+            // Search bar - Glassmorphic style
+            Surface(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
-                placeholder = {
-                    Text(stringResource(R.string.exercise_library_search), color = MaterialTheme.colorScheme.onSurfaceVariant)
-                },
-                leadingIcon = {
-                    Icon(
-                        Icons.Default.Search,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-                singleLine = true,
-                shape = RoundedCornerShape(12.dp),
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = MaterialTheme.colorScheme.surface,
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                    cursorColor = AccentGreen,
-                    focusedTextColor = MaterialTheme.colorScheme.onSurface,
-                    unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-                ),
-            )
+                shape = RoundedCornerShape(16.dp),
+                color = GlassOverlay,
+                border = BorderStroke(1.dp, GlassBorder),
+            ) {
+                TextField(
+                    value = state.searchQuery,
+                    onValueChange = { onEvent(ExerciseLibraryEvent.SearchQueryChanged(it)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = {
+                        Text(stringResource(R.string.exercise_library_search), color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Default.Search,
+                            contentDescription = null,
+                            tint = AccentGreenStart,
+                        )
+                    },
+                    singleLine = true,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        cursorColor = AccentGreenStart,
+                        focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                )
+            }
 
-            // Muscle group filter chips
+            // Muscle group filter chips with gradient when selected
             val filterGroups = listOf(
                 MuscleGroup.CHEST, MuscleGroup.BACK, MuscleGroup.QUADRICEPS,
                 MuscleGroup.SHOULDERS, MuscleGroup.BICEPS, MuscleGroup.CORE,
@@ -195,7 +214,7 @@ fun ExerciseLibraryScreen(
             ) {
                 filterGroups.forEach { group ->
                     val isSelected = state.selectedMuscleGroup == group
-                    FilterChip(
+                    GradientFilterChip(
                         selected = isSelected,
                         onClick = {
                             onEvent(
@@ -204,19 +223,7 @@ fun ExerciseLibraryScreen(
                                 ),
                             )
                         },
-                        label = { Text(group.displayName, fontSize = 13.sp) },
-                        colors = FilterChipDefaults.filterChipColors(
-                            containerColor = MaterialTheme.colorScheme.surface,
-                            labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            selectedContainerColor = AccentGreen.copy(alpha = 0.15f),
-                            selectedLabelColor = AccentGreen,
-                        ),
-                        border = FilterChipDefaults.filterChipBorder(
-                            borderColor = MaterialTheme.colorScheme.surfaceVariant,
-                            selectedBorderColor = AccentGreen.copy(alpha = 0.5f),
-                            enabled = true,
-                            selected = isSelected,
-                        ),
+                        label = group.displayName,
                     )
                 }
             }
@@ -233,14 +240,14 @@ fun ExerciseLibraryScreen(
                 }
                 else -> {
                     LazyColumn(
-                        contentPadding = PaddingValues(horizontal = 16.dp),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         items(
                             items = state.exercises,
                             key = { it.id.toString() },
                         ) { exercise ->
-                            ExerciseRow(
+                            ExerciseCard(
                                 exercise = exercise,
                                 onClick = { onEvent(ExerciseLibraryEvent.ExerciseClicked(exercise)) },
                             )
@@ -253,82 +260,186 @@ fun ExerciseLibraryScreen(
 }
 
 @Composable
-private fun ExerciseRow(
+private fun GradientFilterChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: String,
+) {
+    var isPressed by remember { mutableStateOf(false) }
+    val scale by animateFloatAsState(
+        targetValue = if (selected) 1.0f else if (isPressed) 0.95f else 1.0f,
+        label = "chip_scale"
+    )
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.scale(scale),
+        shape = RoundedCornerShape(20.dp),
+        color = if (selected) Color.Transparent else GlassOverlay,
+        border = if (selected) null else BorderStroke(1.dp, GlassBorder),
+    ) {
+        Box(
+            modifier = Modifier
+                .then(
+                    if (selected) {
+                        Modifier.background(
+                            Brush.horizontalGradient(
+                                listOf(AccentGreenStart, AccentGreenEnd)
+                            )
+                        )
+                    } else {
+                        Modifier
+                    }
+                )
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Text(
+                text = label,
+                fontSize = 13.sp,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                color = if (selected) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExerciseCard(
     exercise: Exercise,
     onClick: () -> Unit,
 ) {
-    Row(
+    var isPressed by remember { mutableStateOf(false) }
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1.0f,
+        label = "card_scale"
+    )
+
+    // Accent color based on muscle group
+    val accentColor = when (exercise.muscleGroup) {
+        MuscleGroup.CHEST, MuscleGroup.BICEPS, MuscleGroup.TRICEPS -> AccentGreenStart
+        MuscleGroup.BACK -> AccentCyanStart
+        MuscleGroup.QUADRICEPS, MuscleGroup.HAMSTRINGS, MuscleGroup.GLUTES, MuscleGroup.CALVES -> AccentAmberStart
+        MuscleGroup.SHOULDERS -> AccentGreenEnd
+        MuscleGroup.CORE -> AccentCyanEnd
+        else -> AccentGreenStart
+    }
+
+    GlassmorphicCard(
         modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .clickable(onClick = onClick)
-            .padding(vertical = 12.dp, horizontal = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
+            .scale(scale)
+            .clickable {
+                isPressed = true
+                onClick()
+            },
+        accentColor = accentColor,
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = exercise.name,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onBackground,
-                fontWeight = FontWeight.SemiBold,
-            )
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                CategoryBadge(category = exercise.category)
-                Spacer(modifier = Modifier.width(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "•",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 12.sp,
+                    text = exercise.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = exercise.muscleGroup.displayName,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    CategoryBadge(category = exercise.category)
+                    Text(
+                        text = "•",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                    )
+                    Text(
+                        text = exercise.muscleGroup.displayName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
-        }
 
-        Icon(
-            Icons.AutoMirrored.Filled.KeyboardArrowRight,
-            contentDescription = stringResource(R.string.exercise_library_view_details),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(20.dp),
-        )
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = stringResource(R.string.exercise_library_view_details),
+                tint = accentColor,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+
+    // Reset pressed state
+    LaunchedEffect(isPressed) {
+        if (isPressed) {
+            kotlinx.coroutines.delay(100)
+            isPressed = false
+        }
     }
 }
 
 @Composable
 private fun CategoryBadge(category: ExerciseCategory) {
-    val color = when (category) {
-        ExerciseCategory.COMPOUND -> AccentGreen
-        ExerciseCategory.ISOLATION -> AccentAmber
-        ExerciseCategory.ACCESSORY -> AccentCyan
-        ExerciseCategory.CARDIO -> AccentRed
+    val gradientColors = when (category) {
+        ExerciseCategory.COMPOUND -> listOf(AccentGreenStart, AccentGreenEnd)
+        ExerciseCategory.ISOLATION -> listOf(AccentAmberStart, AccentAmberEnd)
+        ExerciseCategory.ACCESSORY -> listOf(AccentCyanStart, AccentCyanEnd)
+        ExerciseCategory.CARDIO -> listOf(AccentRed, AccentRed.copy(alpha = 0.8f))
     }
 
-    Text(
-        text = category.displayName.uppercase(),
-        fontSize = 10.sp,
-        fontWeight = FontWeight.Bold,
-        color = color,
+    Box(
         modifier = Modifier
             .background(
-                color = color.copy(alpha = 0.15f),
-                shape = RoundedCornerShape(4.dp),
+                brush = Brush.horizontalGradient(gradientColors),
+                shape = RoundedCornerShape(6.dp),
             )
-            .padding(horizontal = 6.dp, vertical = 2.dp),
-    )
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = category.displayName.uppercase(),
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+    }
 }
 
 @Composable
 private fun EmptyExercisesView() {
-    EmptyState(
-        icon = Icons.Default.Search,
-        title = stringResource(R.string.exercise_library_empty_title),
-        subtitle = stringResource(R.string.exercise_library_empty_subtitle),
-    )
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            Icons.Default.Search,
+            contentDescription = null,
+            modifier = Modifier.size(96.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+        )
+        
+        Spacer(modifier = Modifier.height(24.dp))
+        
+        Text(
+            text = stringResource(R.string.exercise_library_empty_title),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        
+        Spacer(modifier = Modifier.height(8.dp))
+        
+        Text(
+            text = "No encontramos ese ejercicio. ¿Quieres crearlo?",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }


### PR DESCRIPTION
## Changes

- **Search bar**: Glassmorphic style with semi-transparent background (GlassOverlay), subtle white border (GlassBorder), rounded corners (16dp), accent green cursor
- **Filter chips**: Gradient background when selected (AccentGreenStart → AccentGreenEnd) instead of solid color, scale animation on selection (0.95 → 1.0)
- **Exercise cards**: Replaced plain Row with GlassmorphicCard component
  - Accent stripe color based on muscle group (Chest/Arms = Green, Back = Cyan, Legs = Amber, Shoulders/Core = gradient variants)
  - Tap animation with scale (0.97 on press)
- **Category badges**: Gradient backgrounds instead of solid colors, bigger size (10dp → 11sp font, more padding)
- **Empty state**: Larger icon (96dp), motivational Spanish copy: 'No encontramos ese ejercicio. ¿Quieres crearlo?'
- **Architecture**: Moved theme colors to \:core\ module with Compose UI support for cross-module access

## Testing
- ✅ Build successful: \ssembleDebug\ passes
- UI changes follow UX roadmap section 4.1

Closes #215