### PR TITLE
fix: correct YAML syntax in check-history.yaml

### DIFF
--- a/android/.maestro/check-history.yaml
+++ b/android/.maestro/check-history.yaml
@@ -47,8 +47,9 @@ onFlowComplete:
       - assertVisible: "Sin Entrenamientos Aún"
       # Screenshot 02: History empty state with no workouts
       - takeScreenshot: 02_check_history_empty_state
-      - assertVisible: "Comienza tu primer entrenamiento"
-        optional: true
+      - assertVisible:
+          text: "Comienza tu primer entrenamiento"
+          optional: true
 
 - runFlow:
     when:


### PR DESCRIPTION
## Summary
Fixed incorrect YAML indentation in check-history.yaml where the assertVisible command with optional parameter was not using proper nested object syntax.

## Investigation
After searching for testTag usages in Compose code and id: selectors in Maestro flows, I found that **all testTag IDs are already correctly aligned**:
- ✅ nav_exercise_library, nav_history, nav_progress, nav_recovery, nav_profile
- ✅ workout_fab, search_bar, exercise_card
- ✅ weight_input, reps_input
- ✅ onboarding_name_input, onboarding_start

The only issue was the YAML syntax error on line 50-51 in check-history.yaml.

## Changes
- Fixed assertVisible with optional parameter to use proper YAML object syntax

## Testing
- ✅ Android build: \./gradlew.bat assembleDebug\ succeeded
- ✅ YAML syntax now matches the pattern used throughout other Maestro flows

Working as Trinity (UI Dev)