### PR TITLE
Fix dead buttons in Settings screen (#353 #356)

### DIFF
--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -17,6 +17,7 @@
     <!-- Common Actions -->
     <string name="action_back">Atrás</string>
     <string name="action_cancel">Cancelar</string>
+    <string name="action_ok">Aceptar</string>
     <string name="action_save">Guardar</string>
     <string name="action_delete">Eliminar</string>
     <string name="action_retry">Reintentar</string>
@@ -170,6 +171,10 @@
     <string name="settings_app_version">Versión de la App</string>
     <string name="settings_send_feedback">Enviar Comentarios</string>
     <string name="settings_send_feedback_subtitle">Reporta problemas o sugiere características</string>
+    <string name="settings_sign_in_dialog_title">Inicio de Sesión Próximamente</string>
+    <string name="settings_sign_in_dialog_message">La funcionalidad de inicio de sesión llegará en una actualización futura. Tus datos de entrenamiento se guardan localmente en tu dispositivo.</string>
+    <string name="settings_version_dialog_title">Versión de la App</string>
+    <string name="settings_version_dialog_message">GymBro v%1$s</string>
 
     <!-- Onboarding -->
     <string name="onboarding_app_title">GymBro</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <!-- Common Actions -->
     <string name="action_back">Back</string>
     <string name="action_cancel">Cancel</string>
+    <string name="action_ok">OK</string>
     <string name="action_save">Save</string>
     <string name="action_delete">Delete</string>
     <string name="action_retry">Retry</string>
@@ -173,6 +174,10 @@
     <string name="settings_app_version">App Version</string>
     <string name="settings_send_feedback">Send Feedback</string>
     <string name="settings_send_feedback_subtitle">Report issues or suggest features</string>
+    <string name="settings_sign_in_dialog_title">Sign In Coming Soon</string>
+    <string name="settings_sign_in_dialog_message">Sign in functionality is coming in a future update. Your workout data is currently saved locally on your device.</string>
+    <string name="settings_version_dialog_title">App Version</string>
+    <string name="settings_version_dialog_message">GymBro v%1$s</string>
 
     <!-- Onboarding -->
     <string name="onboarding_app_title">GymBro</string>

--- a/android/feature/src/main/java/com/gymbro/feature/settings/SettingsScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/settings/SettingsScreen.kt
@@ -105,6 +105,8 @@ internal fun SettingsScreen(
     onNavigateBack: () -> Unit,
 ) {
     var showClearDataDialog by remember { mutableStateOf(false) }
+    var showSignInDialog by remember { mutableStateOf(false) }
+    var showVersionDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -150,7 +152,7 @@ internal fun SettingsScreen(
                         title = stringResource(R.string.settings_sign_in_status),
                         subtitle = stringResource(R.string.settings_sign_in_subtitle),
                         iconTint = AccentGreen,
-                        onClick = { },
+                        onClick = { showSignInDialog = true },
                     )
                     SettingsDivider()
                     SettingsRow(
@@ -311,7 +313,7 @@ internal fun SettingsScreen(
                         title = stringResource(R.string.settings_app_version),
                         subtitle = state.appVersion,
                         iconTint = AccentGreen,
-                        onClick = { },
+                        onClick = { showVersionDialog = true },
                     )
                     SettingsDivider()
                     SettingsRow(
@@ -362,6 +364,58 @@ internal fun SettingsScreen(
             dismissButton = {
                 OutlinedButton(onClick = { showClearDataDialog = false }) {
                     Text(stringResource(R.string.action_cancel), color = Color.White)
+                }
+            },
+        )
+    }
+
+    // Sign In Dialog
+    if (showSignInDialog) {
+        AlertDialog(
+            onDismissRequest = { showSignInDialog = false },
+            containerColor = CardBackground,
+            title = {
+                Text(
+                    text = stringResource(R.string.settings_sign_in_dialog_title),
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(R.string.settings_sign_in_dialog_message),
+                    color = Color(0xFF9E9E9E),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showSignInDialog = false }) {
+                    Text(stringResource(R.string.action_ok), color = AccentGreen)
+                }
+            },
+        )
+    }
+
+    // App Version Dialog
+    if (showVersionDialog) {
+        AlertDialog(
+            onDismissRequest = { showVersionDialog = false },
+            containerColor = CardBackground,
+            title = {
+                Text(
+                    text = stringResource(R.string.settings_version_dialog_title),
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(R.string.settings_version_dialog_message, state.appVersion),
+                    color = Color(0xFF9E9E9E),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showVersionDialog = false }) {
+                    Text(stringResource(R.string.action_ok), color = AccentGreen)
                 }
             },
         )


### PR DESCRIPTION
Fixes #353 and #356

## Changes
- **Sign In button**: Now shows a dialog explaining that sign-in is coming soon and data is saved locally
- **App Version button**: Now shows a dialog displaying the current app version

## Implementation Details
- Added dialog state variables for both buttons in SettingsScreen
- Implemented AlertDialog components following existing patterns
- Added Spanish translations for all new strings
- Used existing appVersion from state (retrieved via package manager)

## Testing
Both buttons now show appropriate dialogs when tapped instead of doing nothing.

Working as Tank (Backend Dev)