### PR TITLE
fix: Add smart waits and animation handling to Maestro flows

### DIFF
--- a/android/.maestro/ai-coach.yaml
+++ b/android/.maestro/ai-coach.yaml
@@ -9,6 +9,8 @@ tags:
 onFlowStart:
   # Ensure post-onboarding state
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -20,10 +22,14 @@ onFlowComplete:
 # Navigate to Profile tab first
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Hablar con el Entrenador IA"
 
 # Tap AI Coach button
 - tapOn: "Hablar con el Entrenador IA"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify Coach screen opens
 - assertVisible: "GymBro Entrenador IA"
@@ -36,6 +42,8 @@ onFlowComplete:
 
 # Try tapping a quick prompt
 - tapOn: "¿Qué debería entrenar hoy?"
+- waitForAnimationToEnd:
+    timeout: 1000
 - takeScreenshot: coach_prompt_sent
 
 # Wait for response (or loading indicator)
@@ -46,5 +54,7 @@ onFlowComplete:
 
 # Navigate back
 - back
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Perfil"
 - takeScreenshot: coach_back_to_profile

--- a/android/.maestro/browse-library.yaml
+++ b/android/.maestro/browse-library.yaml
@@ -10,6 +10,8 @@ tags:
 onFlowStart:
   # Start at library with clean filters
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -24,29 +26,47 @@ onFlowComplete:
 # Tap on search bar and type a query
 - tapOn:
     id: "search_bar"
+- waitForAnimationToEnd:
+    timeout: 1000
 - inputText: "Press"
+- waitForAnimationToEnd:
+    timeout: 1000
 - takeScreenshot: library_search_results
 
 # Relaunch app to clear search
 - launchApp
+- waitForAnimationToEnd:
+    timeout: 3000
 
 # Wait for library to load
 - assertVisible: "Biblioteca de Ejercicios"
 
 # Filter by Chest muscle group
 - tapOn: "Pecho"
+- waitForAnimationToEnd:
+    timeout: 1000
 - takeScreenshot: library_filter_chest
 
 # Deselect Chest, select Back
 - tapOn: "Pecho"
+- waitForAnimationToEnd:
+    timeout: 500
 - tapOn: "Espalda"
+- waitForAnimationToEnd:
+    timeout: 1000
 - takeScreenshot: library_filter_back
 
 # Deselect Back, select Shoulders
 - tapOn: "Espalda"
+- waitForAnimationToEnd:
+    timeout: 500
 - tapOn: "Hombros"
+- waitForAnimationToEnd:
+    timeout: 1000
 - takeScreenshot: library_filter_shoulders
 
 # Deselect filter
 - tapOn: "Hombros"
+- waitForAnimationToEnd:
+    timeout: 1000
 - takeScreenshot: library_no_filter

--- a/android/.maestro/check-history.yaml
+++ b/android/.maestro/check-history.yaml
@@ -10,6 +10,8 @@ tags:
 onFlowStart:
   # Ensure post-onboarding state
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -21,6 +23,8 @@ onFlowComplete:
 # Navigate to History tab
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: history_tab
 
 # Verify History screen loads
@@ -43,4 +47,6 @@ onFlowComplete:
 
 # Navigate back
 - back
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: history_after_back

--- a/android/.maestro/check-progress.yaml
+++ b/android/.maestro/check-progress.yaml
@@ -10,6 +10,8 @@ tags:
 onFlowStart:
   # Ensure post-onboarding state
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -21,6 +23,8 @@ onFlowComplete:
 # Navigate to Progress tab
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: progress_tab
 
 # Check for content or empty state

--- a/android/.maestro/complete-workout.yaml
+++ b/android/.maestro/complete-workout.yaml
@@ -9,6 +9,8 @@ tags:
 onFlowStart:
   # Ensure clean state at library
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 # Start from Exercise Library
@@ -17,18 +19,24 @@ onFlowStart:
 # Tap FAB to start workout
 - tapOn:
     id: "workout_fab"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify active workout
 - assertVisible: "Entrenamiento Activo"
 
 # Add an exercise
 - tapOn: "Añadir Ejercicio"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Elegir Ejercicio"
 
 # Pick first available exercise
 - tapOn:
     text: "Bench Press"
     index: 0
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify back on workout screen
 - assertVisible: "Entrenamiento Activo"
