### PR TITLE
feat: Make plateau alerts more prominent in Progress screen

### DIFF
--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -342,6 +342,10 @@
     <string name="progress_detailed_insights">Ver información detallada de entrenamiento</string>
     <string name="progress_current_est_1rm">Est. 1RM Actual (%1$s kg × %2$d)</string>
     <string name="progress_this_week">Esta Semana</string>
+    <string name="progress_plateau_detected_stagnation">Estancamiento detectado en %1$s</string>
+    <string name="progress_plateau_detected_regression">Regresión detectada en %1$s</string>
+    <string name="progress_plateau_duration">Sin progreso en %1$d semanas.</string>
+    <string name="progress_plateau_consider">Considera:</string>
 
     <!-- History (additional) -->
     <string name="history_workout_details">Detalles del Entrenamiento</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -342,6 +342,10 @@
     <string name="progress_detailed_insights">View detailed training insights</string>
     <string name="progress_current_est_1rm">Current Est. 1RM (%1$s kg × %2$d)</string>
     <string name="progress_this_week">This Week</string>
+    <string name="progress_plateau_detected_stagnation">Plateau detected on %1$s</string>
+    <string name="progress_plateau_detected_regression">Regression detected on %1$s</string>
+    <string name="progress_plateau_duration">No progress in %1$d weeks.</string>
+    <string name="progress_plateau_consider">Consider:</string>
 
     <!-- History -->
     <string name="history_workout_details">Workout Details</string>

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
@@ -870,50 +871,75 @@ private fun PlateauAlertCard(
     alert: PlateauAlert,
     onDismiss: () -> Unit,
 ) {
+    val haptic = LocalHapticFeedback.current
     val alertColor = when (alert.type) {
         PlateauType.STAGNATION -> Color(AccentAmberStart.value)
         PlateauType.REGRESSION -> AccentRed
     }
 
-    GlassmorphicCard(
-        accentColor = alertColor,
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = alertColor.copy(alpha = 0.15f)
+        ),
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth()
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
             verticalAlignment = Alignment.Top,
         ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = alertColor,
+                modifier = Modifier.size(28.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = if (alert.type == PlateauType.STAGNATION) "⚠️" else "🔴",
-                        fontSize = 20.sp,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = alert.exerciseName,
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontWeight = FontWeight.Bold,
-                    )
-                }
+                Text(
+                    text = when (alert.type) {
+                        PlateauType.STAGNATION -> stringResource(
+                            R.string.progress_plateau_detected_stagnation,
+                            alert.exerciseName
+                        )
+                        PlateauType.REGRESSION -> stringResource(
+                            R.string.progress_plateau_detected_regression,
+                            alert.exerciseName
+                        )
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = stringResource(R.string.progress_weeks_no_progress, alert.weeksDuration),
-                    style = MaterialTheme.typography.bodySmall,
+                    text = stringResource(
+                        R.string.progress_plateau_duration,
+                        alert.weeksDuration
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = alert.suggestion,
+                    text = stringResource(R.string.progress_plateau_consider) + " " + alert.suggestion,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
             }
-            IconButton(onClick = onDismiss) {
+            IconButton(
+                onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onDismiss()
+                }
+            ) {
                 Icon(
-                    Icons.Default.Close,
+                    imageVector = Icons.Default.Close,
                     contentDescription = stringResource(R.string.action_dismiss),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
                 )
             }
         }


### PR DESCRIPTION
## Changes

This PR makes plateau alerts significantly more prominent in the Progress screen by:

- **Visual Hierarchy**: Replaced GlassmorphicCard with a standard Card using a colored semi-transparent background (amber for stagnation, red for regression)
- **Warning Icon**: Added a prominent 28dp Warning icon for immediate visual recognition
- **Better Text Structure**: 
  - Exercise name now appears in the title line
  - Clear duration message
  - Consider prefix for suggestions to improve readability
- **Enhanced UX**: Added haptic feedback when dismissing alerts
- **i18n**: Added Spanish translations for all new alert strings

### Before/After
**Before**: Alert was using GlassmorphicCard with emoji icons and less structured text  
**After**: Alert uses a colored Card with Material Warning icon and clearer message hierarchy

## Testing
- Build passes (Android assembleDebug)
- PlateauDetectionService already wired up in ProgressViewModel
- Alerts are already being detected and shown in the correct section

Closes #354

---
Working as Tank (Backend Dev)
