### PR TITLE
fix: restore bottom nav position and library content

### DIFF
--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -30,14 +30,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -151,42 +147,38 @@ fun ExerciseLibraryScreen(
     showFilterTooltip: Boolean = false,
     onTooltipDismissed: () -> Unit = {},
 ) {
-    Box {
-        Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(if (isPickerMode) R.string.exercise_library_pick_title else R.string.exercise_library_title),
-                        style = MaterialTheme.typography.headlineMedium,
-                        modifier = Modifier.semantics { heading() }
-                    )
-                },
-                actions = {
-                    if (!isPickerMode) {
-                        IconButton(onClick = onNavigateToCreateExercise) {
-                            Icon(
-                                Icons.Default.Add,
-                                contentDescription = stringResource(R.string.exercise_library_create),
-                                tint = AccentGreen,
-                            )
-                        }
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    titleContentColor = MaterialTheme.colorScheme.onBackground,
-                ),
-            )
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) },
-        containerColor = MaterialTheme.colorScheme.background,
-    ) { innerPadding ->
+    Box(modifier = Modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
+            modifier = Modifier.fillMaxSize(),
         ) {
+            // Title Section
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 16.dp)
+            ) {
+                Text(
+                    text = stringResource(if (isPickerMode) R.string.exercise_library_pick_title else R.string.exercise_library_title),
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .semantics { heading() }
+                )
+                if (!isPickerMode) {
+                    IconButton(
+                        onClick = onNavigateToCreateExercise,
+                        modifier = Modifier.align(Alignment.CenterEnd)
+                    ) {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = stringResource(R.string.exercise_library_create),
+                            tint = AccentGreen,
+                        )
+                    }
+                }
+            }
             // Search bar - Glassmorphic style
             Surface(
                 modifier = Modifier
@@ -280,7 +272,6 @@ fun ExerciseLibraryScreen(
                 }
             }
         }
-    }
 
         if (showFilterTooltip && !isPickerMode) {
             TooltipOverlay(


### PR DESCRIPTION
## Problem

After merging multiple UX PRs, the app had a critical regression:
1. Bottom navigation bar was rendering at the TOP of the screen instead of bottom
2. Exercise Library content (exercises, search, filters) was not showing - just black screen

## Root Cause

The ExerciseLibraryScreen had a nested Scaffold with a TopAppBar, while the NavGraph already provided a Scaffold with bottomBar for the route. This created a nested Scaffold situation where:
- The inner Scaffold's topBar pushed all content down
- The bottom nav ended up at the top position
- Content wasn't rendering properly

## Solution

Removed the inner Scaffold from ExerciseLibraryScreen and converted it to match the pattern used by other main screens (HistoryListRoute, ProgressRoute):
- Replaced TopAppBar with a simple Box layout containing the title and actions
- Removed the nested Scaffold wrapper
- Screen now only contains content, letting the NavGraph's Scaffold handle the bottomBar

## Testing

✅ Built successfully
✅ Installed and launched on emulator
✅ Bottom navigation now correctly positioned at bottom
✅ Exercise Library content displays correctly

## Files Changed

- \ndroid/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt\ (1 file, 30 insertions, 39 deletions)