@@ -50,11 +58,15 @@ onFlowStart:
 # Complete the set (tap the check/complete button)
 - tapOn:
     text: "Completar serie 1"
+- waitForAnimationToEnd:
+    timeout: 1000
 
 - takeScreenshot: workout_set1_completed
 
 # Finish the workout
 - tapOn: "Finalizar Entrenamiento"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify workout summary screen
 - assertVisible: "¡Entrenamiento Completado!"
@@ -65,6 +77,8 @@ onFlowStart:
 
 # Tap Done to return
 - tapOn: "Listo"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Back at exercise library
 - assertVisible: "Biblioteca de Ejercicios"
@@ -73,6 +87,8 @@ onFlowStart:
 # PERSISTENCE VERIFICATION: Navigate to History
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
 - takeScreenshot: persistence_check_history
 
@@ -83,6 +99,8 @@ onFlowStart:
 # PERSISTENCE VERIFICATION: Navigate to Progress
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible:
     text: "Volumen Semanal|Sin entrenamientos aún"
 - takeScreenshot: persistence_check_progress

--- a/android/.maestro/empty-state-screens.yaml
+++ b/android/.maestro/empty-state-screens.yaml
@@ -15,6 +15,8 @@ onFlowComplete:
 # Launch with clearState to wipe all data
 - launchApp:
     clearState: true
+- waitForAnimationToEnd:
+    timeout: 3000
 
 # Complete onboarding quickly to get past it
 - assertVisible: "GymBro"
@@ -39,6 +41,8 @@ onFlowComplete:
 - hideKeyboard
 - tapOn:
     id: "onboarding_start"
+- waitForAnimationToEnd:
+    timeout: 3000
 
 # Now at Exercise Library (post-onboarding)
 - assertVisible: "Biblioteca de Ejercicios"
@@ -47,6 +51,8 @@ onFlowComplete:
 # TEST 1: Check History tab (should show empty state)
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify History screen loaded
 - assertVisible: "Historial|History"
@@ -56,6 +62,8 @@ onFlowComplete:
 # TEST 2: Check Progress tab (should show empty state)
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify Progress screen loaded
 - assertVisible: "Progreso|Progress"
@@ -65,6 +73,8 @@ onFlowComplete:
 # TEST 3: Check Recovery tab
 - tapOn:
     id: "nav_recovery"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify Recovery screen loaded
 - takeScreenshot: empty_state_recovery
@@ -72,6 +82,8 @@ onFlowComplete:
 # TEST 4: Check Profile tab
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify Profile screen loaded
 - assertVisible: "Perfil|Profile"

--- a/android/.maestro/flow/ensure-post-onboarding.yaml
+++ b/android/.maestro/flow/ensure-post-onboarding.yaml
@@ -6,6 +6,8 @@ name: "Ensure Post-Onboarding State"
 # If onboarding is visible, complete it to reach post-onboarding state
 
 - launchApp
+- waitForAnimationToEnd:
+    timeout: 3000
 
 # Check if we're on onboarding or post-onboarding
 - runFlow:
@@ -30,6 +32,8 @@ name: "Ensure Post-Onboarding State"
       - hideKeyboard
       - tapOn:
           id: "onboarding_start"
+      - waitForAnimationToEnd:
+          timeout: 3000
 
 # Verify we're now post-onboarding
 - assertVisible: "Biblioteca de Ejercicios|Exercise Library"

--- a/android/.maestro/full-e2e.yaml
+++ b/android/.maestro/full-e2e.yaml
@@ -11,6 +11,8 @@ onFlowComplete:
 
 - launchApp:
     clearState: true
+- waitForAnimationToEnd:
+    timeout: 3000
 
 # === PHASE 1: ONBOARDING ===
 
