### PR TITLE
feat: [UX] Polish Recovery and Onboarding screens

### DIFF
--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -102,6 +102,9 @@
     <string name="recovery_permissions_title">Connect Your Health Data</string>
     <string name="recovery_permissions_message">GymBro uses sleep, heart rate, and step data to calculate your recovery readiness and optimize training.</string>
     <string name="recovery_grant_permissions">Grant Permissions</string>
+    <string name="recovery_tip_green">Great recovery! You\'re ready for high-intensity training. Focus on compound lifts and push your limits.</string>
+    <string name="recovery_tip_amber">Moderate recovery. Consider medium-intensity training or focus on technique and volume work.</string>
+    <string name="recovery_tip_red">Low recovery detected. Prioritize rest, light mobility work, or active recovery. Listen to your body.</string>
 
     <!-- Recovery Status Labels -->
     <string name="recovery_status_optimal">Optimal</string>

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
@@ -1,5 +1,6 @@
 package com.gymbro.feature.onboarding
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -37,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
@@ -47,9 +49,15 @@ import com.gymbro.core.R
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gymbro.core.preferences.UserPreferences.WeightUnit
+import com.gymbro.core.ui.theme.AccentGreenStart
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.Background
+import com.gymbro.core.ui.theme.OnSurfaceVariant
+import com.gymbro.core.ui.theme.GlassOverlay
+import com.gymbro.feature.common.GlassmorphicCard
+import com.gymbro.feature.common.GradientButton
 
 private val AccentGreen = Color(0xFF00FF87)
-private val Background = Color(0xFF0A0A0A)
 private val SurfaceVariant = Color(0xFF2C2C2E)
 
 @Composable
@@ -135,28 +143,38 @@ private fun WelcomePage() {
         Icon(
             imageVector = Icons.Default.FitnessCenter,
             contentDescription = null,
-            tint = AccentGreen,
-            modifier = Modifier.size(120.dp),
+            tint = AccentGreenStart,
+            modifier = Modifier.size(160.dp),
         )
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(40.dp))
+        
+        // Gradient text for app title
         Text(
             text = stringResource(R.string.onboarding_app_title),
-            style = MaterialTheme.typography.displayLarge,
+            style = MaterialTheme.typography.displayLarge.copy(
+                brush = Brush.linearGradient(
+                    colors = listOf(AccentGreenStart, AccentGreenEnd)
+                )
+            ),
             fontWeight = FontWeight.Bold,
-            color = Color.White,
         )
+        
         Spacer(modifier = Modifier.height(16.dp))
+        
         Text(
-            text = stringResource(R.string.onboarding_tagline),
-            style = MaterialTheme.typography.headlineMedium,
-            color = AccentGreen,
+            text = "Tu compañero de gym inteligente",
+            style = MaterialTheme.typography.headlineSmall,
+            color = OnSurfaceVariant,
             fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center,
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        
+        Spacer(modifier = Modifier.height(24.dp))
+        
         Text(
             text = stringResource(R.string.onboarding_subtitle),
             style = MaterialTheme.typography.bodyLarge,
-            color = Color(0xFF9E9E9E),
+            color = OnSurfaceVariant,
             textAlign = TextAlign.Center,
         )
     }
@@ -253,13 +271,13 @@ private fun GetStartedPage(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            UnitButton(
+            UnitCard(
                 text = stringResource(R.string.onboarding_unit_kg),
                 isSelected = selectedUnit == WeightUnit.KG,
                 onClick = { onUnitSelected(WeightUnit.KG) },
                 modifier = Modifier.weight(1f),
             )
-            UnitButton(
+            UnitCard(
                 text = stringResource(R.string.onboarding_unit_lbs),
                 isSelected = selectedUnit == WeightUnit.LBS,
                 onClick = { onUnitSelected(WeightUnit.LBS) },
@@ -280,75 +298,66 @@ private fun GetStartedPage(
         OutlinedTextField(
             value = userName,
             onValueChange = onNameChanged,
-            placeholder = { Text(stringResource(R.string.onboarding_name_placeholder), color = Color(0xFF9E9E9E)) },
+            placeholder = { Text(stringResource(R.string.onboarding_name_placeholder), color = OnSurfaceVariant) },
             modifier = Modifier.fillMaxWidth(),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedTextColor = Color.White,
                 unfocusedTextColor = Color.White,
-                focusedBorderColor = AccentGreen,
-                unfocusedBorderColor = Color(0xFF9E9E9E),
-                cursorColor = AccentGreen,
+                focusedBorderColor = AccentGreenStart,
+                unfocusedBorderColor = OnSurfaceVariant,
+                cursorColor = AccentGreenStart,
             ),
             singleLine = true,
         )
 
         Spacer(modifier = Modifier.height(48.dp))
 
-        Button(
+        GradientButton(
+            text = "¡Vamos!",
             onClick = onComplete,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = AccentGreen,
-                contentColor = Color.Black,
-            ),
-            shape = RoundedCornerShape(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.onboarding_lets_go),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-            )
-        }
+        )
     }
 }
 
 @Composable
