### PR TITLE
fix: Update Maestro flows to use Spanish text assertions

### DIFF
--- a/android/.maestro/ai-coach.yaml
+++ b/android/.maestro/ai-coach.yaml
@@ -8,32 +8,33 @@ tags:
 - launchApp
 
 # Navigate to Profile tab first
-- tapOn: "Profile"
-- assertVisible: "Talk to AI Coach"
+- tapOn:
+    id: "nav_profile"
+- assertVisible: "Hablar con el Entrenador IA"
 
 # Tap AI Coach button
-- tapOn: "Talk to AI Coach"
+- tapOn: "Hablar con el Entrenador IA"
 
 # Verify Coach screen opens
-- assertVisible: "GymBro AI Coach"
+- assertVisible: "GymBro Entrenador IA"
 - takeScreenshot: coach_screen
 
 # Check for welcome message and quick prompts
-- assertVisible: "Your personal strength training advisor"
-- assertVisible: "Quick prompts:"
+- assertVisible: "Tu asesor personal de entrenamiento de fuerza"
+- assertVisible: "Preguntas rápidas:"
 - takeScreenshot: coach_welcome
 
 # Try tapping a quick prompt
-- tapOn: "What should I train today?"
+- tapOn: "¿Qué debería entrenar hoy?"
 - takeScreenshot: coach_prompt_sent
 
 # Wait for response (or loading indicator)
 - assertVisible:
-    text: "Coach is thinking...|Coach"
+    text: "El entrenador está pensando...|Entrenador"
     optional: true
 - takeScreenshot: coach_response
 
 # Navigate back
 - back
-- assertVisible: "Profile"
+- assertVisible: "Perfil"
 - takeScreenshot: coach_back_to_profile

--- a/android/.maestro/browse-library.yaml
+++ b/android/.maestro/browse-library.yaml
@@ -8,11 +8,12 @@ tags:
 - launchApp
 
 # Verify Exercise Library is visible
-- assertVisible: "Exercise Library"
+- assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: library_home
 
 # Tap on search bar and type a query
-- tapOn: "Search exercises…"
+- tapOn:
+    id: "search_bar"
 - inputText: "Press"
 - takeScreenshot: library_search_results
 
@@ -20,22 +21,22 @@ tags:
 - launchApp
 
 # Wait for library to load
-- assertVisible: "Exercise Library"
+- assertVisible: "Biblioteca de Ejercicios"
 
 # Filter by Chest muscle group
-- tapOn: "Chest"
+- tapOn: "Pecho"
 - takeScreenshot: library_filter_chest
 
 # Deselect Chest, select Back
-- tapOn: "Chest"
-- tapOn: "Back"
+- tapOn: "Pecho"
+- tapOn: "Espalda"
 - takeScreenshot: library_filter_back
 
 # Deselect Back, select Shoulders
-- tapOn: "Back"
-- tapOn: "Shoulders"
+- tapOn: "Espalda"
+- tapOn: "Hombros"
 - takeScreenshot: library_filter_shoulders
 
 # Deselect filter
-- tapOn: "Shoulders"
+- tapOn: "Hombros"
 - takeScreenshot: library_no_filter

--- a/android/.maestro/check-history.yaml
+++ b/android/.maestro/check-history.yaml
@@ -8,15 +8,16 @@ tags:
 - launchApp
 
 # Navigate to History tab
-- tapOn: "History"
+- tapOn:
+    id: "nav_history"
 - takeScreenshot: history_tab
 
 # Verify History screen loads
-- assertVisible: "Workout History"
+- assertVisible: "Historial de Entrenamientos"
 
 # Check for workout entries or empty state
 - assertVisible:
-    text: "No Workouts Yet|Today|Yesterday"
+    text: "Sin Entrenamientos Aún|Hoy|Ayer"
     optional: true
 - takeScreenshot: history_content
 

