### PR TITLE
feat: implement plan day detail view

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -347,6 +347,22 @@ fun GymBroNavGraph(
                 onNavigateToActiveWorkout = { template ->
                     navController.navigate("active_workout")
                 },
+                onNavigateToPlanDayDetail = { dayNumber ->
+                    navController.navigate("programs/day/$dayNumber")
+                },
+            )
+        }
+        composable(
+            route = "programs/day/{dayNumber}",
+            arguments = listOf(
+                navArgument("dayNumber") { type = NavType.IntType },
+            ),
+        ) { backStackEntry ->
+            val dayNumber = backStackEntry.arguments?.getInt("dayNumber") ?: 1
+            com.gymbro.feature.programs.PlanDayDetailRoute(
+                dayNumber = dayNumber,
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToActiveWorkout = { navController.navigate("active_workout") },
             )
         }
         composable("coach") {

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -218,4 +218,8 @@
     <string name="programs_day_number">Día %d</string>
     <string name="programs_exercises_in_day">%d ejercicios</string>
     <string name="programs_more_exercises">+%d más</string>
+    <string name="programs_day_detail_title" formatted="false">Día %d: %s</string>
+    <string name="programs_start_this_workout">Iniciar Este Entrenamiento</string>
+    <string name="programs_exercise_sets_reps" formatted="false">%d × %s</string>
+    <string name="programs_rest_time">Descanso: %ds</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -218,4 +218,8 @@
     <string name="programs_day_number">Day %d</string>
     <string name="programs_exercises_in_day">%d exercises</string>
     <string name="programs_more_exercises">+%d more</string>
+    <string name="programs_day_detail_title" formatted="false">Day %d: %s</string>
+    <string name="programs_start_this_workout">Start This Workout</string>
+    <string name="programs_exercise_sets_reps" formatted="false">%d × %s</string>
+    <string name="programs_rest_time">Rest: %ds</string>
 </resources>

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -256,6 +256,21 @@
     <string name="programs_exercises_count">%d ejercicios</string>
     <string name="programs_built_in">Incorporado</string>
     <string name="programs_last_used">Último uso: %s</string>
+    <string name="programs_active_plan_title">Plan Activo</string>
+    <string name="programs_templates_title">Plantillas Guardadas</string>
+    <string name="programs_generate_new_plan">Generar Nuevo Plan de Entrenamiento</string>
+    <string name="programs_generating_plan">Generando plan...</string>
+    <string name="programs_generate_description">Obtén un programa de entrenamiento personalizado basado en tus objetivos</string>
+    <string name="programs_weeks_count">%d semanas</string>
+    <string name="programs_days_per_week">%d días/semana</string>
+    <string name="programs_workout_days">Días de Entrenamiento</string>
+    <string name="programs_day_number">Día %d</string>
+    <string name="programs_exercises_in_day">%d ejercicios</string>
+    <string name="programs_more_exercises">+%d más</string>
+    <string name="programs_day_detail_title" formatted="false">Día %d: %s</string>
+    <string name="programs_start_this_workout">Iniciar Este Entrenamiento</string>
+    <string name="programs_exercise_sets_reps" formatted="false">%d × %s</string>
+    <string name="programs_rest_time">Descanso: %ds</string>
 
     <!-- Coach / AI Chat -->
     <string name="coach_title">GymBro Entrenador IA</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -259,6 +259,21 @@
     <string name="programs_exercises_count">%d exercises</string>
     <string name="programs_built_in">Built-in</string>
     <string name="programs_last_used">Last used: %s</string>
+    <string name="programs_active_plan_title">Active Plan</string>
+    <string name="programs_templates_title">Saved Templates</string>
+    <string name="programs_generate_new_plan">Generate New Workout Plan</string>
+    <string name="programs_generating_plan">Generating plan...</string>
+    <string name="programs_generate_description">Get a personalized training program based on your goals</string>
+    <string name="programs_weeks_count">%d weeks</string>
+    <string name="programs_days_per_week">%d days/week</string>
+    <string name="programs_workout_days">Workout Days</string>
+    <string name="programs_day_number">Day %d</string>
+    <string name="programs_exercises_in_day">%d exercises</string>
+    <string name="programs_more_exercises">+%d more</string>
+    <string name="programs_day_detail_title" formatted="false">Day %d: %s</string>
+    <string name="programs_start_this_workout">Start This Workout</string>
+    <string name="programs_exercise_sets_reps" formatted="false">%d × %s</string>
+    <string name="programs_rest_time">Rest: %ds</string>
 
     <!-- Coach / AI Chat -->
     <string name="coach_title">GymBro AI Coach</string>

--- a/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsContract.kt
@@ -26,4 +26,5 @@ sealed interface ProgramsEvent {
 sealed interface ProgramsEffect {
     data class NavigateToCreateTemplate(val templateId: String?) : ProgramsEffect
     data class NavigateToActiveWorkout(val template: WorkoutTemplate) : ProgramsEffect
+    data class NavigateToPlanDayDetail(val dayNumber: Int) : ProgramsEffect
 }

--- a/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.PlayArrow
@@ -68,6 +69,7 @@ fun ProgramsRoute(
     viewModel: ProgramsViewModel = hiltViewModel(),
     onNavigateToCreateTemplate: (String?) -> Unit = {},
     onNavigateToActiveWorkout: (WorkoutTemplate) -> Unit = {},
+    onNavigateToPlanDayDetail: (Int) -> Unit = {},
 ) {
     val state = viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -85,6 +87,9 @@ fun ProgramsRoute(
                 }
                 is ProgramsEffect.NavigateToActiveWorkout -> {
                     onNavigateToActiveWorkout(effect.template)
+                }
+                is ProgramsEffect.NavigateToPlanDayDetail -> {
+                    onNavigateToPlanDayDetail(effect.dayNumber)
                 }
             }
         }
@@ -535,6 +540,183 @@ private fun WorkoutDayItem(
                 )
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlanDayDetailRoute(
+    dayNumber: Int,
+    viewModel: ProgramsViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit,
+    onNavigateToActiveWorkout: () -> Unit,
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle()
+    
+    val workoutDay = state.value.activePlan?.workoutDays?.find { it.dayNumber == dayNumber }
+    
+    if (workoutDay == null) {
+        LaunchedEffect(Unit) {
+            onNavigateBack()
+        }
+        return
+    }
+    
+    PlanDayDetailScreen(
+        day = workoutDay,
+        onNavigateBack = onNavigateBack,
+        onStartWorkout = onNavigateToActiveWorkout,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PlanDayDetailScreen(
+    day: com.gymbro.core.model.WorkoutDay,
+    onNavigateBack: () -> Unit,
+    onStartWorkout: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.programs_day_detail_title, day.dayNumber, day.name),
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Bold,
+                        ),
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = androidx.compose.material.icons.Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.common_navigate_back),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp),
+            contentPadding = PaddingValues(vertical = 16.dp),
+        ) {
+            items(day.exercises) { exercise ->
+                ExerciseCard(exercise = exercise)
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+            
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                
+                Card(
+                    onClick = onStartWorkout,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = AccentGreen,
+                    ),
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = null,
+                            tint = Color.Black,
+                            modifier = Modifier.size(24.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(R.string.programs_start_this_workout),
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                            ),
+                            color = Color.Black,
+                        )
+                    }
+                }
+                
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExerciseCard(exercise: com.gymbro.core.model.PlannedExercise) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Text(
+                text = exercise.exerciseName,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            
+            Spacer(modifier = Modifier.height(12.dp))
+            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                ExerciseDetailItem(
+                    label = stringResource(R.string.workout_sets),
+                    value = stringResource(R.string.programs_exercise_sets_reps, exercise.sets, exercise.repsRange),
+                )
+                
+                ExerciseDetailItem(
+                    label = stringResource(R.string.workout_rest_timer),
+                    value = stringResource(R.string.programs_rest_time, exercise.restSeconds),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExerciseDetailItem(
+    label: String,
+    value: String,
+) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontWeight = FontWeight.Medium,
+            ),
+            color = AccentGreen,
+        )
     }
 }
 

--- a/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsViewModel.kt
@@ -65,7 +65,9 @@ class ProgramsViewModel @Inject constructor(
                 generateWorkoutPlan()
             }
             is ProgramsEvent.ViewPlanDay -> {
-                // Future: navigate to day detail
+                viewModelScope.launch {
+                    _effect.send(ProgramsEffect.NavigateToPlanDayDetail(event.dayNumber))
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Implements the plan day detail screen for viewing exercises in a specific workout day from a generated plan.

## Changes
- ✅ Added PlanDayDetailScreen composable with Material3 Cards for each exercise
- ✅ Shows exercise name, sets × reps range, and rest time
- ✅ Added 'Start This Workout' button (navigates to active_workout route)
- ✅ Wired up navigation from Programs screen to day detail
- ✅ Added Spanish translations for all new strings
- ✅ Updated ProgramsViewModel to emit NavigateToPlanDayDetail effect
- ✅ Added programs/day/{dayNumber} route to navigation graph

## Testing
- ✅ Build succeeds: ./gradlew app:assembleDebug
- ✅ Verified string resources in both English and Spanish
- ✅ Checked navigation flow from Programs → Day Detail → Active Workout

Closes #355