### PR TITLE
feat: Enhance onboarding with goal-setting and experience level

### DIFF
--- a/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
+++ b/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
@@ -29,10 +29,21 @@ class UserPreferences @Inject constructor(
         val NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
         val ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
         val USER_NAME = stringPreferencesKey("user_name")
+        val TRAINING_GOAL = stringPreferencesKey("training_goal")
+        val EXPERIENCE_LEVEL = stringPreferencesKey("experience_level")
+        val TRAINING_DAYS_PER_WEEK = intPreferencesKey("training_days_per_week")
     }
 
     enum class WeightUnit {
         KG, LBS
+    }
+
+    enum class TrainingGoal {
+        STRENGTH, POWERLIFTING, HYPERTROPHY, GENERAL_FITNESS
+    }
+
+    enum class ExperienceLevel {
+        BEGINNER, INTERMEDIATE, ADVANCED
     }
 
     val weightUnit: Flow<WeightUnit> = dataStore.data.map { preferences ->
@@ -56,6 +67,29 @@ class UserPreferences @Inject constructor(
 
     val hasCompletedOnboarding: Flow<Boolean> = dataStore.data.map { preferences ->
         preferences[ONBOARDING_COMPLETE] ?: false
+    }
+
+    val trainingGoal: Flow<TrainingGoal> = dataStore.data.map { preferences ->
+        when (preferences[TRAINING_GOAL]) {
+            "STRENGTH" -> TrainingGoal.STRENGTH
+            "POWERLIFTING" -> TrainingGoal.POWERLIFTING
+            "HYPERTROPHY" -> TrainingGoal.HYPERTROPHY
+            "GENERAL_FITNESS" -> TrainingGoal.GENERAL_FITNESS
+            else -> TrainingGoal.HYPERTROPHY
+        }
+    }
+
+    val experienceLevel: Flow<ExperienceLevel> = dataStore.data.map { preferences ->
+        when (preferences[EXPERIENCE_LEVEL]) {
+            "BEGINNER" -> ExperienceLevel.BEGINNER
+            "INTERMEDIATE" -> ExperienceLevel.INTERMEDIATE
+            "ADVANCED" -> ExperienceLevel.ADVANCED
+            else -> ExperienceLevel.INTERMEDIATE
+        }
+    }
+
+    val trainingDaysPerWeek: Flow<Int> = dataStore.data.map { preferences ->
+        preferences[TRAINING_DAYS_PER_WEEK] ?: 4
     }
 
     suspend fun setWeightUnit(unit: WeightUnit) {
@@ -91,6 +125,24 @@ class UserPreferences @Inject constructor(
     suspend fun setUserName(name: String) {
         dataStore.edit { preferences ->
             preferences[USER_NAME] = name
+        }
+    }
+
+    suspend fun setTrainingGoal(goal: TrainingGoal) {
+        dataStore.edit { preferences ->
+            preferences[TRAINING_GOAL] = goal.name
+        }
+    }
+
+    suspend fun setExperienceLevel(level: ExperienceLevel) {
+        dataStore.edit { preferences ->
+            preferences[EXPERIENCE_LEVEL] = level.name
+        }
+    }
+
+    suspend fun setTrainingDaysPerWeek(days: Int) {
+        dataStore.edit { preferences ->
+            preferences[TRAINING_DAYS_PER_WEEK] = days
         }
     }
 

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -186,6 +186,27 @@
     <string name="onboarding_your_name">Tu Nombre (Opcional)</string>
     <string name="onboarding_name_placeholder">Ingresa tu nombre</string>
     <string name="onboarding_lets_go">¡Vamos!</string>
+    <string name="onboarding_training_goal_title">¿Cuál es tu Objetivo?</string>
+    <string name="onboarding_training_goal_subtitle">Elige tu enfoque principal de entrenamiento</string>
+    <string name="onboarding_goal_strength">Fuerza</string>
+    <string name="onboarding_goal_strength_desc">Desarrolla fuerza máxima</string>
+    <string name="onboarding_goal_powerlifting">Powerlifting</string>
+    <string name="onboarding_goal_powerlifting_desc">Enfócate en los tres grandes levantamientos</string>
+    <string name="onboarding_goal_hypertrophy">Hipertrofia</string>
+    <string name="onboarding_goal_hypertrophy_desc">Construye músculo y tamaño</string>
+    <string name="onboarding_goal_general_fitness">Fitness General</string>
+    <string name="onboarding_goal_general_fitness_desc">Mantente saludable y activo</string>
+    <string name="onboarding_experience_title">Nivel de Experiencia</string>
+    <string name="onboarding_experience_subtitle">¿Cuánto tiempo llevas entrenando?</string>
+    <string name="onboarding_experience_beginner">Principiante</string>
+    <string name="onboarding_experience_beginner_desc">Menos de 1 año</string>
+    <string name="onboarding_experience_intermediate">Intermedio</string>
+    <string name="onboarding_experience_intermediate_desc">1-3 años</string>
+    <string name="onboarding_experience_advanced">Avanzado</string>
+    <string name="onboarding_experience_advanced_desc">Más de 3 años</string>
+    <string name="onboarding_frequency_title">Frecuencia de Entrenamiento</string>
+    <string name="onboarding_frequency_subtitle">¿Cuántos días por semana entrenas?</string>
+    <string name="onboarding_frequency_days">%d días/semana</string>
 
     <!-- Common -->
     <string name="common_loading">Cargando...</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -189,6 +189,27 @@
     <string name="onboarding_your_name">Your Name (Optional)</string>
     <string name="onboarding_name_placeholder">Enter your name</string>
     <string name="onboarding_lets_go">Let\'s Go</string>
+    <string name="onboarding_training_goal_title">What\'s Your Goal?</string>
+    <string name="onboarding_training_goal_subtitle">Choose your primary training focus</string>
+    <string name="onboarding_goal_strength">Strength</string>
+    <string name="onboarding_goal_strength_desc">Build maximum strength</string>
+    <string name="onboarding_goal_powerlifting">Powerlifting</string>
+    <string name="onboarding_goal_powerlifting_desc">Focus on the big three lifts</string>
+    <string name="onboarding_goal_hypertrophy">Hypertrophy</string>
+    <string name="onboarding_goal_hypertrophy_desc">Build muscle and size</string>
+    <string name="onboarding_goal_general_fitness">General Fitness</string>
+    <string name="onboarding_goal_general_fitness_desc">Stay healthy and active</string>
+    <string name="onboarding_experience_title">Experience Level</string>
+    <string name="onboarding_experience_subtitle">How long have you been training?</string>
+    <string name="onboarding_experience_beginner">Beginner</string>
+    <string name="onboarding_experience_beginner_desc">Less than 1 year</string>
+    <string name="onboarding_experience_intermediate">Intermediate</string>
+    <string name="onboarding_experience_intermediate_desc">1-3 years</string>
+    <string name="onboarding_experience_advanced">Advanced</string>
+    <string name="onboarding_experience_advanced_desc">3+ years</string>
+    <string name="onboarding_frequency_title">Training Frequency</string>
+    <string name="onboarding_frequency_subtitle">How many days per week do you train?</string>
+    <string name="onboarding_frequency_days">%d days/week</string>
 
     <!-- Common -->
     <string name="common_loading">Loading...</string>

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingContract.kt
@@ -1,19 +1,25 @@
 package com.gymbro.feature.onboarding
 
 import com.gymbro.core.preferences.UserPreferences.WeightUnit
+import com.gymbro.core.preferences.UserPreferences.TrainingGoal
+import com.gymbro.core.preferences.UserPreferences.ExperienceLevel
 
 data class OnboardingState(
     val currentPage: Int = 0,
     val selectedUnit: WeightUnit = WeightUnit.KG,
     val userName: String = "",
-    val selectedGoal: String = "both",
+    val selectedGoal: TrainingGoal = TrainingGoal.HYPERTROPHY,
+    val selectedExperience: ExperienceLevel = ExperienceLevel.INTERMEDIATE,
+    val trainingDaysPerWeek: Int = 4,
 )
 
 sealed interface OnboardingEvent {
     data class PageChanged(val page: Int) : OnboardingEvent
     data class UnitSelected(val unit: WeightUnit) : OnboardingEvent
     data class NameChanged(val name: String) : OnboardingEvent
-    data class GoalSelected(val goal: String) : OnboardingEvent
+    data class GoalSelected(val goal: TrainingGoal) : OnboardingEvent
+    data class ExperienceSelected(val experience: ExperienceLevel) : OnboardingEvent
+    data class TrainingDaysSelected(val days: Int) : OnboardingEvent
     data object CompleteOnboarding : OnboardingEvent
 }
 

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.sp
 import com.gymbro.core.R
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gymbro.core.preferences.UserPreferences
 import com.gymbro.core.preferences.UserPreferences.WeightUnit
 import com.gymbro.core.ui.theme.AccentGreenStart
 import com.gymbro.core.ui.theme.AccentGreenEnd
@@ -91,7 +92,7 @@ fun OnboardingScreen(
     onEvent: (OnboardingEvent) -> Unit,
 ) {
     val haptic = LocalHapticFeedback.current
-    val pagerState = rememberPagerState(pageCount = { 4 })
+    val pagerState = rememberPagerState(pageCount = { 7 })
 
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage }.collect { page ->
@@ -115,9 +116,21 @@ fun OnboardingScreen(
             ) { page ->
                 when (page) {
                     0 -> WelcomePage()
-                    1 -> TrackPage()
-                    2 -> ProgressPage()
-                    3 -> GetStartedPage(
+                    1 -> TrainingGoalPage(
+                        selectedGoal = state.selectedGoal,
+                        onGoalSelected = { onEvent(OnboardingEvent.GoalSelected(it)) },
+                    )
+                    2 -> ExperienceLevelPage(
+                        selectedExperience = state.selectedExperience,
+                        onExperienceSelected = { onEvent(OnboardingEvent.ExperienceSelected(it)) },
+                    )
+                    3 -> TrainingFrequencyPage(
+                        trainingDays = state.trainingDaysPerWeek,
+                        onDaysSelected = { onEvent(OnboardingEvent.TrainingDaysSelected(it)) },
+                    )
+                    4 -> TrackPage()
+                    5 -> ProgressPage()
+                    6 -> GetStartedPage(
                         selectedUnit = state.selectedUnit,
                         userName = state.userName,
                         onUnitSelected = { onEvent(OnboardingEvent.UnitSelected(it)) },
@@ -128,7 +141,7 @@ fun OnboardingScreen(
             }
 
             PageIndicators(
-                pageCount = 4,
+                pageCount = 7,
                 currentPage = pagerState.currentPage,
                 modifier = Modifier.padding(bottom = 32.dp),
             )
@@ -368,6 +381,282 @@ private fun UnitCard(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
                 color = if (isSelected) Color.Black else Color.White,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrainingGoalPage(
+    selectedGoal: UserPreferences.TrainingGoal,
+    onGoalSelected: (UserPreferences.TrainingGoal) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_training_goal_title),
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.onboarding_training_goal_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = OnSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(48.dp))
+
+        GoalCard(
+            title = stringResource(R.string.onboarding_goal_strength),
+            description = stringResource(R.string.onboarding_goal_strength_desc),
+            isSelected = selectedGoal == UserPreferences.TrainingGoal.STRENGTH,
+            onClick = { onGoalSelected(UserPreferences.TrainingGoal.STRENGTH) },
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        GoalCard(
+            title = stringResource(R.string.onboarding_goal_powerlifting),
+            description = stringResource(R.string.onboarding_goal_powerlifting_desc),
+            isSelected = selectedGoal == UserPreferences.TrainingGoal.POWERLIFTING,
+            onClick = { onGoalSelected(UserPreferences.TrainingGoal.POWERLIFTING) },
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        GoalCard(
+            title = stringResource(R.string.onboarding_goal_hypertrophy),
+            description = stringResource(R.string.onboarding_goal_hypertrophy_desc),
+            isSelected = selectedGoal == UserPreferences.TrainingGoal.HYPERTROPHY,
+            onClick = { onGoalSelected(UserPreferences.TrainingGoal.HYPERTROPHY) },
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        GoalCard(
+            title = stringResource(R.string.onboarding_goal_general_fitness),
+            description = stringResource(R.string.onboarding_goal_general_fitness_desc),
+            isSelected = selectedGoal == UserPreferences.TrainingGoal.GENERAL_FITNESS,
+            onClick = { onGoalSelected(UserPreferences.TrainingGoal.GENERAL_FITNESS) },
+        )
+    }
+}
+
+@Composable
+private fun ExperienceLevelPage(
+    selectedExperience: UserPreferences.ExperienceLevel,
+    onExperienceSelected: (UserPreferences.ExperienceLevel) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_experience_title),
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.onboarding_experience_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = OnSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(48.dp))
+
+        GoalCard(
+            title = stringResource(R.string.onboarding_experience_beginner),
+            description = stringResource(R.string.onboarding_experience_beginner_desc),
+            isSelected = selectedExperience == UserPreferences.ExperienceLevel.BEGINNER,
+            onClick = { onExperienceSelected(UserPreferences.ExperienceLevel.BEGINNER) },
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        GoalCard(
+            title = stringResource(R.string.onboarding_experience_intermediate),
+            description = stringResource(R.string.onboarding_experience_intermediate_desc),
+            isSelected = selectedExperience == UserPreferences.ExperienceLevel.INTERMEDIATE,
+            onClick = { onExperienceSelected(UserPreferences.ExperienceLevel.INTERMEDIATE) },
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        GoalCard(
+            title = stringResource(R.string.onboarding_experience_advanced),
+            description = stringResource(R.string.onboarding_experience_advanced_desc),
+            isSelected = selectedExperience == UserPreferences.ExperienceLevel.ADVANCED,
+            onClick = { onExperienceSelected(UserPreferences.ExperienceLevel.ADVANCED) },
+        )
+    }
+}
+
+@Composable
+private fun TrainingFrequencyPage(
+    trainingDays: Int,
+    onDaysSelected: (Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_frequency_title),
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.onboarding_frequency_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = OnSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(48.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            FrequencyCard(
+                days = 2,
+                isSelected = trainingDays == 2,
+                onClick = { onDaysSelected(2) },
+                modifier = Modifier.weight(1f),
+            )
+            FrequencyCard(
+                days = 3,
+                isSelected = trainingDays == 3,
+                onClick = { onDaysSelected(3) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            FrequencyCard(
+                days = 4,
+                isSelected = trainingDays == 4,
+                onClick = { onDaysSelected(4) },
+                modifier = Modifier.weight(1f),
+            )
+            FrequencyCard(
+                days = 5,
+                isSelected = trainingDays == 5,
+                onClick = { onDaysSelected(5) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            FrequencyCard(
+                days = 6,
+                isSelected = trainingDays == 6,
+                onClick = { onDaysSelected(6) },
+                modifier = Modifier.weight(1f),
+            )
+            Box(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun GoalCard(
+    title: String,
+    description: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val haptic = LocalHapticFeedback.current
+    GlassmorphicCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(
+                if (isSelected) {
+                    Brush.linearGradient(
+                        colors = listOf(AccentGreenStart, AccentGreenEnd)
+                    )
+                } else {
+                    Brush.linearGradient(
+                        colors = listOf(GlassOverlay, GlassOverlay)
+                    )
+                }
+            )
+            .clip(RoundedCornerShape(16.dp))
+            .clickable {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                onClick()
+            }
+            .padding(20.dp),
+    ) {
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = if (isSelected) Color.Black else Color.White,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (isSelected) Color.Black.copy(alpha = 0.8f) else OnSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FrequencyCard(
+    days: Int,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val haptic = LocalHapticFeedback.current
+    GlassmorphicCard(
+        modifier = modifier
+            .height(100.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(
+                if (isSelected) {
+                    Brush.linearGradient(
+                        colors = listOf(AccentGreenStart, AccentGreenEnd)
+                    )
+                } else {
+                    Brush.linearGradient(
+                        colors = listOf(GlassOverlay, GlassOverlay)
+                    )
+                }
+            )
+            .clip(RoundedCornerShape(16.dp))
+            .clickable {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                onClick()
+            },
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.onboarding_frequency_days, days),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                color = if (isSelected) Color.Black else Color.White,
+                textAlign = TextAlign.Center,
             )
         }
     }

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingViewModel.kt
@@ -36,6 +36,12 @@ class OnboardingViewModel @Inject constructor(
             is OnboardingEvent.GoalSelected -> {
                 _state.value = _state.value.copy(selectedGoal = event.goal)
             }
+            is OnboardingEvent.ExperienceSelected -> {
+                _state.value = _state.value.copy(selectedExperience = event.experience)
+            }
+            is OnboardingEvent.TrainingDaysSelected -> {
+                _state.value = _state.value.copy(trainingDaysPerWeek = event.days)
+            }
             is OnboardingEvent.CompleteOnboarding -> {
                 completeOnboarding()
             }
@@ -47,6 +53,9 @@ class OnboardingViewModel @Inject constructor(
             userPreferences.setWeightUnit(_state.value.selectedUnit)
             val userName = _state.value.userName.takeIf { it.isNotBlank() } ?: ""
             userPreferences.setUserName(userName)
+            userPreferences.setTrainingGoal(_state.value.selectedGoal)
+            userPreferences.setExperienceLevel(_state.value.selectedExperience)
+            userPreferences.setTrainingDaysPerWeek(_state.value.trainingDaysPerWeek)
             userPreferences.setOnboardingComplete(true)
             _effects.send(OnboardingEffect.NavigateToMain)
         }


### PR DESCRIPTION
## Description

Implements enhanced onboarding flow with personalized goal-setting, experience level selection, and training frequency configuration as requested in #329.

## Changes

### New Onboarding Screens (3 screens)
1. **Training Goal Selection** - 4 options:
   - Strength (build maximum strength)
   - Powerlifting (focus on big three lifts)
   - Hypertrophy (build muscle and size)
   - General Fitness (stay healthy and active)

2. **Experience Level** - 3 options:
   - Beginner (< 1 year)
   - Intermediate (1-3 years)
   - Advanced (3+ years)

3. **Training Frequency** - 2-6 days/week selection

### Data Model
Extended \UserPreferences\ with:
- \TrainingGoal\ enum (STRENGTH, POWERLIFTING, HYPERTROPHY, GENERAL_FITNESS)
- \ExperienceLevel\ enum (BEGINNER, INTERMEDIATE, ADVANCED)
- \	rainingDaysPerWeek\ Int (2-6)

All preferences are persisted to DataStore for future AI recommendations.

### Localization
✅ All new UI strings include **Spanish translations** for es-ES locale

## Implementation Notes
- Used Material3 cards for selection UI (simple, functional, no over-animation)
- Onboarding flow: Welcome → Goal → Experience → Frequency → Features → Get Started (7 pages total)
- Haptic feedback on all selections
- State management via ViewModel with proper event handling

## Testing
✅ Kotlin compilation successful
✅ All modules compile without errors

Closes #329