### PR TITLE
fix: Onboarding i18n + Maestro flow corrections

### DIFF
--- a/.squad/agents/switch/history.md
+++ b/.squad/agents/switch/history.md
@@ -249,3 +249,34 @@ cd android
 - Bottom nav tab positions can be found precisely via uiautomator XML bounds on nav label text
 - The FAB's clickable area extends beyond the icon bounds (parent container provides the touch target)
 - Profile screen embeds settings inline (not a separate Settings screen from the tab)
+
+### 2026-04-08: Onboarding i18n Fix + Maestro Flow Corrections (PR #270)
+**Fixed hardcoded strings and Maestro YAML syntax errors across 12 files.**
+
+**Task 1 — Onboarding i18n:**
+- Found 1 hardcoded string in `OnboardingScreen.kt`: `"¡Vamos!"` → replaced with `stringResource(R.string.onboarding_lets_go)`
+- All other onboarding strings already used `stringResource()` correctly
+- Both `values/strings.xml` (English) and `values-es/strings.xml` (Spanish) had complete onboarding translations
+- Build verified: `assembleDebug` passed
+
+**Task 2 — Maestro flow fixes (11 YAML files):**
+- `full-e2e.yaml`: Replaced 3 invalid `swipeLeft` commands → `swipe: { direction: LEFT, duration: 400 }`
+- `onboarding-flow.yaml`: Same swipeLeft fix (3 occurrences) + added `clearState: true`
+- `smoke-test.yaml`: Removed `clearState: true`, used regex assertion `"GymBro|Exercise Library"` for state-agnostic check
+- `browse-library.yaml`: Removed mid-flow `clearState` block that would wipe onboarding; replaced with simple `launchApp`
+- Added explicit `- launchApp` to 7 flows that assumed app was already running (navigation-smoke, start-workout, complete-workout, check-history, check-progress, ai-coach, profile-settings)
+- Updated ALL assertion text from Spanish to English for default-locale emulator compatibility
+- Added `- hideKeyboard` in onboarding flows before tapping "Let's Go" button (keyboard was covering it)
+
+**Maestro test results:**
+- `onboarding-flow.yaml`: ✅ **ALL 25 STEPS PASSED** — swipe syntax correct, all English assertions matched, keyboard dismiss worked
+- `smoke-test.yaml`: ❌ Emulator infrastructure issue (`device offline` / `Unable to launch app`) — YAML syntax valid, runtime failure is emulator instability, not code
+- Emulator (`emulator-5554`) went offline intermittently during Maestro test sessions — affects `launchApp` step consistently
+
+**Key Learnings:**
+- `swipeLeft` / `swipeRight` are NOT valid Maestro commands — must use `swipe: { direction: LEFT, duration: 400 }`
+- Maestro `assertVisible` uses regex matching — `"A|B"` syntax works for OR-matching (useful for state-agnostic assertions)
+- After `inputText` in Maestro, the keyboard covers bottom UI elements — always add `- hideKeyboard` before tapping buttons below the text field
+- The emulator locale is `es-ES` but app shows English strings due to `clearState: true` resetting app locale preferences
+- `clearState` in Maestro clears app data AND forces a fresh install — this means onboarding appears again, which breaks flows that expect post-onboarding state
+- Emulator offline errors are infrastructure issues (ADB TCP forwarding drops) — not YAML or code bugs

--- a/android/.maestro/ai-coach.yaml
+++ b/android/.maestro/ai-coach.yaml
@@ -5,33 +5,35 @@ tags:
   - ai
 ---
 
+- launchApp
+
 # Navigate to Profile tab first
-- tapOn: "Perfil"
-- assertVisible: "Hablar con Entrenador IA"
+- tapOn: "Profile"
+- assertVisible: "Talk to AI Coach"
 
 # Tap AI Coach button
-- tapOn: "Hablar con Entrenador IA"
+- tapOn: "Talk to AI Coach"
 
 # Verify Coach screen opens
-- assertVisible: "GymBro Entrenador IA"
+- assertVisible: "GymBro AI Coach"
 - takeScreenshot: coach_screen
 
 # Check for welcome message and quick prompts
-- assertVisible: "Tu asesor personal de entrenamiento de fuerza"
-- assertVisible: "Preguntas rápidas:"
+- assertVisible: "Your personal strength training advisor"
+- assertVisible: "Quick prompts:"
 - takeScreenshot: coach_welcome
 
 # Try tapping a quick prompt
