### PR TITLE
feat: Add manual recovery entry fallback for users without Health Connect

### DIFF
--- a/.changeset/manual-recovery-entry.md
+++ b/.changeset/manual-recovery-entry.md
@@ -1,0 +1,5 @@
+---
+'gymbro': minor
+---
+
+Add manual recovery entry fallback for users without Health Connect. Users can now track recovery manually with 3 sliders (Sleep Quality, Muscle Soreness, Energy Level) when Health Connect is unavailable, replacing the dead-end message with a functional alternative.

--- a/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
+++ b/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
@@ -32,6 +32,9 @@ class UserPreferences @Inject constructor(
         val TRAINING_GOAL = stringPreferencesKey("training_goal")
         val EXPERIENCE_LEVEL = stringPreferencesKey("experience_level")
         val TRAINING_DAYS_PER_WEEK = intPreferencesKey("training_days_per_week")
+        val MANUAL_SLEEP_QUALITY = intPreferencesKey("manual_sleep_quality")
+        val MANUAL_MUSCLE_SORENESS = intPreferencesKey("manual_muscle_soreness")
+        val MANUAL_ENERGY_LEVEL = intPreferencesKey("manual_energy_level")
     }
 
     enum class WeightUnit {
@@ -159,6 +162,26 @@ class UserPreferences @Inject constructor(
     suspend fun markTooltipShown(id: String) {
         dataStore.edit { preferences ->
             preferences[booleanPreferencesKey("tooltip_shown_$id")] = true
+        }
+    }
+
+    val manualSleepQuality: Flow<Int> = dataStore.data.map { preferences ->
+        preferences[MANUAL_SLEEP_QUALITY] ?: 5
+    }
+
+    val manualMuscleSoreness: Flow<Int> = dataStore.data.map { preferences ->
+        preferences[MANUAL_MUSCLE_SORENESS] ?: 5
+    }
+
+    val manualEnergyLevel: Flow<Int> = dataStore.data.map { preferences ->
+        preferences[MANUAL_ENERGY_LEVEL] ?: 5
+    }
+
+    suspend fun setManualRecoveryMetrics(sleepQuality: Int, muscleSoreness: Int, energyLevel: Int) {
+        dataStore.edit { preferences ->
+            preferences[MANUAL_SLEEP_QUALITY] = sleepQuality
+            preferences[MANUAL_MUSCLE_SORENESS] = muscleSoreness
+            preferences[MANUAL_ENERGY_LEVEL] = energyLevel
         }
     }
 }

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -103,6 +103,17 @@
     <string name="recovery_permissions_title">Conecta tus Datos de Salud</string>
     <string name="recovery_permissions_message">GymBro usa datos de sueño, frecuencia cardíaca y pasos para calcular tu preparación de recuperación y optimizar el entrenamiento.</string>
     <string name="recovery_grant_permissions">Conceder Permisos</string>
+    <string name="recovery_tip_green">¡Excelente recuperación! Estás listo para entrenamiento de alta intensidad. Concéntrate en levantamientos compuestos y desafíate.</string>
+    <string name="recovery_tip_amber">Recuperación moderada. Considera entrenamiento de intensidad media o enfócate en técnica y trabajo de volumen.</string>
+    <string name="recovery_tip_red">Baja recuperación detectada. Prioriza el descanso, trabajo de movilidad ligero o recuperación activa. Escucha a tu cuerpo.</string>
+
+    <!-- Manual Recovery Entry -->
+    <string name="recovery_manual_mode_info">Health Connect no disponible. Rastrea tu recuperación manualmente.</string>
+    <string name="recovery_score_label">Puntuación de Recuperación</string>
+    <string name="recovery_manual_sleep_quality">Calidad del Sueño</string>
+    <string name="recovery_manual_muscle_soreness">Dolor Muscular</string>
+    <string name="recovery_manual_energy_level">Nivel de Energía</string>
+    <string name="recovery_manual_save">Guardar Datos de Recuperación</string>
 
     <!-- Recovery Status Labels -->
     <string name="recovery_status_optimal">Óptimo</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -107,6 +107,14 @@
     <string name="recovery_tip_amber">Moderate recovery. Consider medium-intensity training or focus on technique and volume work.</string>
     <string name="recovery_tip_red">Low recovery detected. Prioritize rest, light mobility work, or active recovery. Listen to your body.</string>
 
+    <!-- Manual Recovery Entry -->
+    <string name="recovery_manual_mode_info">Health Connect not available. Track your recovery manually.</string>
+    <string name="recovery_score_label">Recovery Score</string>
+    <string name="recovery_manual_sleep_quality">Sleep Quality</string>
+    <string name="recovery_manual_muscle_soreness">Muscle Soreness</string>
+    <string name="recovery_manual_energy_level">Energy Level</string>
+    <string name="recovery_manual_save">Save Recovery Data</string>
+
     <!-- Recovery Status Labels -->
     <string name="recovery_status_optimal">Optimal</string>
     <string name="recovery_status_good">Good</string>

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryContract.kt
@@ -10,11 +10,26 @@ data class RecoveryState(
     val permissionsGranted: Boolean = false,
     val isLoading: Boolean = true,
     val error: String? = null,
+    val manualEntry: ManualRecoveryEntry = ManualRecoveryEntry(),
+    val isManualMode: Boolean = false,
 )
+
+data class ManualRecoveryEntry(
+    val sleepQuality: Float = 5f, // 1-10
+    val muscleSoreness: Float = 5f, // 1-10
+    val energyLevel: Float = 5f, // 1-10
+) {
+    val recoveryScore: Int
+        get() = ((sleepQuality + (11f - muscleSoreness) + energyLevel) / 3f * 10f).toInt().coerceIn(0, 100)
+}
 
 sealed interface RecoveryEvent {
     data object RequestPermissions : RecoveryEvent
     data object RefreshData : RecoveryEvent
+    data class UpdateSleepQuality(val value: Float) : RecoveryEvent
+    data class UpdateMuscleSoreness(val value: Float) : RecoveryEvent
+    data class UpdateEnergyLevel(val value: Float) : RecoveryEvent
+    data object SaveManualEntry : RecoveryEvent
 }
 
 sealed interface RecoveryEffect {

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.material.icons.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.BatteryChargingFull
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -31,6 +33,8 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -136,7 +140,13 @@ internal fun RecoveryScreen(
 
         when {
             !state.healthConnectAvailable -> {
-                HealthConnectUnavailableCard()
+                ManualRecoveryEntryCard(
+                    manualEntry = state.manualEntry,
+                    onSleepQualityChange = { onEvent(RecoveryEvent.UpdateSleepQuality(it)) },
+                    onMuscleSorenessChange = { onEvent(RecoveryEvent.UpdateMuscleSoreness(it)) },
+                    onEnergyLevelChange = { onEvent(RecoveryEvent.UpdateEnergyLevel(it)) },
+                    onSave = { onEvent(RecoveryEvent.SaveManualEntry) },
+                )
             }
             !state.permissionsGranted -> {
                 PermissionRequestCard(onRequestPermissions = {
@@ -462,41 +472,248 @@ private fun SleepChartCard(sleepHistory: List<SleepData>) {
 }
 
 @Composable
-private fun HealthConnectUnavailableCard() {
-    Card(
-        colors = CardDefaults.cardColors(containerColor = CardBackground),
-        shape = RoundedCornerShape(20.dp),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+private fun ManualRecoveryEntryCard(
+    manualEntry: ManualRecoveryEntry,
+    onSleepQualityChange: (Float) -> Unit,
+    onMuscleSorenessChange: (Float) -> Unit,
+    onEnergyLevelChange: (Float) -> Unit,
+    onSave: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        // Info banner
+        Card(
+            colors = CardDefaults.cardColors(containerColor = CardBackground),
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            Icon(
-                Icons.Default.MonitorHeart,
-                contentDescription = null,
-                tint = Color(0xFF9E9E9E),
-                modifier = Modifier.size(48.dp),
-            )
+            Row(
+                modifier = Modifier.padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Default.MonitorHeart,
+                    contentDescription = null,
+                    tint = Color(0xFF9E9E9E),
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.recovery_manual_mode_info),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFF9E9E9E),
+                )
+            }
+        }
 
-            Spacer(modifier = Modifier.height(16.dp))
+        // Recovery Score Display
+        val scoreColor = when {
+            manualEntry.recoveryScore >= 70 -> AccentGreenStart
+            manualEntry.recoveryScore >= 40 -> AccentAmberStart
+            else -> AccentRed
+        }
 
+        GlassmorphicCard(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.recovery_score_label),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = OnSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = "${manualEntry.recoveryScore}",
+                    fontSize = 56.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = scoreColor,
+                )
+
+                Text(
+                    text = when {
+                        manualEntry.recoveryScore >= 70 -> stringResource(R.string.recovery_status_good)
+                        manualEntry.recoveryScore >= 40 -> stringResource(R.string.recovery_status_fair)
+                        else -> stringResource(R.string.recovery_status_poor)
+                    },
+                    style = MaterialTheme.typography.titleLarge,
+                    color = scoreColor,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+
+        // Sleep Quality Slider
+        GlassmorphicCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(Color(0xFF7C4DFF).copy(alpha = 0.15f), CircleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Default.Bedtime,
+                            contentDescription = null,
+                            tint = Color(0xFF7C4DFF),
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.recovery_manual_sleep_quality),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = "${manualEntry.sleepQuality.toInt()}/10",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = OnSurfaceVariant,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Slider(
+                    value = manualEntry.sleepQuality,
+                    onValueChange = onSleepQualityChange,
+                    valueRange = 1f..10f,
+                    steps = 8,
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color(0xFF7C4DFF),
+                        activeTrackColor = Color(0xFF7C4DFF),
+                        inactiveTrackColor = Color(0xFF7C4DFF).copy(alpha = 0.3f),
+                    ),
+                )
+            }
+        }
+
+        // Muscle Soreness Slider
+        GlassmorphicCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(Color(0xFFFF5252).copy(alpha = 0.15f), CircleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Default.FitnessCenter,
+                            contentDescription = null,
+                            tint = Color(0xFFFF5252),
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.recovery_manual_muscle_soreness),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = "${manualEntry.muscleSoreness.toInt()}/10",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = OnSurfaceVariant,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Slider(
+                    value = manualEntry.muscleSoreness,
+                    onValueChange = onMuscleSorenessChange,
+                    valueRange = 1f..10f,
+                    steps = 8,
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color(0xFFFF5252),
+                        activeTrackColor = Color(0xFFFF5252),
+                        inactiveTrackColor = Color(0xFFFF5252).copy(alpha = 0.3f),
+                    ),
+                )
+            }
+        }
+
+        // Energy Level Slider
+        GlassmorphicCard(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(AccentGreen.copy(alpha = 0.15f), CircleShape),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Default.BatteryChargingFull,
+                            contentDescription = null,
+                            tint = AccentGreen,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.recovery_manual_energy_level),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = "${manualEntry.energyLevel.toInt()}/10",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = OnSurfaceVariant,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Slider(
+                    value = manualEntry.energyLevel,
+                    onValueChange = onEnergyLevelChange,
+                    valueRange = 1f..10f,
+                    steps = 8,
+                    colors = SliderDefaults.colors(
+                        thumbColor = AccentGreen,
+                        activeTrackColor = AccentGreen,
+                        inactiveTrackColor = AccentGreen.copy(alpha = 0.3f),
+                    ),
+                )
+            }
+        }
+
+        // Save Button
+        Button(
+            onClick = onSave,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = AccentGreen,
+                contentColor = Color.Black,
+            ),
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
             Text(
-                text = stringResource(R.string.recovery_health_connect_unavailable),
-                style = MaterialTheme.typography.titleMedium,
-                color = Color.White,
+                text = stringResource(R.string.recovery_manual_save),
                 fontWeight = FontWeight.SemiBold,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = stringResource(R.string.recovery_health_connect_unavailable_message),
-                style = MaterialTheme.typography.bodyMedium,
-                color = Color(0xFF9E9E9E),
-                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(vertical = 4.dp),
             )
         }
     }

