### PR TITLE
feat: Add Maestro E2E tests to GitHub Actions CI

### DIFF
--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -1,0 +1,86 @@
+name: Maestro E2E Tests
+
+on:
+  pull_request:
+    branches: [ main, master ]
+    paths: ['android/**', '.github/workflows/maestro-e2e.yml']
+
+jobs:
+  maestro-e2e:
+    name: Maestro E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Build debug APK
+      working-directory: android
+      run: ./gradlew assembleDebug --no-daemon
+
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Run Maestro E2E tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 34
+        target: google_apis
+        arch: x86_64
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
+        script: |
+          # Install Maestro
+          export MAESTRO_VERSION=1.39.0
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          export PATH="$PATH:$HOME/.maestro/bin"
+          
+          # Install APK
+          adb install android/app/build/outputs/apk/debug/*.apk
+          
+          # Wait for device to be ready
+          adb wait-for-device
+          sleep 5
+          
+          # Run smoke tests
+          maestro test android/.maestro/smoke-test.yaml || echo "SMOKE_TEST_FAILED=true" >> $GITHUB_ENV
+          maestro test android/.maestro/navigation-smoke.yaml || echo "NAV_TEST_FAILED=true" >> $GITHUB_ENV
+          
+          # Check if any tests failed
+          if [ "$SMOKE_TEST_FAILED" = "true" ] || [ "$NAV_TEST_FAILED" = "true" ]; then
+            exit 1
+          fi
+
+    - name: Upload Maestro screenshots
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: maestro-screenshots
+        path: |
+          ~/.maestro/tests/**/*.png
+          ~/.maestro/tests/**/*.mp4
+        if-no-files-found: ignore
+        retention-days: 7
+
+    - name: Upload Maestro logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: maestro-logs
+        path: ~/.maestro/tests/**/*.log
+        if-no-files-found: ignore
+        retention-days: 7


### PR DESCRIPTION
Closes #272

## What
Adds a GitHub Actions workflow that runs Maestro E2E tests on Android changes in PRs.

## How
- Created .github/workflows/maestro-e2e.yml
- Uses eactivecircus/android-emulator-runner@v2 with API 34, x86_64
- Builds debug APK with Gradle caching
- Installs Maestro CLI and runs smoke-test.yaml + 
avigation-smoke.yaml
- Uploads screenshots and logs as artifacts on failure
- Enabled KVM hardware acceleration for emulator speed
- 30min timeout with optimized emulator options

## Testing
Will be tested by this PR itself when the workflow runs.

Working as Tank (Backend Dev / DevOps)