### PR TITLE
refactor: improve screenshot naming and add docstrings to all Maestro flows

### DIFF
--- a/android/.maestro/ai-coach.yaml
+++ b/android/.maestro/ai-coach.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "AI Coach — Open coach and send a message"
+#
+# Tests: AI Coach feature accessibility and basic interaction
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: Quick prompt "¿Qué debería entrenar hoy?"
+# Assertions: Coach screen opens, welcome message visible, prompt sent successfully
+# Cleanup: Navigate back to Profile tab
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - regression
 ---
@@ -33,28 +40,33 @@ onFlowComplete:
 
 # Verify Coach screen opens
 - assertVisible: "GymBro Entrenador IA"
-- takeScreenshot: coach_screen
+# Screenshot 01: AI Coach screen opened from Profile
+- takeScreenshot: 01_ai_coach_screen
 
 # Check for welcome message and quick prompts
 - assertVisible: "Tu asesor personal de entrenamiento de fuerza"
 - assertVisible: "Preguntas rápidas:"
-- takeScreenshot: coach_welcome
+# Screenshot 02: Welcome message and quick prompt buttons visible
+- takeScreenshot: 02_ai_coach_welcome
 
 # Try tapping a quick prompt
 - tapOn: "¿Qué debería entrenar hoy?"
 - waitForAnimationToEnd:
     timeout: 1000
-- takeScreenshot: coach_prompt_sent
+# Screenshot 03: Quick prompt sent to AI Coach
+- takeScreenshot: 03_ai_coach_prompt_sent
 
 # Wait for response (or loading indicator)
 - assertVisible:
     text: "El entrenador está pensando...|Entrenador"
     optional: true
-- takeScreenshot: coach_response
+# Screenshot 04: AI Coach response or loading state
+- takeScreenshot: 04_ai_coach_response
 
 # Navigate back
 - back
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Perfil"
-- takeScreenshot: coach_back_to_profile
+# Screenshot 05: Returned to Profile tab after AI Coach interaction
+- takeScreenshot: 05_ai_coach_back_to_profile

--- a/android/.maestro/browse-library.yaml
+++ b/android/.maestro/browse-library.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Browse Library — Search and filter exercises"
+#
+# Tests: Verifying search functionality and muscle group filters in exercise library
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: Search query "Press", muscle groups "Pecho", "Espalda", "Hombros"
+# Assertions: Search results display correctly, filters toggle on/off, no results message appears when applicable
+# Cleanup: App relaunched with clean filters
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - library
   - smoke
@@ -21,7 +28,8 @@ onFlowComplete:
 
 # Verify Exercise Library is visible
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: library_home
+# Screenshot 01: Exercise library home screen with default view
+- takeScreenshot: 01_browse_library_home
 
 # Tap on search bar and type a query
 - tapOn:
@@ -31,7 +39,8 @@ onFlowComplete:
 - inputText: "Press"
 - waitForAnimationToEnd:
     timeout: 1000
-- takeScreenshot: library_search_results
+# Screenshot 02: Search results for "Press" query
+- takeScreenshot: 02_browse_library_search_results
 
 # Conditional: Check search results
 - runFlow:
@@ -44,7 +53,8 @@ onFlowComplete:
           element:
             text: ".*Press.*"
           timeout: 5000
-      - takeScreenshot: library_exercise_found
+      # Screenshot 03: Specific exercise found in search results
+      - takeScreenshot: 03_browse_library_exercise_found
       
       # Tap the found exercise
       - tapOn:
@@ -52,7 +62,8 @@ onFlowComplete:
           index: 0
       - waitForAnimationToEnd:
           timeout: 1000
-      - takeScreenshot: library_exercise_detail
+      # Screenshot 04: Exercise detail view after tapping from search
+      - takeScreenshot: 04_browse_library_exercise_detail
       
       # Navigate back
       - back
@@ -63,7 +74,8 @@ onFlowComplete:
     commands:
       # No results path
       - assertVisible: "No se encontraron ejercicios"
-      - takeScreenshot: library_no_search_results
+      # Screenshot 05: Empty search results message
+      - takeScreenshot: 05_browse_library_no_search_results
 
 # Relaunch app to clear search
 - launchApp
@@ -77,7 +89,8 @@ onFlowComplete:
 - tapOn: "Pecho"
 - waitForAnimationToEnd:
     timeout: 1000
-- takeScreenshot: library_filter_chest
+# Screenshot 06: Library filtered by Chest/Pecho muscle group
+- takeScreenshot: 06_browse_library_filter_chest
 
 # Deselect Chest, select Back
 - tapOn: "Pecho"
@@ -86,7 +99,8 @@ onFlowComplete:
 - tapOn: "Espalda"
 - waitForAnimationToEnd:
     timeout: 1000
-- takeScreenshot: library_filter_back
+# Screenshot 07: Library filtered by Back/Espalda muscle group
+- takeScreenshot: 07_browse_library_filter_back
 
 # Deselect Back, select Shoulders
 - tapOn: "Espalda"
@@ -95,10 +109,12 @@ onFlowComplete:
 - tapOn: "Hombros"
 - waitForAnimationToEnd:
     timeout: 1000
-- takeScreenshot: library_filter_shoulders
+# Screenshot 08: Library filtered by Shoulders/Hombros muscle group
+- takeScreenshot: 08_browse_library_filter_shoulders
 
 # Deselect filter
 - tapOn: "Hombros"
 - waitForAnimationToEnd:
     timeout: 1000
-- takeScreenshot: library_no_filter
+# Screenshot 09: Library with no filters applied (all exercises shown)
+- takeScreenshot: 09_browse_library_no_filter