-- tapOn: "¿Qué debería entrenar hoy?"
+- tapOn: "What should I train today?"
 - takeScreenshot: coach_prompt_sent
 
 # Wait for response (or loading indicator)
 - assertVisible:
-    text: "El entrenador está pensando...|Entrenador"
+    text: "Coach is thinking...|Coach"
     optional: true
 - takeScreenshot: coach_response
 
 # Navigate back
 - back
-- assertVisible: "Perfil"
+- assertVisible: "Profile"
 - takeScreenshot: coach_back_to_profile

--- a/android/.maestro/browse-library.yaml
+++ b/android/.maestro/browse-library.yaml
@@ -5,23 +5,22 @@ tags:
   - smoke
 ---
 
+- launchApp
+
 # Verify Exercise Library is visible
-- assertVisible: "Biblioteca de Ejercicios"
+- assertVisible: "Exercise Library"
 - takeScreenshot: library_home
 
 # Tap on search bar and type a query
-- tapOn: "Buscar ejercicios…"
+- tapOn: "Search exercises…"
 - inputText: "Press"
 - takeScreenshot: library_search_results
 
-# Clear search
-- clearState:
-    appId: com.gymbro.app
-- launchApp:
-    appId: com.gymbro.app
+# Relaunch app to clear search
+- launchApp
 
 # Wait for library to load
-- assertVisible: "Biblioteca de Ejercicios"
+- assertVisible: "Exercise Library"
 
 # Filter by Chest muscle group
 - tapOn: "Chest"

--- a/android/.maestro/check-history.yaml
+++ b/android/.maestro/check-history.yaml
@@ -5,16 +5,18 @@ tags:
   - smoke
 ---
 
+- launchApp
+
 # Navigate to History tab
-- tapOn: "Historial"
+- tapOn: "History"
 - takeScreenshot: history_tab
 
 # Verify History screen loads
-- assertVisible: "Historial de Entrenamientos"
+- assertVisible: "Workout History"
 
 # Check for workout entries or empty state
 - assertVisible:
-    text: "Sin Entrenamientos Aún|Hoy|Ayer"
+    text: "No Workouts Yet|Today|Yesterday"
     optional: true
 - takeScreenshot: history_content
 

--- a/android/.maestro/check-progress.yaml
+++ b/android/.maestro/check-progress.yaml
@@ -5,24 +5,26 @@ tags:
   - smoke
 ---
 
+- launchApp
+
 # Navigate to Progress tab
-- tapOn: "Progreso"
+- tapOn: "Progress"
 - takeScreenshot: progress_tab
 
 # Check for content or empty state
 - assertVisible:
-    text: "Sin entrenamientos aún"
+    text: "No workouts yet"
     optional: true
 
 # If data exists, verify KPI section
 - assertVisible:
-    text: "Volumen Semanal"
+    text: "Weekly Volume"
     optional: true
 - assertVisible:
-    text: "PRs Recientes"
+    text: "Recent PRs"
     optional: true
 - assertVisible:
-    text: "Tendencia Est. 1RM"
+    text: "Estimated 1RM Trend"
     optional: true
 - takeScreenshot: progress_kpi_cards
 

--- a/android/.maestro/complete-workout.yaml
+++ b/android/.maestro/complete-workout.yaml
@@ -5,18 +5,20 @@ tags:
   - e2e
 ---
 
+- launchApp
+
 # Start from Exercise Library
-- assertVisible: "Biblioteca de Ejercicios"
+- assertVisible: "Exercise Library"
 
 # Tap FAB to start workout
-- tapOn: "Iniciar Entrenamiento"
+- tapOn: "Start Workout"
 
 # Verify active workout
-- assertVisible: "Entrenamiento Activo"
+- assertVisible: "Active Workout"
 
 # Add an exercise
-- tapOn: "Añadir Ejercicio"
-- assertVisible: "Elegir Ejercicio"
+- tapOn: "Add Exercise"
+- assertVisible: "Pick Exercise"
 
 # Pick first available exercise
 - tapOn:
@@ -24,7 +26,7 @@ tags:
     index: 0
 
 # Verify back on workout screen
-- assertVisible: "Entrenamiento Activo"
+- assertVisible: "Active Workout"
 
 # Fill in weight for set 1
 - tapOn:
@@ -42,23 +44,23 @@ tags:
 
 # Complete the set (tap the check/complete button)
 - tapOn:
-    text: "Completar serie 1"
+    text: "Complete set 1"
 
 - takeScreenshot: workout_set1_completed
 
 # Finish the workout
-- tapOn: "Finalizar Entrenamiento"
+- tapOn: "Finish Workout"
 
 # Verify workout summary screen
-- assertVisible: "¡Entrenamiento Completado!"
+- assertVisible: "Workout Complete!"
 - takeScreenshot: workout_summary
 
 # Verify stats are displayed
-- assertVisible: "Estadísticas del Entrenamiento"
+- assertVisible: "Workout Stats"
 
 # Tap Done to return
-- tapOn: "Listo"
+- tapOn: "Done"
 
 # Back at exercise library
-- assertVisible: "Biblioteca de Ejercicios"
+- assertVisible: "Exercise Library"
 - takeScreenshot: workout_flow_complete

--- a/android/.maestro/full-e2e.yaml
+++ b/android/.maestro/full-e2e.yaml
@@ -5,6 +5,9 @@ tags:
   - regression
 ---
 
+- launchApp:
+    clearState: true
+
 # === PHASE 1: ONBOARDING ===
 
 # Welcome page
@@ -12,30 +15,37 @@ tags:
 - takeScreenshot: e2e_onboarding_start
 
 # Swipe through all pages
-- swipeLeft
-- assertVisible: "Registro Ultra-Rápido"
+- swipe:
+    direction: LEFT
+    duration: 400
+- assertVisible: "Ultra-Fast Logging"
 
-- swipeLeft
-- assertVisible: "Rastrea tu Progreso"
+- swipe:
+    direction: LEFT
+    duration: 400
+- assertVisible: "Track Your Progress"
 
-- swipeLeft
-- assertVisible: "Comencemos"
+- swipe:
+    direction: LEFT
+    duration: 400
+- assertVisible: "Let's Get Started"
 
 # Select units and enter name
-- tapOn: "Kilogramos (kg)"
-- tapOn: "Ingresa tu nombre"
+- tapOn: "Kilograms (kg)"
+- tapOn: "Enter your name"
 - inputText: "E2EUser"
+- hideKeyboard
 
 # Complete onboarding
-- tapOn: "¡Vamos!"
-- assertVisible: "Biblioteca de Ejercicios"
+- tapOn: "Let's Go"
+- assertVisible: "Exercise Library"
 - takeScreenshot: e2e_onboarding_complete
 
 # === PHASE 2: QUICK LIBRARY BROWSE ===
 
 # Dismiss tooltip if present
 - tapOn:
-    text: "Entendido"
+    text: "Got it"
     optional: true
 
 # Verify library content is loaded
@@ -44,13 +54,13 @@ tags:
 # === PHASE 3: START AND COMPLETE WORKOUT ===
 
 # Tap FAB to start workout
-- tapOn: "Iniciar Entrenamiento"
-- assertVisible: "Entrenamiento Activo"
+- tapOn: "Start Workout"
+- assertVisible: "Active Workout"
 - takeScreenshot: e2e_workout_started
 
 # Add an exercise
-- tapOn: "Añadir Ejercicio"
-- assertVisible: "Elegir Ejercicio"
+- tapOn: "Add Exercise"
+- assertVisible: "Pick Exercise"
 
 # Pick an exercise
 - tapOn:
@@ -58,7 +68,7 @@ tags:
     index: 0
 
 # Fill in set data
-- assertVisible: "Entrenamiento Activo"
+- assertVisible: "Active Workout"
 - tapOn:
     text: "0"
     index: 0
@@ -73,45 +83,45 @@ tags:
 
 # Complete the set
 - tapOn:
-    text: "Completar serie 1"
+    text: "Complete set 1"
 
 # Finish workout
-- tapOn: "Finalizar Entrenamiento"
+- tapOn: "Finish Workout"
 
 # Verify summary
-- assertVisible: "¡Entrenamiento Completado!"
+- assertVisible: "Workout Complete!"
 - takeScreenshot: e2e_workout_summary
 
 # Tap done
-- tapOn: "Listo"
-- assertVisible: "Biblioteca de Ejercicios"
+- tapOn: "Done"
+- assertVisible: "Exercise Library"
 
 # === PHASE 4: VERIFY HISTORY ===
 
 # Navigate to History tab