@@ -44,6 +46,8 @@ onFlowComplete:
 # Complete onboarding
 - tapOn:
     id: "onboarding_start"
+- waitForAnimationToEnd:
+    timeout: 3000
 - assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: e2e_onboarding_complete
 
@@ -62,17 +66,23 @@ onFlowComplete:
 # Tap FAB to start workout
 - tapOn:
     id: "workout_fab"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Entrenamiento Activo"
 - takeScreenshot: e2e_workout_started
 
 # Add an exercise
 - tapOn: "Añadir Ejercicio"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Elegir Ejercicio"
 
 # Pick an exercise
 - tapOn:
     text: "Bench Press"
     index: 0
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Fill in set data
 - assertVisible: "Entrenamiento Activo"
@@ -91,9 +101,13 @@ onFlowComplete:
 # Complete the set
 - tapOn:
     text: "Completar serie 1"
+- waitForAnimationToEnd:
+    timeout: 1000
 
 # Finish workout
 - tapOn: "Finalizar Entrenamiento"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify summary
 - assertVisible: "¡Entrenamiento Completado!"
@@ -101,6 +115,8 @@ onFlowComplete:
 
 # Tap done
 - tapOn: "Listo"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Biblioteca de Ejercicios"
 
 # === PHASE 4: VERIFY HISTORY ===
@@ -108,6 +124,8 @@ onFlowComplete:
 # Navigate to History tab
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
 - takeScreenshot: e2e_history_with_workout
 
@@ -121,6 +139,8 @@ onFlowComplete:
 # Navigate to Progress tab
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: e2e_progress_after_workout
 
 # === PHASE 6: VERIFY PROFILE ===
@@ -128,6 +148,8 @@ onFlowComplete:
 # Navigate to Profile tab
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Cuenta"
 - takeScreenshot: e2e_profile
 

--- a/android/.maestro/navigation-smoke.yaml
+++ b/android/.maestro/navigation-smoke.yaml
@@ -10,6 +10,8 @@ tags:
 onFlowStart:
   # Ensure app is in post-onboarding state
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -25,26 +27,36 @@ onFlowComplete:
 # Tap History tab
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
 - takeScreenshot: nav_history
 
 # Tap Progress tab
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: nav_progress
 
 # Tap Recovery tab
 - tapOn:
     id: "nav_recovery"
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: nav_recovery
 
 # Tap Profile tab
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: nav_profile
 
 # Navigate back to Library
 - tapOn:
     id: "nav_exercise_library"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Biblioteca de Ejercicios"
 - takeScreenshot: nav_back_to_library

--- a/android/.maestro/negative-workout-input.yaml
+++ b/android/.maestro/negative-workout-input.yaml
@@ -9,6 +9,8 @@ tags:
 
 onFlowStart:
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -23,6 +25,8 @@ onFlowComplete:
 - assertVisible: "Biblioteca de Ejercicios"
 - tapOn:
     id: "workout_fab"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify Active Workout screen
 - assertVisible: "Entrenamiento Activo"
@@ -30,6 +34,8 @@ onFlowComplete:
 
 # Add an exercise
 - tapOn: "Añadir Ejercicio"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Elegir Ejercicio"
 - tapOn:
     id: "search_bar"
@@ -97,4 +103,6 @@ onFlowComplete:
 
 # Cancel workout to clean up
 - back
+- waitForAnimationToEnd:
+    timeout: 1000
 - tapOn: "Cancelar Entrenamiento|Descartar"

--- a/android/.maestro/onboarding-edge-cases.yaml
+++ b/android/.maestro/onboarding-edge-cases.yaml
@@ -14,6 +14,8 @@ onFlowComplete:
 # TEST 1: Try to proceed with empty name
 - launchApp:
     clearState: true
+- waitForAnimationToEnd:
+    timeout: 3000
 
 - assertVisible: "GymBro"
 - takeScreenshot: onboarding_edge_start