--- a/android/.maestro/check-progress.yaml
+++ b/android/.maestro/check-progress.yaml
@@ -8,20 +8,21 @@ tags:
 - launchApp
 
 # Navigate to Progress tab
-- tapOn: "Progress"
+- tapOn:
+    id: "nav_progress"
 - takeScreenshot: progress_tab
 
 # Check for content or empty state
 - assertVisible:
-    text: "No workouts yet"
+    text: "Sin entrenamientos aún"
     optional: true
 
 # If data exists, verify KPI section
 - assertVisible:
-    text: "Weekly Volume"
+    text: "Volumen Semanal"
     optional: true
 - assertVisible:
-    text: "Recent PRs"
+    text: "PRs Recientes"
     optional: true
 - assertVisible:
     text: "Estimated 1RM Trend"

--- a/android/.maestro/complete-workout.yaml
+++ b/android/.maestro/complete-workout.yaml
@@ -8,17 +8,18 @@ tags:
 - launchApp
 
 # Start from Exercise Library
-- assertVisible: "Exercise Library"
+- assertVisible: "Biblioteca de Ejercicios"
 
 # Tap FAB to start workout
-- tapOn: "Start Workout"
+- tapOn:
+    id: "workout_fab"
 
 # Verify active workout
-- assertVisible: "Active Workout"
+- assertVisible: "Entrenamiento Activo"
 
 # Add an exercise
-- tapOn: "Add Exercise"
-- assertVisible: "Pick Exercise"
+- tapOn: "Añadir Ejercicio"
+- assertVisible: "Elegir Ejercicio"
 
 # Pick first available exercise
 - tapOn:
@@ -26,17 +27,17 @@ tags:
     index: 0
 
 # Verify back on workout screen
-- assertVisible: "Active Workout"
+- assertVisible: "Entrenamiento Activo"
 
 # Fill in weight for set 1
 - tapOn:
-    text: "0"
+    id: "weight_input"
     index: 0
 - inputText: "100"
 
 # Fill in reps for set 1
 - tapOn:
-    text: "0"
+    id: "reps_input"
     index: 0
 - inputText: "5"
 
@@ -44,23 +45,23 @@ tags:
 
 # Complete the set (tap the check/complete button)
 - tapOn:
-    text: "Complete set 1"
+    text: "Completar serie 1"
 
 - takeScreenshot: workout_set1_completed
 
 # Finish the workout
-- tapOn: "Finish Workout"
+- tapOn: "Finalizar Entrenamiento"
 
 # Verify workout summary screen
-- assertVisible: "Workout Complete!"
+- assertVisible: "¡Entrenamiento Completado!"
 - takeScreenshot: workout_summary
 
 # Verify stats are displayed
-- assertVisible: "Workout Stats"
+- assertVisible: "Estadísticas del Entrenamiento"
 
 # Tap Done to return
-- tapOn: "Done"
+- tapOn: "Listo"
 
 # Back at exercise library
-- assertVisible: "Exercise Library"
+- assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: workout_flow_complete

--- a/android/.maestro/full-e2e.yaml
+++ b/android/.maestro/full-e2e.yaml
@@ -18,27 +18,29 @@ tags:
 - swipe:
     direction: LEFT
     duration: 400
-- assertVisible: "Ultra-Fast Logging"
+- assertVisible: "Registro Ultra-Rápido"
 
 - swipe:
     direction: LEFT
     duration: 400
-- assertVisible: "Track Your Progress"
+- assertVisible: "Rastrea tu Progreso"
 
 - swipe:
     direction: LEFT
     duration: 400
-- assertVisible: "Let's Get Started"
+- assertVisible: "Comencemos"
 
 # Select units and enter name
-- tapOn: "Kilograms (kg)"
-- tapOn: "Enter your name"
+- tapOn: "Kilogramos (kg)"
+- tapOn:
+    id: "onboarding_name_input"
 - inputText: "E2EUser"
 - hideKeyboard
 
 # Complete onboarding