-private fun UnitButton(
+private fun UnitCard(
     text: String,
     isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (isSelected) {
-        Button(
-            onClick = onClick,
-            modifier = modifier.height(48.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = AccentGreen,
-                contentColor = Color.Black,
-            ),
-            shape = RoundedCornerShape(12.dp),
-        ) {
-            Text(
-                text = text,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Bold,
+    GlassmorphicCard(
+        modifier = modifier
+            .height(80.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(
+                if (isSelected) {
+                    Brush.linearGradient(
+                        colors = listOf(AccentGreenStart, AccentGreenEnd)
+                    )
+                } else {
+                    Brush.linearGradient(
+                        colors = listOf(GlassOverlay, GlassOverlay)
+                    )
+                }
             )
-        }
-    } else {
-        OutlinedButton(
-            onClick = onClick,
-            modifier = modifier.height(48.dp),
-            colors = ButtonDefaults.outlinedButtonColors(
-                contentColor = Color.White,
+            .clip(RoundedCornerShape(16.dp))
+            .then(
+                Modifier.clickable(onClick = onClick)
             ),
-            shape = RoundedCornerShape(12.dp),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = text,
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                color = if (isSelected) Color.Black else Color.White,
             )
         }
     }
@@ -370,7 +379,7 @@ private fun PageIndicators(
                     .size(if (index == currentPage) 10.dp else 8.dp)
                     .clip(CircleShape)
                     .background(
-                        if (index == currentPage) AccentGreen else Color(0xFF9E9E9E)
+                        if (index == currentPage) AccentGreenStart else GlassOverlay
                     ),
             )
         }

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
@@ -56,7 +56,17 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.gymbro.core.model.SleepData
+import com.gymbro.core.ui.theme.AccentGreenStart
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.AccentAmberStart
+import com.gymbro.core.ui.theme.AccentAmberEnd
+import com.gymbro.core.ui.theme.AccentRed
+import com.gymbro.core.ui.theme.Background
+import com.gymbro.core.ui.theme.OnSurfaceVariant
 import com.gymbro.feature.common.FullScreenLoading
+import com.gymbro.feature.common.GlassmorphicCard
+import com.gymbro.feature.common.AnimatedProgressCircle
+import androidx.compose.ui.graphics.Brush
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -94,7 +104,7 @@ internal fun RecoveryScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(SurfaceDark)
+            .background(Background)
             .verticalScroll(rememberScrollState())
             .padding(16.dp),
     ) {
@@ -182,76 +192,59 @@ internal fun RecoveryScreen(
 
 @Composable
 private fun ReadinessScoreCard(score: Int, label: String) {
-    val scoreColor = when {
-        score >= 80 -> AccentGreen
-        score >= 60 -> Color(0xFFFFD600)
-        score >= 40 -> Color(0xFFFF9100)
-        else -> Color(0xFFFF5252)
+    val gradientColors = when {
+        score >= 80 -> listOf(AccentGreenStart, AccentGreenEnd)
+        score >= 60 -> listOf(AccentAmberStart, AccentAmberEnd)
+        else -> listOf(AccentRed, AccentRed)
     }
+    val scoreColor = gradientColors[0]
 
-    Card(
-        colors = CardDefaults.cardColors(containerColor = CardBackground),
-        shape = RoundedCornerShape(20.dp),
+    GlassmorphicCard(
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(24.dp),
+                .padding(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = stringResource(R.string.recovery_readiness_score),
                 style = MaterialTheme.typography.titleMedium,
-                color = Color(0xFF9E9E9E),
+                color = OnSurfaceVariant,
             )
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Circular score indicator
+            // Large animated progress circle with gradient
             Box(contentAlignment = Alignment.Center, modifier = Modifier.semantics {
                 contentDescription = "Readiness score: $score out of 100, $label"
             }) {
-                Canvas(modifier = Modifier.size(140.dp).clearAndSetSemantics { }) {
-                    // Background arc
-                    drawArc(
-                        color = Color(0xFF2A2A2A),
-                        startAngle = 135f,
-                        sweepAngle = 270f,
-                        useCenter = false,
-                        style = Stroke(width = 12.dp.toPx()),
-                        topLeft = Offset(12.dp.toPx(), 12.dp.toPx()),
-                        size = Size(
-                            size.width - 24.dp.toPx(),
-                            size.height - 24.dp.toPx(),
-                        ),
-                    )
-                    // Score arc
-                    drawArc(
-                        color = scoreColor,
-                        startAngle = 135f,
-                        sweepAngle = 270f * (score / 100f),
-                        useCenter = false,
-                        style = Stroke(width = 12.dp.toPx()),
-                        topLeft = Offset(12.dp.toPx(), 12.dp.toPx()),
-                        size = Size(
-                            size.width - 24.dp.toPx(),
-                            size.height - 24.dp.toPx(),
-                        ),
-                    )
-                }
-
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = "$score",
-                        fontSize = 48.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = scoreColor,
-                    )
+                AnimatedProgressCircle(
+                    progress = score / 100f,
+                    size = 160.dp,
+                    strokeWidth = 16.dp,
+                    gradientColors = gradientColors,
+                    modifier = Modifier.clearAndSetSemantics { }
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "$score",
+                            fontSize = 56.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                        )
+                        Text(
+                            text = "%",
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = OnSurfaceVariant,
+                        )
+                    }
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
             Text(
                 text = label,
@@ -259,6 +252,10 @@ private fun ReadinessScoreCard(score: Int, label: String) {
                 color = scoreColor,
                 fontWeight = FontWeight.SemiBold,
             )
+            
+            Spacer(modifier = Modifier.height(16.dp))
+            
+            RecoveryTips(score = score)
         }
     }
 }
@@ -320,15 +317,13 @@ private fun MetricCard(
     value: String,
     iconTint: Color,
 ) {
-    Card(
+    GlassmorphicCard(
         modifier = modifier.semantics(mergeDescendants = true) { 
             contentDescription = "$label: $value"
         },
-        colors = CardDefaults.cardColors(containerColor = CardBackground),
-        shape = RoundedCornerShape(16.dp),
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(4.dp),
         ) {
             Box(
                 modifier = Modifier
@@ -356,9 +351,44 @@ private fun MetricCard(
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodySmall,
-                color = Color(0xFF9E9E9E),
+                color = OnSurfaceVariant,
             )
         }
+    }
+}
+
+@Composable
+private fun RecoveryTips(score: Int) {
+    val tipText = when {
+        score >= 80 -> stringResource(R.string.recovery_tip_green)
+        score >= 60 -> stringResource(R.string.recovery_tip_amber)
+        else -> stringResource(R.string.recovery_tip_red)
+    }
+    
+    val tipColor = when {
+        score >= 80 -> AccentGreenStart
+        score >= 60 -> AccentAmberStart
+        else -> AccentRed
+    }
+    
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(tipColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "💡 Recovery Tip",
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = tipColor,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = tipText,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.White,
+        )
     }
 }
 


### PR DESCRIPTION
Closes #221

## Changes

### Recovery Screen
- ✅ Large 160dp AnimatedProgressCircle with gradient for readiness score
- ✅ GlassmorphicCard components for metric cards (Sleep, HRV, Activity, Steps)
- ✅ Recovery tips with actionable advice based on score (green=ready, amber=moderate, red=rest)
- ✅ Updated to use theme colors from Color.kt

### Onboarding Screen  
- ✅ Larger icon (160dp) and gradient text for GymBro title
- ✅ Spanish tagline: Tu compañero de gym inteligente
- ✅ GlassmorphicCards for unit selection with gradient selected state
- ✅ GradientButton ¡Vamos! instead of plain button
- ✅ Accent green for active page indicator, glass for inactive

## Build Status
✅ Build successful - assembleDebug passes

## Working as
Tank - UX/Performance Engineer