--- a/android/.maestro/check-history.yaml
+++ b/android/.maestro/check-history.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Check History — Navigate to history and verify entries"
+#
+# Tests: History tab navigation and conditional verification of empty state or workout data
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: None (tests both empty and populated states)
+# Assertions: History screen loads, handles both empty state and data-exists scenarios correctly
+# Cleanup: Return to Library tab
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - history
   - smoke
@@ -25,7 +32,8 @@ onFlowComplete:
     id: "nav_history"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: history_tab
+# Screenshot 01: History tab opened
+- takeScreenshot: 01_check_history_tab
 
 # Verify History screen loads
 - assertVisible: "Historial de Entrenamientos"
@@ -37,7 +45,8 @@ onFlowComplete:
     commands:
       # Empty state path
       - assertVisible: "Sin Entrenamientos Aún"
-      - takeScreenshot: history_empty_state
+      # Screenshot 02: History empty state with no workouts
+      - takeScreenshot: 02_check_history_empty_state
       - assertVisible: "Comienza tu primer entrenamiento"
         optional: true
 
@@ -47,7 +56,8 @@ onFlowComplete:
         text: "Hoy|Ayer|hace.*día"
     commands:
       # Data exists path
-      - takeScreenshot: history_with_data
+      # Screenshot 03: History with workout data visible
+      - takeScreenshot: 03_check_history_with_data
       
       # Use scrollUntilVisible to find older workouts
       - scrollUntilVisible:
@@ -56,7 +66,8 @@ onFlowComplete:
             index: 2
           timeout: 5000
           optional: true
-      - takeScreenshot: history_scrolled
+      # Screenshot 04: History scrolled to show more workouts
+      - takeScreenshot: 04_check_history_scrolled
       
       # Tap the first workout to see details
       - tapOn:
@@ -64,7 +75,8 @@ onFlowComplete:
           index: 0
       - waitForAnimationToEnd:
           timeout: 2000
-      - takeScreenshot: history_workout_detail
+      # Screenshot 05: Workout detail screen opened from history
+      - takeScreenshot: 05_check_history_workout_detail
       
       # Navigate back
       - back

--- a/android/.maestro/check-progress.yaml
+++ b/android/.maestro/check-progress.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Check Progress — Navigate to progress and verify KPI cards"
+#
+# Tests: Progress tab navigation and KPI data display (volume, PRs, 1RM trends)
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: None (tests both empty and populated states)
+# Assertions: Progress screen loads, copyTextFrom captures volume stats, KPI cards visible
+# Cleanup: Return to Library tab
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - progress
   - smoke
@@ -25,7 +32,8 @@ onFlowComplete:
     id: "nav_progress"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: progress_tab
+# Screenshot 01: Progress tab opened
+- takeScreenshot: 01_check_progress_tab
 
 # Conditional: Check for empty state or stats
 - runFlow:
@@ -34,7 +42,8 @@ onFlowComplete:
     commands:
       # Empty state path
       - assertVisible: "Sin entrenamientos aún"
-      - takeScreenshot: progress_empty_state
+      # Screenshot 02: Progress empty state with no workout data
+      - takeScreenshot: 02_check_progress_empty_state
       - assertVisible: "Registra tu primer entrenamiento"
         optional: true
 
@@ -44,7 +53,8 @@ onFlowComplete:
     commands:
       # Data exists path — verify and capture KPI stats
       - assertVisible: "Volumen Semanal"
-      - takeScreenshot: progress_with_data
+      # Screenshot 03: Progress with KPI data visible
+      - takeScreenshot: 03_check_progress_with_data
       
       # copyTextFrom: Capture volume stat
       - copyTextFrom:
@@ -58,8 +68,10 @@ onFlowComplete:
       - assertVisible:
           text: "Estimated 1RM Trend"
           optional: true
-      - takeScreenshot: progress_kpi_cards
+      # Screenshot 04: KPI cards with volume and PR sections
+      - takeScreenshot: 04_check_progress_kpi_cards
       
       # Scroll down to see more content
       - scroll
-      - takeScreenshot: progress_scrolled
+      # Screenshot 05: Progress scrolled to show additional data
+      - takeScreenshot: 05_check_progress_scrolled

--- a/android/.maestro/complete-workout.yaml
+++ b/android/.maestro/complete-workout.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Complete Workout — Full workout to completion and summary"
+#
+# Tests: Full workout lifecycle from start to completion, including persistence verification
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: EXERCISE_NAME (Bench Press), WEIGHT (100), REPS (5), 3 sets
+# Assertions: Sets logged correctly with copyTextFrom, workout summary shows, data persists in History and Progress
+# Cleanup: None (workout data persists for history/progress validation)
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - core
 ---
@@ -69,14 +76,16 @@ onFlowStart:
           index: 0
       - assertTrue: ${maestro.copiedText == "${REPS:=5}"}
       
-      - takeScreenshot: workout_set_${repeat.index}_filled
+      # Screenshot: Set filled with weight and reps values (numbered per repeat index)
+      - takeScreenshot: 0${repeat.index}_complete_workout_set_filled
       
       # Complete the set
       - tapOn:
           text: "Completar serie.*"
       - waitForAnimationToEnd:
           timeout: 1000
-      - takeScreenshot: workout_set_${repeat.index}_completed
+      # Screenshot: Set marked as completed (numbered per repeat index)
+      - takeScreenshot: 0${repeat.index}_complete_workout_set_completed
 
 # Finish the workout
 - tapOn: "Finalizar Entrenamiento"
@@ -85,7 +94,8 @@ onFlowStart:
 
 # Verify workout summary screen
 - assertVisible: "¡Entrenamiento Completado!"
-- takeScreenshot: workout_summary
+# Screenshot 04: Workout summary screen after completion
+- takeScreenshot: 04_complete_workout_summary
 
 # Verify stats are displayed and capture values
 - assertVisible: "Estadísticas del Entrenamiento"