--- a/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/recovery/RecoveryViewModel.kt
@@ -3,6 +3,7 @@ package com.gymbro.feature.recovery
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gymbro.core.health.HealthConnectRepository
+import com.gymbro.core.preferences.UserPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class RecoveryViewModel @Inject constructor(
     private val healthConnectRepository: HealthConnectRepository,
+    private val userPreferences: UserPreferences,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(RecoveryState())
@@ -26,6 +28,7 @@ class RecoveryViewModel @Inject constructor(
 
     init {
         checkAvailabilityAndLoad()
+        loadManualEntryData()
     }
 
     fun onEvent(event: RecoveryEvent) {
@@ -36,6 +39,24 @@ class RecoveryViewModel @Inject constructor(
                 }
             }
             is RecoveryEvent.RefreshData -> loadData()
+            is RecoveryEvent.UpdateSleepQuality -> {
+                _state.update { 
+                    it.copy(manualEntry = it.manualEntry.copy(sleepQuality = event.value))
+                }
+            }
+            is RecoveryEvent.UpdateMuscleSoreness -> {
+                _state.update { 
+                    it.copy(manualEntry = it.manualEntry.copy(muscleSoreness = event.value))
+                }
+            }
+            is RecoveryEvent.UpdateEnergyLevel -> {
+                _state.update { 
+                    it.copy(manualEntry = it.manualEntry.copy(energyLevel = event.value))
+                }
+            }
+            is RecoveryEvent.SaveManualEntry -> {
+                saveManualEntry()
+            }
         }
     }
 