@@ -44,6 +46,8 @@ onFlowComplete:
 # TEST 2: Very long name (50+ characters)
 - launchApp:
     clearState: true
+- waitForAnimationToEnd:
+    timeout: 3000
 
 - swipe:
     direction: LEFT
@@ -65,6 +69,8 @@ onFlowComplete:
 
 - tapOn:
     id: "onboarding_start"
+- waitForAnimationToEnd:
+    timeout: 3000
 # App should handle and proceed
 
 - stopApp
@@ -72,6 +78,8 @@ onFlowComplete:
 # TEST 3: Name with special characters
 - launchApp:
     clearState: true
+- waitForAnimationToEnd:
+    timeout: 3000
 
 - swipe:
     direction: LEFT
@@ -92,6 +100,8 @@ onFlowComplete:
 
 - tapOn:
     id: "onboarding_start"
+- waitForAnimationToEnd:
+    timeout: 3000
 # App should handle special characters
 
 - stopApp
@@ -99,6 +109,8 @@ onFlowComplete:
 # TEST 4: Name with emoji
 - launchApp:
     clearState: true
+- waitForAnimationToEnd:
+    timeout: 3000
 
 - swipe:
     direction: LEFT
@@ -119,6 +131,8 @@ onFlowComplete:
 
 - tapOn:
     id: "onboarding_start"
+- waitForAnimationToEnd:
+    timeout: 3000
 # App should handle emoji input
 
 # Verify we reached Exercise Library (no crash)

--- a/android/.maestro/onboarding-flow.yaml
+++ b/android/.maestro/onboarding-flow.yaml
@@ -56,6 +56,8 @@ onFlowComplete:
 
 # Complete onboarding
 - tapOn: "Let's Go"
+- waitForAnimationToEnd:
+    timeout: 3000
 
 # Verify we landed on Exercise Library
 - assertVisible: "Exercise Library"

--- a/android/.maestro/profile-settings.yaml
+++ b/android/.maestro/profile-settings.yaml
@@ -9,6 +9,8 @@ tags:
 onFlowStart:
   # Ensure post-onboarding state
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -20,6 +22,8 @@ onFlowComplete:
 # Navigate to Profile tab
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 2000
 - takeScreenshot: profile_screen
 
 # Verify profile sections are visible

--- a/android/.maestro/rapid-navigation.yaml
+++ b/android/.maestro/rapid-navigation.yaml
@@ -9,6 +9,8 @@ tags:
 
 onFlowStart:
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 # Start from Exercise Library
@@ -18,21 +20,31 @@ onFlowStart:
 # RAPID TAP SEQUENCE 1: Cycle through all nav tabs quickly
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Historial|History"
 
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Progreso|Progress"
 
 - tapOn:
     id: "nav_recovery"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Perfil|Profile"
 
 - tapOn:
     id: "nav_exercise_library"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Biblioteca de Ejercicios"
 
 - takeScreenshot: rapid_nav_cycle1
@@ -40,39 +52,61 @@ onFlowStart:
 # RAPID TAP SEQUENCE 2: Reverse order
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_recovery"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_exercise_library"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - takeScreenshot: rapid_nav_cycle2
 
 # RAPID TAP SEQUENCE 3: Random pattern
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_exercise_library"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_recovery"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_exercise_library"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - takeScreenshot: rapid_nav_cycle3
 
@@ -83,6 +117,8 @@ onFlowStart:
     id: "nav_history"
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Historial|History"
 
 - tapOn:
@@ -91,6 +127,8 @@ onFlowStart:
     id: "nav_exercise_library"
 - tapOn:
     id: "nav_exercise_library"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Biblioteca de Ejercicios"
 
 - takeScreenshot: rapid_nav_stress
@@ -98,21 +136,31 @@ onFlowStart:
 # Final verification: All tabs still work correctly
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Historial|History"
 
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Progreso|Progress"
 
 - tapOn:
     id: "nav_recovery"
+- waitForAnimationToEnd:
+    timeout: 1500
 
 - tapOn:
     id: "nav_profile"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Perfil|Profile"
 
 - tapOn:
     id: "nav_exercise_library"