@@ -100,7 +110,8 @@ onFlowStart:
     text: "\\d+.*series"
 - assertVisible: "${maestro.copiedText}"
 
-- takeScreenshot: workout_stats_captured
+# Screenshot 05: Workout stats captured with copyTextFrom verification
+- takeScreenshot: 05_complete_workout_stats_captured
 
 # Tap Done to return
 - tapOn: "Listo"
@@ -109,7 +120,8 @@ onFlowStart:
 
 # Back at exercise library
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: workout_flow_complete
+# Screenshot 06: Returned to Exercise Library after workout completion
+- takeScreenshot: 06_complete_workout_flow_complete
 
 # PERSISTENCE VERIFICATION: Navigate to History
 - tapOn:
@@ -117,11 +129,13 @@ onFlowStart:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
-- takeScreenshot: persistence_check_history
+# Screenshot 07: History tab opened for persistence verification
+- takeScreenshot: 07_complete_workout_persistence_check_history
 
 # Verify workout appears in history (Exercise should be visible)
 - assertVisible: "${EXERCISE_NAME:=Bench Press}"
-- takeScreenshot: persistence_workout_in_history
+# Screenshot 08: Workout appears in history confirming data persistence
+- takeScreenshot: 08_complete_workout_persistence_workout_in_history
 
 # PERSISTENCE VERIFICATION: Navigate to Progress
 - tapOn:
@@ -130,13 +144,15 @@ onFlowStart:
     timeout: 2000
 - assertVisible:
     text: "Volumen Semanal|Sin entrenamientos aún"
-- takeScreenshot: persistence_check_progress
+# Screenshot 09: Progress tab opened for persistence verification
+- takeScreenshot: 09_complete_workout_persistence_check_progress
 
 # If progress data exists, verify it's updated (not empty state)
 - assertVisible:
     text: "Volumen Semanal"
     optional: true
-- takeScreenshot: persistence_progress_updated
+# Screenshot 10: Progress data updated after workout completion
+- takeScreenshot: 10_complete_workout_persistence_progress_updated
 
 # Return to Exercise Library
 - tapOn:

--- a/android/.maestro/empty-state-screens.yaml
+++ b/android/.maestro/empty-state-screens.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Negative — Empty State UI (fresh app with no data)"
+#
+# Tests: Empty state UI across all tabs with fresh app install
+# Preconditions: App launched with clearState (fresh install simulation)
+# Test data: User name "EmptyTest", units kg
+# Assertions: All tabs (Library, History, Progress, Recovery, Profile) handle empty state gracefully
+# Cleanup: App state cleared via stopApp
+# Dependencies: None
 tags:
   - negative
   - core
@@ -20,7 +27,8 @@ onFlowComplete:
 
 # Complete onboarding quickly to get past it
 - assertVisible: "GymBro"
-- takeScreenshot: empty_state_onboarding_start
+# Screenshot 01: Onboarding start screen (fresh app state)
+- takeScreenshot: 01_empty_state_onboarding_start
 
 # Swipe through onboarding pages
 - swipe:
@@ -46,7 +54,8 @@ onFlowComplete:
 
 # Now at Exercise Library (post-onboarding)
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: empty_state_library
+# Screenshot 02: Exercise Library empty state (no workouts yet)
+- takeScreenshot: 02_empty_state_library
 
 # TEST 1: Check History tab (should show empty state)
 - tapOn:
@@ -56,7 +65,8 @@ onFlowComplete:
 
 # Verify History screen loaded
 - assertVisible: "Historial|History"
-- takeScreenshot: empty_state_history
+# Screenshot 03: History tab empty state (no workout history)
+- takeScreenshot: 03_empty_state_history
 # Should show empty state message or empty list
 
 # TEST 2: Check Progress tab (should show empty state)
@@ -67,7 +77,8 @@ onFlowComplete:
 
 # Verify Progress screen loaded
 - assertVisible: "Progreso|Progress"
-- takeScreenshot: empty_state_progress
+# Screenshot 04: Progress tab empty state (no progress data)
+- takeScreenshot: 04_empty_state_progress
 # Should show empty state with no data
 
 # TEST 3: Check Recovery tab
@@ -77,7 +88,8 @@ onFlowComplete:
     timeout: 2000
 
 # Verify Recovery screen loaded
-- takeScreenshot: empty_state_recovery
+# Screenshot 05: Recovery tab empty state
+- takeScreenshot: 05_empty_state_recovery
 
 # TEST 4: Check Profile tab
 - tapOn:
@@ -87,7 +99,8 @@ onFlowComplete:
 
 # Verify Profile screen loaded
 - assertVisible: "Perfil|Profile"
-- takeScreenshot: empty_state_profile
+# Screenshot 06: Profile tab with fresh user data
+- takeScreenshot: 06_empty_state_profile
 
 # Verify app handles all empty states gracefully
 - assertVisible: "EmptyTest"

--- a/android/.maestro/full-e2e.yaml
+++ b/android/.maestro/full-e2e.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Full E2E — Complete user journey: onboarding → workout → history"
+#
+# Tests: Complete end-to-end user journey from onboarding through workout completion and verification
+# Preconditions: App launched with clearState (fresh install state)
+# Test data: USER_NAME (E2EUser), EXERCISE_NAME (Bench Press), WEIGHT (80), REPS (10)
+# Assertions: Onboarding completes, workout logged and finished, data visible in History and Progress
+# Cleanup: App state cleared via stopApp
+# Dependencies: None
 tags:
   - e2e
   - regression
@@ -18,7 +25,8 @@ onFlowComplete:
 
 # Welcome page
 - assertVisible: "GymBro"