@@ -55,6 +76,7 @@ class RecoveryViewModel @Inject constructor(
                 it.copy(
                     healthConnectAvailable = available,
                     permissionsGranted = hasPermissions,
+                    isManualMode = !available,
                 )
             }
 
@@ -89,6 +111,37 @@ class RecoveryViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun loadManualEntryData() {
+        viewModelScope.launch {
+            userPreferences.manualSleepQuality.collect { sleepQuality ->
+                userPreferences.manualMuscleSoreness.collect { soreness ->
+                    userPreferences.manualEnergyLevel.collect { energy ->
+                        _state.update { 
+                            it.copy(
+                                manualEntry = ManualRecoveryEntry(
+                                    sleepQuality = sleepQuality.toFloat(),
+                                    muscleSoreness = soreness.toFloat(),
+                                    energyLevel = energy.toFloat(),
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun saveManualEntry() {
+        viewModelScope.launch {
+            val entry = _state.value.manualEntry
+            userPreferences.setManualRecoveryMetrics(
+                sleepQuality = entry.sleepQuality.toInt(),
+                muscleSoreness = entry.muscleSoreness.toInt(),
+                energyLevel = entry.energyLevel.toInt(),
+            )
         }
     }
 }


### PR DESCRIPTION
Closes #357

Summary: Implements manual recovery tracking for users without Health Connect (~70% of users). Shows a simple manual entry form with 3 sliders instead of the dead-end message.

Implementation:
- Sleep Quality slider (1-10) with purple color coding
- Muscle Soreness slider (1-10) with red color coding
- Energy Level slider (1-10) with green color coding
- Recovery Score calculated as simple average (soreness inverted)
- Score color-coded: green (>=70), yellow (40-69), red (<40)

Data Storage:
- Persisted in DataStore via UserPreferences
- Values loaded on screen init
- Saved when user taps Save button

Localization:
- Added Spanish translations for all new strings

Testing:
- Build succeeds
- Manual testing required on device without Health Connect

Working as Tank (Backend Dev)