+- waitForAnimationToEnd:
+    timeout: 1500
 - assertVisible: "Biblioteca de Ejercicios"
 
 - takeScreenshot: rapid_nav_complete

--- a/android/.maestro/search-no-results.yaml
+++ b/android/.maestro/search-no-results.yaml
@@ -8,6 +8,8 @@ tags:
 
 onFlowStart:
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 # Start from Exercise Library

--- a/android/.maestro/smoke-test.yaml
+++ b/android/.maestro/smoke-test.yaml
@@ -9,6 +9,8 @@ tags:
 onFlowStart:
   # Launch app and verify it's functional
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
 
 # Verify post-onboarding state
 - assertVisible: "Biblioteca de Ejercicios|Exercise Library"

--- a/android/.maestro/start-workout.yaml
+++ b/android/.maestro/start-workout.yaml
@@ -9,6 +9,8 @@ tags:
 onFlowStart:
   # Ensure we're at library with no active workout
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -25,6 +27,8 @@ onFlowComplete:
 # Tap FAB to start new workout
 - tapOn:
     id: "workout_fab"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify Active Workout screen
 - assertVisible: "Entrenamiento Activo"
@@ -32,6 +36,8 @@ onFlowComplete:
 
 # Tap Add Exercise button
 - tapOn: "Añadir Ejercicio"
+- waitForAnimationToEnd:
+    timeout: 2000
 
 # Verify exercise picker opens
 - assertVisible: "Elegir Ejercicio"

--- a/android/.maestro/verify-data-persistence.yaml
+++ b/android/.maestro/verify-data-persistence.yaml
@@ -10,6 +10,8 @@ tags:
 onFlowStart:
   # Ensure clean state at library
   - launchApp
+  - waitForAnimationToEnd:
+      timeout: 3000
   - assertVisible: "Biblioteca de Ejercicios"
 
 onFlowComplete:
@@ -25,11 +27,15 @@ onFlowComplete:
 # STEP 1: Start a workout
 - tapOn:
     id: "workout_fab"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Entrenamiento Activo"
 - takeScreenshot: persistence_workout_started
 
 # STEP 2: Add an exercise
 - tapOn: "Añadir Ejercicio"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Elegir Ejercicio"
 
 # Pick Squat exercise
@@ -56,20 +62,28 @@ onFlowComplete:
 # Complete the set
 - tapOn:
     text: "Completar serie 1"
+- waitForAnimationToEnd:
+    timeout: 1000
 - takeScreenshot: persistence_set_completed
 
 # STEP 4: Complete the workout
 - tapOn: "Finalizar Entrenamiento"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "¡Entrenamiento Completado!"
 - takeScreenshot: persistence_workout_summary
 
 # Return to library
 - tapOn: "Listo"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Biblioteca de Ejercicios"
 
 # VERIFICATION 1: Check History for workout
 - tapOn:
     id: "nav_history"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
 - takeScreenshot: persistence_verify_history
 
@@ -86,11 +100,15 @@ onFlowComplete:
 
 # Go back to history list
 - back
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
 
 # VERIFICATION 2: Check Progress for updated stats
 - tapOn:
     id: "nav_progress"
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertVisible:
     text: "Volumen Semanal|Sin entrenamientos aún"
 - takeScreenshot: persistence_verify_progress


### PR DESCRIPTION
## Summary
Adds intelligent wait conditions to all Maestro E2E flows to prevent flaky tests.

## Changes
- Added \waitForAnimationToEnd\ after all navigation transitions (tab switches, screen transitions)
- Added explicit 3-second waits after \launchApp\ for splash/migration
- Added waits after modal dialogs and sheet presentations  
- Added waits after completing actions (completing sets, finishing workouts)
- Applied to all 18 Maestro flow files including \nsure-post-onboarding\ helper

## Testing
All flows now wait for animations to complete before making assertions, reducing race conditions and improving test stability.

Closes #285