### PR TITLE
[UX] Implementar tooltips contextuales para first-time discovery

### DIFF
--- a/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
+++ b/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
@@ -99,4 +99,14 @@ class UserPreferences @Inject constructor(
             preferences.clear()
         }
     }
+
+    fun isTooltipShown(id: String): Flow<Boolean> = dataStore.data.map { preferences ->
+        preferences[booleanPreferencesKey("tooltip_shown_$id")] ?: false
+    }
+
+    suspend fun markTooltipShown(id: String) {
+        dataStore.edit { preferences ->
+            preferences[booleanPreferencesKey("tooltip_shown_$id")] = true
+        }
+    }
 }

--- a/android/feature/src/main/java/com/gymbro/feature/common/TooltipManager.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/TooltipManager.kt
@@ -1,0 +1,24 @@
+package com.gymbro.feature.common
+
+import com.gymbro.core.preferences.UserPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TooltipManager @Inject constructor(
+    private val userPreferences: UserPreferences,
+) {
+    suspend fun shouldShow(id: String): Boolean {
+        return !userPreferences.isTooltipShown(id).first()
+    }
+
+    fun shouldShowFlow(id: String): Flow<Boolean> {
+        return userPreferences.isTooltipShown(id)
+    }
+
+    suspend fun markShown(id: String) {
+        userPreferences.markTooltipShown(id)
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/common/TooltipOverlay.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/TooltipOverlay.kt
@@ -1,0 +1,75 @@
+package com.gymbro.feature.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import com.gymbro.core.ui.theme.GlassBorder
+import com.gymbro.core.ui.theme.GlassOverlay
+
+enum class TooltipPosition {
+    TOP_CENTER,
+    BOTTOM_CENTER,
+    CENTER
+}
+
+@Composable
+fun TooltipOverlay(
+    message: String,
+    position: TooltipPosition = TooltipPosition.CENTER,
+    offsetY: Int = 0,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color(0x80000000))
+            .zIndex(1000f),
+        contentAlignment = when (position) {
+            TooltipPosition.TOP_CENTER -> Alignment.TopCenter
+            TooltipPosition.BOTTOM_CENTER -> Alignment.BottomCenter
+            TooltipPosition.CENTER -> Alignment.Center
+        }
+    ) {
+        GlassmorphicCard(
+            modifier = Modifier
+                .widthIn(max = 280.dp)
+                .padding(24.dp)
+                .offset { IntOffset(0, offsetY) }
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = message,
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    lineHeight = 22.sp,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                GradientButton(
+                    text = "Entendido",
+                    onClick = onDismiss,
+                    modifier = Modifier
+                )
+            }
+        }
+    }
+}

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
 import androidx.compose.ui.res.stringResource
 import com.gymbro.core.ui.theme.AccentGreenStart
 import com.gymbro.core.ui.theme.AccentGreenEnd
@@ -75,8 +76,11 @@ import com.gymbro.core.model.MuscleGroup
 import com.gymbro.feature.common.FullScreenLoading
 import com.gymbro.feature.common.GlassmorphicCard
 import com.gymbro.feature.common.ObserveErrors
+import com.gymbro.feature.common.TooltipOverlay
+import com.gymbro.feature.common.TooltipPosition
 import com.gymbro.feature.common.icon
 import com.gymbro.core.R
+import kotlinx.coroutines.launch
 
 // Backwards compatibility
 private val AccentGreen = AccentGreenStart
@@ -93,6 +97,11 @@ fun ExerciseLibraryRoute(
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    var showFilterTooltip by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        showFilterTooltip = viewModel.tooltipManager.shouldShow("exercise_library_filter")
+    }
 
     ObserveErrors(
         errorFlow = viewModel.errorEvents,
@@ -121,6 +130,13 @@ fun ExerciseLibraryRoute(
         onNavigateToCreateExercise = onNavigateToCreateExercise,
         isPickerMode = isPickerMode,
         snackbarHostState = snackbarHostState,
+        showFilterTooltip = showFilterTooltip,
+        onTooltipDismissed = {
+            showFilterTooltip = false
+            viewModel.viewModelScope.launch {
+                viewModel.tooltipManager.markShown("exercise_library_filter")
+            }
+        }
     )
 }
 
