### PR TITLE
feat: Add app icon and splash screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <application
         android:name=".GymBroApplication"
         android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.GymBro">

--- a/android/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#0A0A0A"
+        android:pathData="M0,0h108v108h-108z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,42 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:scaleX="0.8"
+        android:scaleY="0.8"
+        android:translateX="10.8"
+        android:translateY="10.8">
+        <!-- Left weight -->
+        <path
+            android:fillColor="#00FF87"
+            android:pathData="M20,35 L30,35 L30,65 L20,65 Z" />
+        <path
+            android:fillColor="#00FF87"
+            android:pathData="M15,30 L35,30 L35,70 L15,70 Z" />
+        
+        <!-- Left bar connector -->
+        <path
+            android:fillColor="#00FF87"
+            android:pathData="M30,46 L45,46 L45,54 L30,54 Z" />
+        
+        <!-- Center grip -->
+        <path
+            android:fillColor="#00FF87"
+            android:pathData="M42,42 L66,42 L66,58 L42,58 Z" />
+        
+        <!-- Right bar connector -->
+        <path
+            android:fillColor="#00FF87"
+            android:pathData="M63,46 L78,46 L78,54 L63,54 Z" />
+        
+        <!-- Right weight -->
+        <path
+            android:fillColor="#00FF87"
+            android:pathData="M73,30 L93,30 L93,70 L73,70 Z" />
+        <path
+            android:fillColor="#00FF87"
+            android:pathData="M78,35 L88,35 L88,65 L78,65 Z" />
+    </group>
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Base Theme -->
     <style name="Theme.GymBro" parent="android:Theme.Material.NoActionBar">
         <item name="android:statusBarColor">#FF0A0A0A</item>
         <item name="android:navigationBarColor">#FF0A0A0A</item>
         <item name="android:windowBackground">#FF0A0A0A</item>
+        <!-- Android 12+ Splash Screen -->
+        <item name="android:windowSplashScreenBackground">#FF0A0A0A</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">#FF0A0A0A</item>
     </style>
 </resources>


### PR DESCRIPTION
Closes #253

Added GymBro branding to Android app:
- Vector drawable app icon (green dumbbell on dark background)
- Adaptive icon configuration for modern Android
- Android 12+ splash screen with GymBro colors (#00FF87 green, #0A0A0A dark)
- Launch theme configured with brand colors

Tested: ✅ Build passes with gradlew assembleDebug