-- takeScreenshot: e2e_onboarding_start
+# Screenshot 01: E2E test starting at onboarding welcome
+- takeScreenshot: 01_full_e2e_onboarding_start
 
 # Swipe through all pages
 - swipe:
@@ -49,7 +57,8 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 3000
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: e2e_onboarding_complete
+# Screenshot 02: Onboarding completed, landed on Exercise Library
+- takeScreenshot: 02_full_e2e_onboarding_complete
 
 # === PHASE 2: QUICK LIBRARY BROWSE ===
 
@@ -59,7 +68,8 @@ onFlowComplete:
     optional: true
 
 # Verify library content is loaded
-- takeScreenshot: e2e_library_loaded
+# Screenshot 03: Exercise library loaded with exercises
+- takeScreenshot: 03_full_e2e_library_loaded
 
 # === PHASE 3: START AND COMPLETE WORKOUT ===
 
@@ -69,7 +79,8 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Entrenamiento Activo"
-- takeScreenshot: e2e_workout_started
+# Screenshot 04: Active workout started
+- takeScreenshot: 04_full_e2e_workout_started
 
 # Add an exercise
 - tapOn: "Añadir Ejercicio"
@@ -96,7 +107,8 @@ onFlowComplete:
     index: 0
 - inputText: "${REPS:=10}"
 
-- takeScreenshot: e2e_set_filled
+# Screenshot 05: Set filled with weight and reps
+- takeScreenshot: 05_full_e2e_set_filled
 
 # Complete the set
 - tapOn:
@@ -111,7 +123,8 @@ onFlowComplete:
 
 # Verify summary
 - assertVisible: "¡Entrenamiento Completado!"
-- takeScreenshot: e2e_workout_summary
+# Screenshot 06: Workout summary screen after completion
+- takeScreenshot: 06_full_e2e_workout_summary
 
 # Tap done
 - tapOn: "Listo"
@@ -127,7 +140,8 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
-- takeScreenshot: e2e_history_with_workout
+# Screenshot 07: History tab showing completed workout
+- takeScreenshot: 07_full_e2e_history_with_workout
 
 # Verify the workout appears (today's entry)
 - assertVisible:
@@ -141,7 +155,8 @@ onFlowComplete:
     id: "nav_progress"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: e2e_progress_after_workout
+# Screenshot 08: Progress tab after workout completion
+- takeScreenshot: 08_full_e2e_progress_after_workout
 
 # === PHASE 6: VERIFY PROFILE ===
 
@@ -151,10 +166,12 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Cuenta"
-- takeScreenshot: e2e_profile
+# Screenshot 09: Profile tab with user account
+- takeScreenshot: 09_full_e2e_profile
 
 # Return to library
 - tapOn:
     id: "nav_exercise_library"
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: e2e_complete
+# Screenshot 10: E2E test completed, back at Exercise Library
+- takeScreenshot: 10_full_e2e_complete

--- a/android/.maestro/navigation-smoke.yaml
+++ b/android/.maestro/navigation-smoke.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Navigation Smoke — Tap through all bottom nav tabs"
+#
+# Tests: Bottom navigation bar functionality across all tabs
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: None
+# Assertions: All nav tabs (Library, History, Progress, Recovery, Profile) are accessible and load correctly
+# Cleanup: Return to Library tab
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - navigation
   - smoke
@@ -22,7 +29,8 @@ onFlowComplete:
 
 # Start at Library tab
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: nav_library
+# Screenshot 01: Exercise Library tab (navigation starting point)
+- takeScreenshot: 01_navigation_smoke_library
 
 # Tap History tab
 - tapOn:
@@ -30,28 +38,32 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
-- takeScreenshot: nav_history
+# Screenshot 02: History tab loaded via navigation
+- takeScreenshot: 02_navigation_smoke_history
 
 # Tap Progress tab
 - tapOn:
     id: "nav_progress"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: nav_progress
+# Screenshot 03: Progress tab loaded via navigation
+- takeScreenshot: 03_navigation_smoke_progress
 
 # Tap Recovery tab
 - tapOn:
     id: "nav_recovery"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: nav_recovery
+# Screenshot 04: Recovery tab loaded via navigation
+- takeScreenshot: 04_navigation_smoke_recovery
 
 # Tap Profile tab
 - tapOn:
     id: "nav_profile"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: nav_profile
+# Screenshot 05: Profile tab loaded via navigation
+- takeScreenshot: 05_navigation_smoke_profile
 
 # Navigate back to Library
 - tapOn:
@@ -59,4 +71,5 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: nav_back_to_library
+# Screenshot 06: Returned to Exercise Library after full navigation cycle
+- takeScreenshot: 06_navigation_smoke_back_to_library

--- a/android/.maestro/negative-workout-input.yaml
+++ b/android/.maestro/negative-workout-input.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Negative — Invalid Workout Inputs (zero/negative/extreme values)"
+#
+# Tests: App resilience with invalid workout input values (zero, negative, extreme)
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: Invalid inputs (0, -50, 99999, -10) for weight and reps
+# Assertions: App handles invalid inputs gracefully without crashes
+# Cleanup: Cancel active workout
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - negative
   - core
@@ -30,7 +37,8 @@ onFlowComplete:
 
 # Verify Active Workout screen
 - assertVisible: "Entrenamiento Activo"
-- takeScreenshot: negative_workout_started
+# Screenshot 01: Workout started for negative input testing
+- takeScreenshot: 01_negative_workout_input_started
 
 # Add an exercise
 - tapOn: "Añadir Ejercicio"
@@ -58,7 +66,8 @@ onFlowComplete:
     index: 0
 - inputText: "5"
 - hideKeyboard
-- takeScreenshot: negative_zero_weight
+# Screenshot 02: Zero weight input test
+- takeScreenshot: 02_negative_workout_input_zero_weight
 # App should handle gracefully (no crash)
 
 # Clear and try TEST 2: Negative weight
