### PR TITLE
fix: Canvas fillMaxSize causing bottom nav at top

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/MainActivity.kt
+++ b/android/app/src/main/java/com/gymbro/app/MainActivity.kt
@@ -3,7 +3,6 @@ package com.gymbro.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import com.gymbro.app.navigation.GymBroNavGraph
 import com.gymbro.app.ui.theme.GymBroTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -12,7 +11,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContent {
             GymBroTheme {
                 GymBroNavGraph()

--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -434,7 +436,8 @@ private fun GymBroBottomNavBar(
         // Animated indicator bar at the top of the bottom nav
         androidx.compose.foundation.Canvas(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
+                .height(3.dp)
                 .align(Alignment.TopStart)
         ) {
             val tabWidth = size.width / BottomNavTab.entries.size


### PR DESCRIPTION
Root cause: animated indicator Canvas used fillMaxSize() inside NavigationBar Box, expanding nav to full screen. Fix: fillMaxWidth().height(3.dp)