@@ -132,8 +148,11 @@ fun ExerciseLibraryScreen(
     onNavigateToCreateExercise: () -> Unit = {},
     isPickerMode: Boolean = false,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    showFilterTooltip: Boolean = false,
+    onTooltipDismissed: () -> Unit = {},
 ) {
-    Scaffold(
+    Box {
+        Scaffold(
         topBar = {
             TopAppBar(
                 title = {
@@ -260,6 +279,16 @@ fun ExerciseLibraryScreen(
                     }
                 }
             }
+        }
+    }
+
+        if (showFilterTooltip && !isPickerMode) {
+            TooltipOverlay(
+                message = "Filtra por grupo muscular",
+                position = TooltipPosition.TOP_CENTER,
+                offsetY = 300,
+                onDismiss = onTooltipDismissed
+            )
         }
     }
 }

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryViewModel.kt
@@ -3,6 +3,7 @@ package com.gymbro.feature.exerciselibrary
 import androidx.lifecycle.viewModelScope
 import com.gymbro.core.repository.ExerciseRepository
 import com.gymbro.feature.common.BaseViewModel
+import com.gymbro.feature.common.TooltipManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -17,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ExerciseLibraryViewModel @Inject constructor(
     private val exerciseRepository: ExerciseRepository,
+    val tooltipManager: TooltipManager,
 ) : BaseViewModel() {
 
     private val _state = MutableStateFlow(ExerciseLibraryState())

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
@@ -42,7 +42,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -65,6 +67,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
 import com.gymbro.core.model.E1RMDataPoint
 import com.gymbro.core.model.PersonalRecord
 import com.gymbro.core.model.PlateauAlert
@@ -83,6 +86,9 @@ import com.gymbro.core.ui.theme.SurfaceVariant
 import com.gymbro.feature.common.EmptyState
 import com.gymbro.feature.common.FullScreenLoading
 import com.gymbro.feature.common.GlassmorphicCard
+import com.gymbro.feature.common.TooltipOverlay
+import com.gymbro.feature.common.TooltipPosition
+import kotlinx.coroutines.launch
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -96,6 +102,11 @@ fun ProgressRoute(
 ) {
     val viewModel: ProgressViewModel = hiltViewModel()
     val state by viewModel.state.collectAsStateWithLifecycle()
+    var showChartTooltip by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        showChartTooltip = viewModel.tooltipManager.shouldShow("progress_chart")
+    }
 
     LaunchedEffect(Unit) {
         viewModel.effects.collect { effect ->
@@ -110,6 +121,13 @@ fun ProgressRoute(
         state = state,
         onEvent = viewModel::onEvent,
         onNavigateToAnalytics = onNavigateToAnalytics,
+        showChartTooltip = showChartTooltip,
+        onTooltipDismissed = {
+            showChartTooltip = false
+            viewModel.viewModelScope.launch {
+                viewModel.tooltipManager.markShown("progress_chart")
+            }
+        }
     )
 }
 
@@ -118,6 +136,8 @@ private fun ProgressScreen(
     state: ProgressState,
     onEvent: (ProgressEvent) -> Unit,
     onNavigateToAnalytics: () -> Unit = {},
+    showChartTooltip: Boolean = false,
+    onTooltipDismissed: () -> Unit = {},
 ) {
     if (state.isLoading) {
         FullScreenLoading(message = "Loading progress...")
@@ -129,7 +149,8 @@ private fun ProgressScreen(
         return
     }
 
-    LazyColumn(
+    Box {
+        LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background),
@@ -219,6 +240,16 @@ private fun ProgressScreen(
                     }
                 }
             }
+        }
+    }
+
+        if (showChartTooltip && state.chartData.isNotEmpty()) {
+            TooltipOverlay(
+                message = "Tu evolución de fuerza",
+                position = TooltipPosition.CENTER,
+                offsetY = 0,
+                onDismiss = onTooltipDismissed
+            )
         }
     }
 }

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.gymbro.core.repository.ExerciseRepository
 import com.gymbro.core.service.PersonalRecordService
 import com.gymbro.core.service.PlateauDetectionService
+import com.gymbro.feature.common.TooltipManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,6 +21,7 @@ class ProgressViewModel @Inject constructor(
     private val prService: PersonalRecordService,
     private val exerciseRepository: ExerciseRepository,
     private val plateauDetectionService: PlateauDetectionService,
+    val tooltipManager: TooltipManager,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ProgressState())

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -52,7 +52,9 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -72,6 +74,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
 import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.MuscleGroup
 import com.gymbro.core.preferences.UserPreferences
@@ -86,6 +89,9 @@ import com.gymbro.feature.common.AnimatedProgressCircle
 import com.gymbro.feature.common.FullScreenLoading
 import com.gymbro.feature.common.GlassmorphicCard
 import com.gymbro.feature.common.GradientButton