-- tapOn: "Historial"
-- assertVisible: "Historial de Entrenamientos"
+- tapOn: "History"
+- assertVisible: "Workout History"
 - takeScreenshot: e2e_history_with_workout
 
 # Verify the workout appears (today's entry)
 - assertVisible:
-    text: "Hoy"
+    text: "Today"
     optional: true
 
 # === PHASE 5: CHECK PROGRESS ===
 
 # Navigate to Progress tab
-- tapOn: "Progreso"
+- tapOn: "Progress"
 - takeScreenshot: e2e_progress_after_workout
 
 # === PHASE 6: VERIFY PROFILE ===
 
 # Navigate to Profile tab
-- tapOn: "Perfil"
-- assertVisible: "Cuenta"
+- tapOn: "Profile"
+- assertVisible: "Account"
 - takeScreenshot: e2e_profile
 
 # Return to library
-- tapOn: "Biblioteca"
-- assertVisible: "Biblioteca de Ejercicios"
+- tapOn: "Library"
+- assertVisible: "Exercise Library"
 - takeScreenshot: e2e_complete

--- a/android/.maestro/navigation-smoke.yaml
+++ b/android/.maestro/navigation-smoke.yaml
@@ -5,28 +5,30 @@ tags:
   - smoke
 ---
 
+- launchApp
+
 # Start at Library tab
-- assertVisible: "Biblioteca de Ejercicios"
+- assertVisible: "Exercise Library"
 - takeScreenshot: nav_library
 
 # Tap History tab
-- tapOn: "Historial"
-- assertVisible: "Historial de Entrenamientos"
+- tapOn: "History"
+- assertVisible: "Workout History"
 - takeScreenshot: nav_history
 
 # Tap Progress tab
-- tapOn: "Progreso"
+- tapOn: "Progress"
 - takeScreenshot: nav_progress
 
 # Tap Recovery tab
-- tapOn: "Recuperación"
+- tapOn: "Recovery"
 - takeScreenshot: nav_recovery
 
 # Tap Profile tab
-- tapOn: "Perfil"
+- tapOn: "Profile"
 - takeScreenshot: nav_profile
 
 # Navigate back to Library
-- tapOn: "Biblioteca"
-- assertVisible: "Biblioteca de Ejercicios"
+- tapOn: "Library"
+- assertVisible: "Exercise Library"
 - takeScreenshot: nav_back_to_library

--- a/android/.maestro/onboarding-flow.yaml
+++ b/android/.maestro/onboarding-flow.yaml
@@ -5,43 +5,53 @@ tags:
   - smoke
 ---
 
+- launchApp:
+    clearState: true
+
 # Page 0: Welcome
 - assertVisible: "GymBro"
-- assertVisible: "Tu compañero de gym inteligente"
+- assertVisible: "Your smart gym companion"
 - takeScreenshot: onboarding_welcome
 
 # Swipe to Page 1: Fast Logging
-- swipeLeft
+- swipe:
+    direction: LEFT
+    duration: 400
 
-- assertVisible: "Registro Ultra-Rápido"
+- assertVisible: "Ultra-Fast Logging"
 - takeScreenshot: onboarding_fast_logging
 
 # Swipe to Page 2: Track Progress
-- swipeLeft
+- swipe:
+    direction: LEFT
+    duration: 400
 
-- assertVisible: "Rastrea tu Progreso"
+- assertVisible: "Track Your Progress"
 - takeScreenshot: onboarding_track_progress
 
 # Swipe to Page 3: Get Started
-- swipeLeft
+- swipe:
+    direction: LEFT
+    duration: 400
 
-- assertVisible: "Comencemos"
-- assertVisible: "Unidades Preferidas"
-- assertVisible: "Kilogramos (kg)"
-- assertVisible: "Libras (lbs)"
+- assertVisible: "Let's Get Started"
+- assertVisible: "Preferred Units"
+- assertVisible: "Kilograms (kg)"
+- assertVisible: "Pounds (lbs)"
 - takeScreenshot: onboarding_get_started
 
 # Select kg unit
-- tapOn: "Kilogramos (kg)"
+- tapOn: "Kilograms (kg)"
 
 # Enter name
-- tapOn: "Ingresa tu nombre"
+- tapOn: "Enter your name"
 - inputText: "TestUser"
 - takeScreenshot: onboarding_name_entered
+- hideKeyboard
 
 # Complete onboarding
-- tapOn: "¡Vamos!"
+- tapOn: "Let's Go"
 
 # Verify we landed on Exercise Library