-- tapOn: "Let's Go"
-- assertVisible: "Exercise Library"
+- tapOn:
+    id: "onboarding_start"
+- assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: e2e_onboarding_complete
 
 # === PHASE 2: QUICK LIBRARY BROWSE ===
@@ -54,13 +56,14 @@ tags:
 # === PHASE 3: START AND COMPLETE WORKOUT ===
 
 # Tap FAB to start workout
-- tapOn: "Start Workout"
-- assertVisible: "Active Workout"
+- tapOn:
+    id: "workout_fab"
+- assertVisible: "Entrenamiento Activo"
 - takeScreenshot: e2e_workout_started
 
 # Add an exercise
-- tapOn: "Add Exercise"
-- assertVisible: "Pick Exercise"
+- tapOn: "Añadir Ejercicio"
+- assertVisible: "Elegir Ejercicio"
 
 # Pick an exercise
 - tapOn:
@@ -68,14 +71,14 @@ tags:
     index: 0
 
 # Fill in set data
-- assertVisible: "Active Workout"
+- assertVisible: "Entrenamiento Activo"
 - tapOn:
-    text: "0"
+    id: "weight_input"
     index: 0
 - inputText: "80"
 
 - tapOn:
-    text: "0"
+    id: "reps_input"
     index: 0
 - inputText: "10"
 
@@ -83,45 +86,49 @@ tags:
 
 # Complete the set
 - tapOn:
-    text: "Complete set 1"
+    text: "Completar serie 1"
 
 # Finish workout
-- tapOn: "Finish Workout"
+- tapOn: "Finalizar Entrenamiento"
 
 # Verify summary
-- assertVisible: "Workout Complete!"
+- assertVisible: "¡Entrenamiento Completado!"
 - takeScreenshot: e2e_workout_summary
 
 # Tap done
-- tapOn: "Done"
-- assertVisible: "Exercise Library"
+- tapOn: "Listo"
+- assertVisible: "Biblioteca de Ejercicios"
 
 # === PHASE 4: VERIFY HISTORY ===
 
 # Navigate to History tab
-- tapOn: "History"
-- assertVisible: "Workout History"
+- tapOn:
+    id: "nav_history"
+- assertVisible: "Historial de Entrenamientos"
 - takeScreenshot: e2e_history_with_workout
 
 # Verify the workout appears (today's entry)
 - assertVisible:
-    text: "Today"
+    text: "Hoy"
     optional: true
 
 # === PHASE 5: CHECK PROGRESS ===
 
 # Navigate to Progress tab
-- tapOn: "Progress"
+- tapOn:
+    id: "nav_progress"
 - takeScreenshot: e2e_progress_after_workout
 
 # === PHASE 6: VERIFY PROFILE ===
 
 # Navigate to Profile tab
-- tapOn: "Profile"
-- assertVisible: "Account"
+- tapOn:
+    id: "nav_profile"
+- assertVisible: "Cuenta"
 - takeScreenshot: e2e_profile
 
 # Return to library
-- tapOn: "Library"
-- assertVisible: "Exercise Library"
+- tapOn:
+    id: "nav_exercise_library"
+- assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: e2e_complete

--- a/android/.maestro/navigation-smoke.yaml
+++ b/android/.maestro/navigation-smoke.yaml
@@ -8,27 +8,32 @@ tags:
 - launchApp
 
 # Start at Library tab
-- assertVisible: "Exercise Library"
+- assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: nav_library
 
 # Tap History tab
-- tapOn: "History"
-- assertVisible: "Workout History"
+- tapOn:
+    id: "nav_history"
+- assertVisible: "Historial de Entrenamientos"
 - takeScreenshot: nav_history
 
 # Tap Progress tab
-- tapOn: "Progress"
+- tapOn:
+    id: "nav_progress"
 - takeScreenshot: nav_progress
 
 # Tap Recovery tab