@@ -71,7 +80,8 @@ onFlowComplete:
     index: 0
 - inputText: "5"
 - hideKeyboard
-- takeScreenshot: negative_weight
+# Screenshot 03: Negative weight input test
+- takeScreenshot: 03_negative_workout_input_negative_weight
 # App should handle gracefully
 
 # Clear and try TEST 3: Extremely large weight
@@ -80,7 +90,8 @@ onFlowComplete:
     index: 0
 - inputText: "99999"
 - hideKeyboard
-- takeScreenshot: negative_extreme_weight
+# Screenshot 04: Extreme weight input test (99999 kg)
+- takeScreenshot: 04_negative_workout_input_extreme_weight
 
 # TEST 4: Zero reps
 - tapOn:
@@ -88,7 +99,8 @@ onFlowComplete:
     index: 0
 - inputText: "0"
 - hideKeyboard
-- takeScreenshot: negative_zero_reps
+# Screenshot 05: Zero reps input test
+- takeScreenshot: 05_negative_workout_input_zero_reps
 
 # TEST 5: Negative reps
 - tapOn:
@@ -96,7 +108,8 @@ onFlowComplete:
     index: 0
 - inputText: "-10"
 - hideKeyboard
-- takeScreenshot: negative_reps
+# Screenshot 06: Negative reps input test
+- takeScreenshot: 06_negative_workout_input_negative_reps
 
 # Verify app is still responsive (no crash)
 - assertVisible: "Entrenamiento Activo"

--- a/android/.maestro/onboarding-edge-cases.yaml
+++ b/android/.maestro/onboarding-edge-cases.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Negative — Onboarding Edge Cases (empty/long/special names)"
+#
+# Tests: Onboarding form validation with edge case inputs (empty, very long, special chars, emoji)
+# Preconditions: App launched with clearState for each test
+# Test data: Various invalid/edge case names (empty, 50+ chars, special chars, emoji)
+# Assertions: App handles all edge cases gracefully without crashes
+# Cleanup: App stopped after all tests
+# Dependencies: None
 tags:
   - negative
   - onboarding
@@ -18,7 +25,8 @@ onFlowComplete:
     timeout: 3000
 
 - assertVisible: "GymBro"
-- takeScreenshot: onboarding_edge_start
+# Screenshot 01: Onboarding edge case testing start
+- takeScreenshot: 01_onboarding_edge_start
 
 # Swipe to final onboarding page
 - swipe:
@@ -37,7 +45,8 @@ onFlowComplete:
 # Try to proceed without entering name
 - tapOn:
     id: "onboarding_start"
-- takeScreenshot: onboarding_edge_empty_name
+# Screenshot 02: Empty name input test
+- takeScreenshot: 02_onboarding_edge_empty_name
 # App should either require name or proceed with empty (verify no crash)
 
 # Stop and restart for next test
@@ -64,7 +73,8 @@ onFlowComplete:
     id: "onboarding_name_input"
 - inputText: "ThisIsAVeryLongNameThatExceedsFiftyCharactersToTestInputHandling"
 - hideKeyboard
-- takeScreenshot: onboarding_edge_long_name
+# Screenshot 03: Very long name input test (50+ characters)
+- takeScreenshot: 03_onboarding_edge_long_name
 # Verify name field handles long input
 
 - tapOn:
@@ -96,7 +106,8 @@ onFlowComplete:
     id: "onboarding_name_input"
 - inputText: "User@123!#$%"
 - hideKeyboard
-- takeScreenshot: onboarding_edge_special_chars
+# Screenshot 04: Special characters in name input test
+- takeScreenshot: 04_onboarding_edge_special_chars
 
 - tapOn:
     id: "onboarding_start"
@@ -127,7 +138,8 @@ onFlowComplete:
     id: "onboarding_name_input"
 - inputText: "User💪🏋️"
 - hideKeyboard
-- takeScreenshot: onboarding_edge_emoji
+# Screenshot 05: Emoji in name input test
+- takeScreenshot: 05_onboarding_edge_emoji
 
 - tapOn:
     id: "onboarding_start"
@@ -137,4 +149,5 @@ onFlowComplete:
 
 # Verify we reached Exercise Library (no crash)
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: onboarding_edge_complete
+# Screenshot 06: Edge case tests completed, app stable
+- takeScreenshot: 06_onboarding_edge_complete

--- a/android/.maestro/onboarding-flow.yaml
+++ b/android/.maestro/onboarding-flow.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Onboarding — Complete 4-page onboarding flow"
+#
+# Tests: Complete onboarding flow from welcome through name/unit selection
+# Preconditions: App launched with clearState (fresh install state)
+# Test data: USER_NAME env var (defaults to "TestUser"), units selection (kg)
+# Assertions: All 4 onboarding pages visible, name and units saved, lands on Exercise Library
+# Cleanup: App state cleared via stopApp and clearState
+# Dependencies: None
 tags:
   - onboarding
   - smoke
@@ -16,7 +23,8 @@ onFlowComplete:
 # Page 0: Welcome
 - assertVisible: "GymBro"
 - assertVisible: "Your smart gym companion"
-- takeScreenshot: onboarding_welcome
+# Screenshot 01: Welcome page (first onboarding screen)
+- takeScreenshot: 01_onboarding_welcome
 
 # Swipe to Page 1: Fast Logging
 - swipe:
@@ -24,7 +32,8 @@ onFlowComplete:
     duration: 400
 
 - assertVisible: "Ultra-Fast Logging"
-- takeScreenshot: onboarding_fast_logging
+# Screenshot 02: Fast Logging page (second onboarding screen)
+- takeScreenshot: 02_onboarding_fast_logging
 
 # Swipe to Page 2: Track Progress
 - swipe:
@@ -32,7 +41,8 @@ onFlowComplete:
     duration: 400
 
 - assertVisible: "Track Your Progress"
-- takeScreenshot: onboarding_track_progress
+# Screenshot 03: Track Progress page (third onboarding screen)
+- takeScreenshot: 03_onboarding_track_progress
 
 # Swipe to Page 3: Get Started
 - swipe:
@@ -43,7 +53,8 @@ onFlowComplete:
 - assertVisible: "Preferred Units"
 - assertVisible: "Kilograms (kg)"
 - assertVisible: "Pounds (lbs)"
-- takeScreenshot: onboarding_get_started
+# Screenshot 04: Get Started page with unit selection (fourth onboarding screen)
+- takeScreenshot: 04_onboarding_get_started
 
 # Select kg unit
 - tapOn: "Kilograms (kg)"
@@ -51,7 +62,8 @@ onFlowComplete:
 # Enter name
 - tapOn: "Enter your name"
 - inputText: "${USER_NAME:=TestUser}"
-- takeScreenshot: onboarding_name_entered
+# Screenshot 05: User name entered in onboarding form
+- takeScreenshot: 05_onboarding_name_entered
 - hideKeyboard
 
 # Complete onboarding
@@ -61,4 +73,5 @@ onFlowComplete:
 
 # Verify we landed on Exercise Library
 - assertVisible: "Exercise Library"
-- takeScreenshot: onboarding_complete
+# Screenshot 06: Successfully completed onboarding, landed on Exercise Library
+- takeScreenshot: 06_onboarding_complete

--- a/android/.maestro/profile-settings.yaml
+++ b/android/.maestro/profile-settings.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Profile Settings — Open profile and check settings sections"
+#
+# Tests: Profile tab sections and settings visibility
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: None
+# Assertions: All profile sections visible (AI Coach, Account, Training Preferences, About, Version)
+# Cleanup: Return to Library tab
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - regression
 ---
@@ -24,29 +31,34 @@ onFlowComplete:
     id: "nav_profile"
 - waitForAnimationToEnd:
     timeout: 2000
-- takeScreenshot: profile_screen
+# Screenshot 01: Profile screen opened
+- takeScreenshot: 01_profile_settings_screen
 
 # Verify profile sections are visible
 - assertVisible: "Hablar con el Entrenador IA"
 - assertVisible: "Cuenta"
 - assertVisible: "Preferencias de Entrenamiento"
-- takeScreenshot: profile_sections
+# Screenshot 02: Profile sections visible (AI Coach, Account, Preferences)
+- takeScreenshot: 02_profile_settings_sections
 
 # Scroll to see more sections
 - scroll
 
 - assertVisible: "Acerca de"
 - assertVisible: "Versión 1.0"
-- takeScreenshot: profile_about_section
+# Screenshot 03: About section with app version visible
+- takeScreenshot: 03_profile_settings_about_section
 
 # Verify preference items
 - assertVisible: "Temporizador de Descanso Predeterminado"
 - assertVisible: "Unidad de Peso"
 - assertVisible: "Recordatorios de Entrenamiento"
-- takeScreenshot: profile_preferences
+# Screenshot 04: Training preferences items visible
+- takeScreenshot: 04_profile_settings_preferences
 
 # Scroll back up
 - scrollUntilVisible:
     element: "Hablar con el Entrenador IA"
     direction: UP
-- takeScreenshot: profile_top
+# Screenshot 05: Scrolled back to top of profile
+- takeScreenshot: 05_profile_settings_top

--- a/android/.maestro/rapid-navigation.yaml
+++ b/android/.maestro/rapid-navigation.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Negative — Rapid Navigation Stress Test"
+#
+# Tests: App stability under rapid navigation between tabs (stress test)
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: None
+# Assertions: App handles rapid/repeated navigation without crashes or state corruption
+# Cleanup: None
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - negative
   - regression
@@ -15,7 +22,8 @@ onFlowStart:
 
 # Start from Exercise Library
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: rapid_nav_start
+# Screenshot 01: Rapid navigation test starting point
+- takeScreenshot: 01_rapid_navigation_start
 
 # RAPID TAP SEQUENCE 1: Cycle through all nav tabs quickly
 - tapOn:
@@ -47,7 +55,8 @@ onFlowStart:
     timeout: 1500
 - assertVisible: "Biblioteca de Ejercicios"
 
-- takeScreenshot: rapid_nav_cycle1
+# Screenshot 02: First navigation cycle completed
+- takeScreenshot: 02_rapid_navigation_cycle1
 
 # RAPID TAP SEQUENCE 2: Reverse order
 - tapOn:
@@ -75,7 +84,8 @@ onFlowStart:
 - waitForAnimationToEnd:
     timeout: 1500
 
-- takeScreenshot: rapid_nav_cycle2
+# Screenshot 03: Reverse navigation cycle completed
+- takeScreenshot: 03_rapid_navigation_cycle2
 
 # RAPID TAP SEQUENCE 3: Random pattern
 - tapOn:
@@ -108,7 +118,8 @@ onFlowStart:
 - waitForAnimationToEnd:
     timeout: 1500
 
-- takeScreenshot: rapid_nav_cycle3
+# Screenshot 04: Random pattern navigation cycle completed
+- takeScreenshot: 04_rapid_navigation_cycle3
 
 # STRESS TEST: Multiple rapid taps on same tab
 - tapOn:
@@ -131,7 +142,8 @@ onFlowStart:
     timeout: 1500
 - assertVisible: "Biblioteca de Ejercicios"
 
-- takeScreenshot: rapid_nav_stress
+# Screenshot 05: Stress test (multiple rapid taps on same tab) completed
+- takeScreenshot: 05_rapid_navigation_stress
 
 # Final verification: All tabs still work correctly
 - tapOn:
@@ -163,4 +175,5 @@ onFlowStart:
     timeout: 1500
 - assertVisible: "Biblioteca de Ejercicios"
 
-- takeScreenshot: rapid_nav_complete
+# Screenshot 06: All tabs still functional after stress test
+- takeScreenshot: 06_rapid_navigation_complete

--- a/android/.maestro/search-no-results.yaml
+++ b/android/.maestro/search-no-results.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Negative — Search for Nonexistent Exercise"
+#
+# Tests: Search functionality with invalid/edge case queries (nonexistent, numbers, special chars, emoji)
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: Invalid search queries (XYZNONEXISTENT, 99999, !@#$%^&*(), 💪🏋️, Bench)
+# Assertions: App handles invalid searches gracefully, shows appropriate empty results, recovers with valid search
+# Cleanup: None
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - negative
 ---
@@ -14,14 +21,16 @@ onFlowStart:
 
 # Start from Exercise Library
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: search_no_results_start
+# Screenshot 01: Search no results test starting point
+- takeScreenshot: 01_search_no_results_start
 
 # TEST 1: Search for completely nonexistent term
 - tapOn:
     id: "search_bar"
 - inputText: "XYZNONEXISTENT"
 - hideKeyboard
-- takeScreenshot: search_no_results_nonexistent
+# Screenshot 02: Search with completely nonexistent term
+- takeScreenshot: 02_search_no_results_nonexistent
 # Should show empty results or "no results" message
 
 # Clear search
@@ -35,7 +44,8 @@ onFlowStart:
     id: "search_bar"
 - inputText: "99999"
 - hideKeyboard
-- takeScreenshot: search_no_results_numbers
+# Screenshot 03: Search with numbers only
+- takeScreenshot: 03_search_no_results_numbers
 
 # Clear search
 - tapOn:
@@ -48,7 +58,8 @@ onFlowStart:
     id: "search_bar"
 - inputText: "!@#$%^&*()"
 - hideKeyboard
-- takeScreenshot: search_no_results_special_chars
+# Screenshot 04: Search with special characters
+- takeScreenshot: 04_search_no_results_special_chars
 
 # Clear search
 - tapOn:
@@ -61,7 +72,8 @@ onFlowStart:
     id: "search_bar"
 - inputText: "💪🏋️"
 - hideKeyboard
-- takeScreenshot: search_no_results_emoji
+# Screenshot 05: Search with emoji
+- takeScreenshot: 05_search_no_results_emoji
 
 # Clear search and verify app still responsive
 - tapOn:
@@ -75,5 +87,6 @@ onFlowStart:
     id: "search_bar"
 - inputText: "Bench"
 - hideKeyboard
-- takeScreenshot: search_valid_after_invalid
+# Screenshot 06: Valid search after invalid attempts (verifies recovery)
+- takeScreenshot: 06_search_no_results_valid_after_invalid
 # Should show results for Bench Press

--- a/android/.maestro/smoke-test.yaml
+++ b/android/.maestro/smoke-test.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Smoke Test — Basic app launch"
+#
+# Tests: Basic app launch and post-onboarding state verification
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: None
+# Assertions: App launches successfully and Exercise Library is visible
+# Cleanup: None
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - smoke
 ---

--- a/android/.maestro/start-workout.yaml
+++ b/android/.maestro/start-workout.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Start Workout — Begin workout, add exercises, log sets"
+#
+# Tests: Starting a workout, adding exercises via search, and logging set data
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: EXERCISE_SEARCH (Bench), EXERCISE_NAME (Bench Press), WEIGHT (80), REPS (8)
+# Assertions: Workout starts, exercise picker opens, exercise added, set data entered
+# Cleanup: Cancel active workout
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - core
 ---
@@ -32,7 +39,8 @@ onFlowComplete:
 
 # Verify Active Workout screen
 - assertVisible: "Entrenamiento Activo"
-- takeScreenshot: workout_started
+# Screenshot 01: Active workout screen after starting
+- takeScreenshot: 01_start_workout_started
 
 # Tap Add Exercise button
 - tapOn: "Añadir Ejercicio"
@@ -41,13 +49,15 @@ onFlowComplete:
 
 # Verify exercise picker opens
 - assertVisible: "Elegir Ejercicio"
-- takeScreenshot: exercise_picker
+# Screenshot 02: Exercise picker opened from workout
+- takeScreenshot: 02_start_workout_exercise_picker
 
 # Search and select an exercise
 - tapOn:
     id: "search_bar"
 - inputText: "${EXERCISE_SEARCH:=Bench}"
-- takeScreenshot: exercise_picker_search
+# Screenshot 03: Search query entered in exercise picker
+- takeScreenshot: 03_start_workout_exercise_picker_search
 
 # Tap the first exercise result
 - tapOn:
@@ -56,7 +66,8 @@ onFlowComplete:
 
 # Back on workout screen — verify exercise was added
 - assertVisible: "Entrenamiento Activo"
-- takeScreenshot: workout_exercise_added
+# Screenshot 04: Exercise added to active workout
+- takeScreenshot: 04_start_workout_exercise_added
 
 # Log a set — enter weight value
 - tapOn:
@@ -70,4 +81,5 @@ onFlowComplete:
     index: 0
 - inputText: "${REPS:=8}"
 
-- takeScreenshot: workout_set_logged
+# Screenshot 05: Set data logged (weight and reps entered)
+- takeScreenshot: 05_start_workout_set_logged

--- a/android/.maestro/verify-data-persistence.yaml
+++ b/android/.maestro/verify-data-persistence.yaml
@@ -1,5 +1,12 @@
 appId: com.gymbro.app
 name: "Verify Data Persistence — Cross-screen data verification"
+#
+# Tests: Workout data persistence across History and Progress tabs
+# Preconditions: User has completed onboarding (ensured by ensure-post-onboarding.yaml)
+# Test data: EXERCISE_NAME (Squat), WEIGHT (80), REPS (8), 1 set
+# Assertions: Completed workout appears in History with details, Progress shows updated stats
+# Cleanup: Return to Library tab
+# Dependencies: flow/ensure-post-onboarding.yaml
 tags:
   - core
   - regression
@@ -22,7 +29,8 @@ onFlowComplete:
 
 # Start from Exercise Library
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: persistence_flow_start
+# Screenshot 01: Data persistence flow starting point
+- takeScreenshot: 01_verify_data_persistence_flow_start
 
 # STEP 1: Start a workout
 - tapOn:
@@ -30,7 +38,8 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Entrenamiento Activo"
-- takeScreenshot: persistence_workout_started
+# Screenshot 02: Workout started for persistence test
+- takeScreenshot: 02_verify_data_persistence_workout_started
 
 # STEP 2: Add an exercise
 - tapOn: "Añadir Ejercicio"
@@ -57,21 +66,24 @@ onFlowComplete:
 - inputText: "${REPS:=8}"
 - hideKeyboard
 
-- takeScreenshot: persistence_set_filled
+# Screenshot 03: Set filled with weight and reps
+- takeScreenshot: 03_verify_data_persistence_set_filled
 
 # Complete the set
 - tapOn:
     text: "Completar serie 1"
 - waitForAnimationToEnd:
     timeout: 1000
-- takeScreenshot: persistence_set_completed
+# Screenshot 04: Set completed successfully
+- takeScreenshot: 04_verify_data_persistence_set_completed
 
 # STEP 4: Complete the workout
 - tapOn: "Finalizar Entrenamiento"
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "¡Entrenamiento Completado!"
-- takeScreenshot: persistence_workout_summary
+# Screenshot 05: Workout summary displayed
+- takeScreenshot: 05_verify_data_persistence_workout_summary
 
 # Return to library
 - tapOn: "Listo"
@@ -85,18 +97,21 @@ onFlowComplete:
 - waitForAnimationToEnd:
     timeout: 2000
 - assertVisible: "Historial de Entrenamientos"
-- takeScreenshot: persistence_verify_history
+# Screenshot 06: History tab opened to verify persistence
+- takeScreenshot: 06_verify_data_persistence_verify_history
 
 # Verify workout appears
 - assertVisible: "${EXERCISE_NAME:=Squat}"
-- takeScreenshot: persistence_workout_found_in_history
+# Screenshot 07: Workout found in history confirming persistence
+- takeScreenshot: 07_verify_data_persistence_workout_found_in_history
 
 # Tap on the workout to see details
 - tapOn: "${EXERCISE_NAME:=Squat}"
 - assertVisible:
     text: "${WEIGHT:=80}|${REPS:=8}"
     optional: true
-- takeScreenshot: persistence_history_detail
+# Screenshot 08: Workout detail view with set data
+- takeScreenshot: 08_verify_data_persistence_history_detail
 
 # Go back to history list
 - back
@@ -111,11 +126,13 @@ onFlowComplete:
     timeout: 2000
 - assertVisible:
     text: "Volumen Semanal|Sin entrenamientos aún"
-- takeScreenshot: persistence_verify_progress
+# Screenshot 09: Progress tab opened to verify persistence
+- takeScreenshot: 09_verify_data_persistence_verify_progress
 
 # Verify progress data shows (not empty state)
 - assertVisible: "Volumen Semanal"
-- takeScreenshot: persistence_progress_stats_visible
+# Screenshot 10: Progress stats visible confirming data persistence
+- takeScreenshot: 10_verify_data_persistence_progress_stats_visible
 
 # Verify PRs section is present (indicates data exists)
 - assertVisible:
@@ -124,10 +141,12 @@ onFlowComplete:
 
 # Scroll to see more stats
 - scroll
-- takeScreenshot: persistence_progress_scrolled
+# Screenshot 11: Progress scrolled to show additional stats
+- takeScreenshot: 11_verify_data_persistence_progress_scrolled
 
 # VERIFICATION 3: Return to library and verify state
 - tapOn:
     id: "nav_exercise_library"
 - assertVisible: "Biblioteca de Ejercicios"
-- takeScreenshot: persistence_flow_complete
+# Screenshot 12: Data persistence flow completed, back at Library
+- takeScreenshot: 12_verify_data_persistence_flow_complete


### PR DESCRIPTION
Closes #286
Closes #290

## Changes

### Screenshot Naming (#286)
- Renamed all \	akeScreenshot\ calls to follow format: \{NN}_{flow}_{what_verified}\
- Added descriptive comments before each screenshot explaining what's being verified
- Sequential numbering (01, 02, 03...) per flow for better organization

### Docstrings (#290)
- Added metadata header comment block to ALL flows after the name field
- Each flow now includes:
  - **Tests**: What user journey is being verified
  - **Preconditions**: Required app state before flow starts
  - **Test data**: What values are used (or ENV vars)
  - **Assertions**: What outcomes are checked
  - **Cleanup**: What state changes persist
  - **Dependencies**: Other flows this depends on (or 'None')

## Modified Files (17)
All Maestro flow files in android/.maestro/:
- ai-coach.yaml
- browse-library.yaml
- check-history.yaml
- check-progress.yaml
- complete-workout.yaml
- empty-state-screens.yaml
- full-e2e.yaml
- navigation-smoke.yaml
- negative-workout-input.yaml
- onboarding-edge-cases.yaml
- onboarding-flow.yaml
- profile-settings.yaml
- rapid-navigation.yaml
- search-no-results.yaml
- smoke-test.yaml
- start-workout.yaml
- verify-data-persistence.yaml