+import com.gymbro.feature.common.TooltipOverlay
+import com.gymbro.feature.common.TooltipPosition
+import kotlinx.coroutines.launch
 
 private fun getMuscleGroupColor(muscleGroup: MuscleGroup): Color {
     return when (muscleGroup) {
@@ -109,6 +115,11 @@ fun ActiveWorkoutRoute(
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle()
     val context = androidx.compose.ui.platform.LocalContext.current
+    var showCompleteSetTooltip by remember { mutableStateOf(false) }
+    
+    LaunchedEffect(Unit) {
+        showCompleteSetTooltip = viewModel.tooltipManager.shouldShow("active_workout_complete_set")
+    }
     
     // Get services from Hilt through entry point
     val voiceRecognitionService = remember {
@@ -156,6 +167,13 @@ fun ActiveWorkoutRoute(
         onEvent = viewModel::onEvent,
         voiceRecognitionService = voiceRecognitionService,
         defaultWeightUnit = weightUnit.value,
+        showCompleteSetTooltip = showCompleteSetTooltip,
+        onTooltipDismissed = {
+            showCompleteSetTooltip = false
+            viewModel.viewModelScope.launch {
+                viewModel.tooltipManager.markShown("active_workout_complete_set")
+            }
+        }
     )
 }
 
@@ -178,13 +196,18 @@ fun ActiveWorkoutScreen(
     onEvent: (ActiveWorkoutEvent) -> Unit,
     voiceRecognitionService: VoiceRecognitionService,
     defaultWeightUnit: UserPreferences.WeightUnit,
+    showCompleteSetTooltip: Boolean = false,
+    onTooltipDismissed: () -> Unit = {},
 ) {
     if (state.isLoading) {
         FullScreenLoading(message = "Starting workout...")
         return
     }
 
-    Scaffold(
+    Box {
+        val haptic = LocalHapticFeedback.current
+        
+        Scaffold(
         topBar = {
             TopAppBar(
                 title = {
@@ -297,6 +320,16 @@ fun ActiveWorkoutScreen(
                 // Bottom spacer for FAB
                 item { Spacer(modifier = Modifier.height(80.dp)) }
             }
+        }
+    }
+
+        if (showCompleteSetTooltip && state.exercises.isNotEmpty() && state.exercises.any { it.sets.isNotEmpty() }) {
+            TooltipOverlay(
+                message = "Toca para completar la serie",
+                position = TooltipPosition.CENTER,
+                offsetY = 100,
+                onDismiss = onTooltipDismissed
+            )
         }
     }
 }
@@ -471,6 +504,8 @@ private fun ExerciseCardContent(
     voiceRecognitionService: com.gymbro.core.voice.VoiceRecognitionService,
     defaultWeightUnit: com.gymbro.core.preferences.UserPreferences.WeightUnit,
 ) {
+    val haptic = LocalHapticFeedback.current
+    
     Column(modifier = Modifier.fillMaxWidth()) {
         // Exercise header
         Row(

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -6,6 +6,7 @@ import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.ExerciseSet
 import com.gymbro.core.repository.WorkoutRepository
 import com.gymbro.core.service.PersonalRecordService
+import com.gymbro.feature.common.TooltipManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -23,6 +24,7 @@ import javax.inject.Inject
 class ActiveWorkoutViewModel @Inject constructor(
     private val workoutRepository: WorkoutRepository,
     private val personalRecordService: PersonalRecordService,
+    val tooltipManager: TooltipManager,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ActiveWorkoutState())


### PR DESCRIPTION
Closes #226

## Implementación

Este PR implementa tooltips contextuales que guían a nuevos usuarios a través de la app en su primera visita a cada pantalla.

### Cambios realizados:

1. **Creado TooltipOverlay composable** ('TooltipOverlay.kt'):
   - Overlay semi-transparente (0x80000000)
   - Bubble estilo GlassmorphicCard
   - Botón 'Entendido' con GradientButton
   - Posicionamiento configurable

2. **Creado TooltipManager** ('TooltipManager.kt'):
   - Tracking de tooltips mostrados en UserPreferences
   - Métodos shouldShow() y markShown()

3. **Tooltips agregados a pantallas clave:**
   - **ExerciseLibrary**: 'Filtra por grupo muscular' → apuntando a los filter chips
   - **ActiveWorkout**: 'Toca para completar la serie' → guía del botón Complete Set
   - **Progress**: 'Tu evolución de fuerza' → señala el área del chart

### Testing:
- ✅ Build exitoso
- ✅ Tooltips se muestran solo en primera visita
- ✅ Estado persiste en UserPreferences