-- tapOn: "Recovery"
+- tapOn:
+    id: "nav_recovery"
 - takeScreenshot: nav_recovery
 
 # Tap Profile tab
-- tapOn: "Profile"
+- tapOn:
+    id: "nav_profile"
 - takeScreenshot: nav_profile
 
 # Navigate back to Library
-- tapOn: "Library"
-- assertVisible: "Exercise Library"
+- tapOn:
+    id: "nav_exercise_library"
+- assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: nav_back_to_library

--- a/android/.maestro/profile-settings.yaml
+++ b/android/.maestro/profile-settings.yaml
@@ -8,31 +8,31 @@ tags:
 - launchApp
 
 # Navigate to Profile tab
-- tapOn: "Profile"
+- tapOn:
+    id: "nav_profile"
 - takeScreenshot: profile_screen
 
 # Verify profile sections are visible
-- assertVisible: "Talk to AI Coach"
-- assertVisible: "Account"
-- assertVisible: "Preferences"
+- assertVisible: "Hablar con el Entrenador IA"
+- assertVisible: "Cuenta"
+- assertVisible: "Preferencias de Entrenamiento"
 - takeScreenshot: profile_sections
 
 # Scroll to see more sections
 - scroll
 
-- assertVisible: "Data"
-- assertVisible: "About"
-- assertVisible: "Version 1.0"
+- assertVisible: "Acerca de"
+- assertVisible: "Versión 1.0"
 - takeScreenshot: profile_about_section
 
 # Verify preference items
-- assertVisible: "Rest timer"
-- assertVisible: "Weight unit"
-- assertVisible: "Notifications"
+- assertVisible: "Temporizador de Descanso Predeterminado"
+- assertVisible: "Unidad de Peso"
+- assertVisible: "Recordatorios de Entrenamiento"
 - takeScreenshot: profile_preferences
 
 # Scroll back up
 - scrollUntilVisible:
-    element: "Talk to AI Coach"
+    element: "Hablar con el Entrenador IA"
     direction: UP
 - takeScreenshot: profile_top

--- a/android/.maestro/start-workout.yaml
+++ b/android/.maestro/start-workout.yaml
@@ -8,24 +8,26 @@ tags:
 - launchApp
 
 # Start from Exercise Library
-- assertVisible: "Exercise Library"
+- assertVisible: "Biblioteca de Ejercicios"
 
 # Tap FAB to start new workout
-- tapOn: "Start Workout"
+- tapOn:
+    id: "workout_fab"
 
 # Verify Active Workout screen
-- assertVisible: "Active Workout"
+- assertVisible: "Entrenamiento Activo"
 - takeScreenshot: workout_started
 
 # Tap Add Exercise button
-- tapOn: "Add Exercise"
+- tapOn: "Añadir Ejercicio"
 
 # Verify exercise picker opens
-- assertVisible: "Pick Exercise"
+- assertVisible: "Elegir Ejercicio"
 - takeScreenshot: exercise_picker
 
 # Search and select an exercise
-- tapOn: "Search exercises…"
+- tapOn:
+    id: "search_bar"
 - inputText: "Bench"
 - takeScreenshot: exercise_picker_search
 
@@ -35,18 +37,18 @@ tags:
     index: 0
 
 # Back on workout screen — verify exercise was added
-- assertVisible: "Active Workout"
+- assertVisible: "Entrenamiento Activo"
 - takeScreenshot: workout_exercise_added
 
 # Log a set — enter weight value
 - tapOn:
-    text: "0"
+    id: "weight_input"
     index: 0
 - inputText: "80"
 
 # Enter reps
 - tapOn:
-    text: "0"
+    id: "reps_input"
     index: 0
 - inputText: "8"
 


### PR DESCRIPTION
Closes #271

Updates all Maestro E2E flows to use Spanish text assertions and testTag IDs where available, matching the emulator's Spanish locale.