-- assertVisible: "Biblioteca de Ejercicios"
+- assertVisible: "Exercise Library"
 - takeScreenshot: onboarding_complete

--- a/android/.maestro/profile-settings.yaml
+++ b/android/.maestro/profile-settings.yaml
@@ -5,32 +5,34 @@ tags:
   - settings
 ---
 
+- launchApp
+
 # Navigate to Profile tab
-- tapOn: "Perfil"
+- tapOn: "Profile"
 - takeScreenshot: profile_screen
 
 # Verify profile sections are visible
-- assertVisible: "Hablar con Entrenador IA"
-- assertVisible: "Cuenta"
-- assertVisible: "Preferencias"
+- assertVisible: "Talk to AI Coach"
+- assertVisible: "Account"
+- assertVisible: "Preferences"
 - takeScreenshot: profile_sections
 
 # Scroll to see more sections
 - scroll
 
-- assertVisible: "Datos"
-- assertVisible: "Acerca de"
-- assertVisible: "Versión 1.0"
+- assertVisible: "Data"
+- assertVisible: "About"
+- assertVisible: "Version 1.0"
 - takeScreenshot: profile_about_section
 
 # Verify preference items
-- assertVisible: "Temporizador de descanso"
-- assertVisible: "Unidad de peso"
-- assertVisible: "Notificaciones"
+- assertVisible: "Rest timer"
+- assertVisible: "Weight unit"
+- assertVisible: "Notifications"
 - takeScreenshot: profile_preferences
 
 # Scroll back up
 - scrollUntilVisible:
-    element: "Hablar con Entrenador IA"
+    element: "Talk to AI Coach"
     direction: UP
 - takeScreenshot: profile_top

--- a/android/.maestro/smoke-test.yaml
+++ b/android/.maestro/smoke-test.yaml
@@ -1,5 +1,4 @@
 appId: com.gymbro.app
 ---
-- launchApp:
-    clearState: true
-- assertVisible: "GymBro"
+- launchApp
+- assertVisible: "GymBro|Exercise Library"

--- a/android/.maestro/start-workout.yaml
+++ b/android/.maestro/start-workout.yaml
@@ -5,25 +5,27 @@ tags:
   - core
 ---
 
+- launchApp
+
 # Start from Exercise Library
-- assertVisible: "Biblioteca de Ejercicios"
+- assertVisible: "Exercise Library"
 
 # Tap FAB to start new workout
-- tapOn: "Iniciar Entrenamiento"
+- tapOn: "Start Workout"
 
 # Verify Active Workout screen
-- assertVisible: "Entrenamiento Activo"
+- assertVisible: "Active Workout"
 - takeScreenshot: workout_started
 
 # Tap Add Exercise button
-- tapOn: "Añadir Ejercicio"
+- tapOn: "Add Exercise"
 
 # Verify exercise picker opens
-- assertVisible: "Elegir Ejercicio"
+- assertVisible: "Pick Exercise"
 - takeScreenshot: exercise_picker
 
 # Search and select an exercise
-- tapOn: "Buscar ejercicios…"
+- tapOn: "Search exercises…"
 - inputText: "Bench"
 - takeScreenshot: exercise_picker_search
 
@@ -33,7 +35,7 @@ tags:
     index: 0
 
 # Back on workout screen — verify exercise was added
-- assertVisible: "Entrenamiento Activo"
+- assertVisible: "Active Workout"
 - takeScreenshot: workout_exercise_added
 
 # Log a set — enter weight value

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
@@ -317,7 +317,7 @@ private fun GetStartedPage(
         Spacer(modifier = Modifier.height(48.dp))
 
         GradientButton(
-            text = "¡Vamos!",
+            text = stringResource(R.string.onboarding_lets_go),
             onClick = onComplete,
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
Fixes hardcoded English strings in onboarding and corrects Maestro YAML syntax.

## Changes
- **OnboardingScreen.kt**: Replace hardcoded '¡Vamos!' with stringResource(R.string.onboarding_lets_go)
- **full-e2e.yaml**: Fix 3 invalid swipeLeft commands → proper swipe syntax
- **onboarding-flow.yaml / full-e2e.yaml**: Add clearState: true for fresh onboarding
- **smoke-test.yaml / browse-library.yaml**: Remove clearState to avoid onboarding interference
- **All flows**: Add explicit launchApp, update assertions to English (default locale emulator)