### PR TITLE
feat: Add data model support for editing AI workout plans

### DIFF
--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -589,3 +589,103 @@ Implemented intelligent split selection based on training frequency and goals:
 - Add readiness-aware split downscaling (6d PPL → 4d U/L when fatigued)
 - Track split adherence in ComplianceService (did user actually follow the split structure?)
 
+---
+
+## Learnings
+
+### PR #375 Review Response (2025-07-19)
+
+**Context:**
+- Tank's PR #375 (feat: Add data model for editing AI workout plans) received CHANGES REQUESTED from Morpheus
+- Per reviewer-protocol, Tank is locked out from revising rejected PRs
+- Assigned to address two issues: missing @Transient field and scope creep removal
+
+**Issue 1: Missing @Transient val originalPlan Field**
+- The decisions doc (lines 2167-2178) explicitly requires WorkoutPlan to store in-memory reference to original plan
+- Tank's PR added isModified and originalPlanId but omitted the @Transient val originalPlan field
+- Why this matters: Without it, ViewModels must maintain separate state for original plan → tight coupling
+- Fix: Added @Transient val originalPlan: WorkoutPlan? = null to WorkoutPlan data class (line 19)
+
+**Issue 2: targetWeightKg Scope Creep**
+- Tank added targetWeightKg: Double? to PlannedExercise (not in issue #365 scope)
+- Issue #365 scope: swap exercises, modify sets/reps/rest, add/remove — no weight targets
+- targetWeightKg exists in WorkoutTemplate and database entities (separate feature domain)
+- Fix: Removed targetWeightKg from PlannedExercise (line 44 deleted)
+
+**Key Learning: @Transient in Kotlin Data Classes**
+- @Transient annotation marks fields as non-persistent (not serialized to database)
+- Essential for in-memory-only references like originalPlan
+- Prevents circular serialization issues while enabling rich object graphs
+- Pattern: Use @Transient for derived/cached data, parent references, UI-specific state
+
+**Key Learning: Scope Discipline in Data Model PRs**
+- Data models are foundational — scope creep here cascades to ViewModels, repositories, migrations
+- Before adding a field, check: (1) Is it in the issue scope? (2) Is it documented in decisions?
+- If field exists elsewhere (targetWeightKg in WorkoutTemplate), investigate why separation exists
+- Progressive overload tracking ≠ plan definition → different features, different models
+
+**Reviewer Protocol Applied:**
+- Tank locked out after rejection (cannot revise own rejected PR)
+- Neo (me) assigned as fresh eyes to address feedback
+- This prevents "defensive fixing" where original author minimally addresses feedback
+- Clean slate: I read the decisions doc, understood the intent, made precise fixes
+
+**Technical Execution:**
+- Fetched PR branch: git fetch origin squad/365-edit-ai-plans && git checkout
+- Made two targeted edits to WorkoutPlan.kt (add @Transient line, remove targetWeightKg line)
+- Verified no other targetWeightKg references in PlannedExercise context (grep confirmed it's only in WorkoutTemplate)
+- Staged ONLY the modified file: git add android/core/.../WorkoutPlan.kt (NEVER git add .)
+- Verified diff: git diff --cached (confirmed 1 insertion, 1 deletion)
+- Committed with descriptive message referencing PR #375 and issues addressed
+- Pushed: git push origin squad/365-edit-ai-plans
+
+**Commit Message Pattern:**
+`
+fix: Address PR #375 review — add originalPlan transient, remove targetWeightKg scope creep
+
+- Add @Transient val originalPlan field to WorkoutPlan for ViewModel decoupling
+- Remove targetWeightKg from PlannedExercise (out of scope for #365)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+`
+
+**Outcome:**
+- PR branch updated with both fixes
+- Ready for Morpheus re-review
+- Demonstrates reviewer protocol in action (lockout → reassignment → focused fix)
+
+**File Modified:**
+- android/core/src/main/java/com/gymbro/core/model/WorkoutPlan.kt
+
+**SHA:** aee2474
+
+### 2026-04-10: Issue #381 Complete — PR #385 Opened (Draft)
+
+**Task:** Implement adaptive split selection based on training frequency (Issue #381)  
+**Outcome:** PR #385 (draft) — Intelligent split selection implemented  
+
+**Split Selection Rules:**
+| Days/Week | Split Type | Why |
+|-----------|------------|-----|
+| 2 | Full Body | Only way to hit all muscle groups 2x/week |
+| 3 | Full Body (default) or Powerlifting 3-Day (PLers) | Optimal frequency for compound learning; PLers get Squat/Bench/Deadlift focus |
+| 4 | Upper/Lower | Classic balanced, 2x frequency per muscle |
+| 5 | PPLUL (PPL + Upper/Lower) | Advanced hybrid for high volume tolerance |
+| 6+ | PPL (2x per week) | Optimal hypertrophy frequency |
+
+**Implementation:**
+1. TrainingSplit enum with selectOptimalSplit(daysPerWeek, goal) method
+2. Refactored WorkoutPlanGenerator to use split-specific day generation
+3. Added split field to WorkoutPlan model
+4. Updated AI coach system prompt with split knowledge
+5. Full test coverage (all frequency/goal combinations)
+
+**Impact:**
+- User plans now match evidence-based recommendations for their frequency
+- Differentiation: No competitor adapts split to frequency automatically
+- Foundation for future recovery-aware split downscaling (6d → 4d when fatigued)
+
+**Evidence Base:** Mike Israetel (Renaissance Periodization), Starting Strength (full body), PPL community (6-day hypertrophy)
+
+**Status:** PR #385 draft ready for review. Unrelated: Morpheus review of Tank's PR #375 does not affect Neo's work.  
+**Reference:** .squad/decisions.md (new entry: "Adaptive Split Selection")

--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -992,3 +992,28 @@ ProGuard rules follow official library documentation and Android best practices.
 - Conflict resolution if user generates a new AI plan while an edited plan is active — replace or keep both?
 - UI for adding exercises: inline picker vs. modal exercise library?
 
+
+### 2026-04-10: Issue #380 Complete — PR #384 Opened (Draft)
+
+**Task:** Add conditioning exercises to exercise library (Issue #380)  
+**Outcome:** PR #384 (draft) — 9 conditioning exercises added  
+**Decision:** Reused existing ExerciseCategory.CARDIO rather than creating new "conditioning" category.
+
+**Exercises Added:**
+Sled push, battle ropes, assault bike, jump rope, rowing machine, medicine ball slams, burpees, kettlebell swings, rope climbs
+
+**Rationale:**
+- CARDIO enum already exists
+- Conditioning IS cardio (elevates HR, builds cardiovascular capacity, work capacity)
+- Avoids category proliferation (no "metcon", "HIIT", "conditioning" fragmentation)
+- Seed data pattern consistent (lowercase: "compound", "isolation", "accessory", "cardio")
+
+**Files Affected:**
+- shared/data/exercises-seed.json — 9 cardio exercises added
+- android/core/src/main/assets/exercises-seed.json — 9 cardio exercises added
+- No enum changes (CARDIO already exists)
+
+**Future Extensibility:** If filtering needed (gym-only vs outdoor), add secondary attributes (environment: gym/outdoor/pool, intensity: steady_state/intervals/hiit) rather than new categories.
+
+**Status:** PR #384 draft ready for review. Unrelated: Morpheus has lockout on PR #375 (Tank's earlier work)—does not affect this PR.  
+**Reference:** .squad/decisions.md (new entry: "Reuse CARDIO Category")

--- a/.squad/agents/tank/history.md
+++ b/.squad/agents/tank/history.md
@@ -958,3 +958,37 @@ ProGuard rules follow official library documentation and Android best practices.
 **Branch:** squad/380-conditioning-exercises
 **PR:** #384 (draft, targeting master, label: feat)
 **Status:** Ready for review
+### 2026-01-10: Editable AI-Generated Workout Plans — Data Model Foundation (Issue #365, PR #375)
+
+**Problem:** AI-generated plans from WorkoutPlanGenerator were immutable — users couldn't modify exercises, sets, reps, or rest days after generation.
+
+**Solution — Plan Versioning + Edit Tracking:**
+- **WorkoutPlan Model Extensions:**
+  - Added `isModified: Boolean` flag to track if plan has been edited by user
+  - Added `originalPlanId: String?` to store reference to original AI-generated plan
+  - Added `createOriginalCopy()` helper — creates immutable snapshot before first edit
+  - Added `markAsModified()` helper — marks plan as modified and sets originalPlanId if not already set
+- **PlannedExercise Model Extensions:**
+  - Added unique `id: String` field (UUID) for tracking individual exercises in edit operations
+  - Added optional `targetWeightKg: Double?` for progressive overload tracking
+  
+**Architecture Decisions:**
+- **Immutable Original Copy Strategy:** When user enters edit mode for the first time, `createOriginalCopy()` creates a separate WorkoutPlan instance with a new ID. This copy is stored in `ProgramsState.originalPlan` and never modified. The user edits the active plan; they can revert by restoring `originalPlan`.
+- **Lazy originalPlanId Assignment:** `originalPlanId` is only set when `markAsModified()` is called (on save). Fresh AI plans have `originalPlanId = null` until edited.
+- **Exercise IDs Required for Mutations:** SwapExercises, RemoveExercise, and UpdateExercise* events all operate on exercise IDs, not indices. This prevents race conditions when exercises are reordered.
+
+**Files Changed (PR #375):**
+- Modified: `android/core/src/main/java/com/gymbro/core/model/WorkoutPlan.kt` (+16 lines)
+  - Data class extensions with `isModified`, `originalPlanId`
+  - Helper methods for copy/modify workflows
+
+**Status:** Data model foundation complete. ViewModel and UI implementation deferred to follow-up work. This unblocks:
+- Edit operations in ProgramsViewModel (swap, add, remove, update exercises)
+- Save/revert UI in ProgramsScreen
+- Plan modification persistence (future: save edited plans to WorkoutTemplateRepository)
+
+**Open Questions:**
+- Should edited plans be auto-saved to WorkoutTemplateRepository as custom templates?
+- Conflict resolution if user generates a new AI plan while an edited plan is active — replace or keep both?
+- UI for adding exercises: inline picker vs. modal exercise library?
+

--- a/.squad/log/2026-04-10T10-16-39-ralph-round1.md
+++ b/.squad/log/2026-04-10T10-16-39-ralph-round1.md
@@ -1,0 +1,28 @@
+# Scribe Session Log | Ralph Round 1 | 2026-04-10T10:16:39Z
+
+## Directive Executed
+**User:** "los issues que requieran del emulador no los hagamos" (skip emulator-dependent issues)  
+**Status:** Recorded in decision inbox and merged to decisions.md
+
+## Agents Spawned
+1. **Morpheus** — Review PR #375 (AI workout plan editing) → Changes Requested (locked)
+2. **Tank** — Issue #380 (conditioning exercises) → PR #384 (draft)
+3. **Neo** — Issue #381 (adaptive split selection) → PR #385 (draft)
+
+## Scribe Tasks
+1. ✅ Orchestration logs written (3 entries)
+2. ✅ Session log written (this file)
+3. ✅ Decisions merged (inbox → decisions.md, deduplicated, inbox cleared)
+4. ✅ Agent histories updated (Morpheus lockout, Tank PR #384 noted, Neo PR #385 noted)
+5. ✅ Git commit staged and pushed
+
+## Key Outcomes
+- **PR #375 (Morpheus Review):** Missing `@Transient originalPlan` field + scope creep (`targetWeightKg`). Tank locked; Trinity/Neo to fix.
+- **PR #384 (Tank):** 9 conditioning exercises added to CARDIO category. Draft ready.
+- **PR #385 (Neo):** Adaptive split selection (2-6+ days/week) with tests. Draft ready.
+- **Directive:** Emulator-dependent work deferred. Noted in decisions.
+
+## Next Ralph Round
+- Monitor PRs #384, #385 for review feedback
+- Await Neo/Trinity action on PR #375 fixes
+- Continue non-emulator issues

--- a/.squad/orchestration-log/2026-04-10T10-16-39-morpheus.md
+++ b/.squad/orchestration-log/2026-04-10T10-16-39-morpheus.md
@@ -1,0 +1,25 @@
+# Agent: Morpheus | Task: Review PR #375 | 2026-04-10T10:16:39Z
+
+## Outcome
+**Status:** Changes Requested (Lockout)
+
+## Summary
+Morpheus reviewed PR #375 (feat: Add data model support for editing AI workout plans) and requested critical architectural changes:
+
+1. **Missing @Transient Field:** WorkoutPlan model must include `@Transient val originalPlan: WorkoutPlan? = null` per decision doc (lines 2140-2210). Tank's PR omits this field.
+2. **Scope Creep:** PR adds `targetWeightKg: Double?` to PlannedExercise—not in issue #365 or architectural decision. Must be removed.
+
+## Architectural Rationale
+- `@Transient` field keeps model self-contained for edit/revert workflow while preventing serialization (no database bloat)
+- Without it, ViewModel must maintain separate `originalPlan` reference, creating tight coupling and maintenance debt
+- Progressive overload tracking (`targetWeightKg`) is out-of-scope and requires separate architectural review
+
+## Next Steps
+- **Tank is locked** per reviewer-protocol (cannot self-revise after rejection)
+- **Trinity or Neo** must implement fixes and resubmit
+- **Morpheus** available for re-review once corrected
+
+## Reference
+- Decision doc: `.squad/decisions.md` lines 2140-2210
+- PR: https://github.com/jperezdelreal/GymBro/pull/375
+- Detailed review: `.squad/decisions/inbox/morpheus-pr375-review.md`

--- a/.squad/orchestration-log/2026-04-10T10-16-39-neo.md
+++ b/.squad/orchestration-log/2026-04-10T10-16-39-neo.md
@@ -1,0 +1,42 @@
+# Agent: Neo | Task: #381 Adaptive split selection | 2026-04-10T10:16:39Z
+
+## Outcome
+**Status:** PR #385 opened (draft)
+
+## Summary
+Neo implemented issue #381 (adaptive split selection) by adding intelligent split selection based on training frequency and goals:
+
+### Split Selection Rules
+| Days/Week | Split Type | Rationale |
+|-----------|------------|-----------|
+| 2 | Full Body | Only way to hit all muscle groups 2x/week |
+| 3 | Full Body (default) or Powerlifting 3-Day (PLers) | Optimal frequency for compound learning |
+| 4 | Upper/Lower | Classic balanced split, 2x frequency per muscle |
+| 5 | PPLUL (PPL + Upper/Lower) | Advanced hybrid for high volume tolerance |
+| 6+ | PPL (2x per week) | Optimal hypertrophy frequency |
+
+## Implementation
+1. Created `TrainingSplit` enum with `selectOptimalSplit(daysPerWeek, goal)` method
+2. Refactored WorkoutPlanGenerator to use split-specific day generation functions
+3. Added `split` field to WorkoutPlan model
+4. Updated AI coach system prompt with split knowledge
+5. Added test coverage for all frequency/goal combinations
+
+## Impact
+- **User experience:** Plans now match evidence-based recommendations for their frequency
+- **Differentiation:** No competitor adapts split to frequency automatically
+- **Foundation:** Enables recovery-aware split downscaling (future: 6d → 4d when fatigued)
+
+## PR Status
+- **#385 (draft):** Ready for review
+- **Note:** PR #375 review findings do NOT block Neo's work (different feature area)
+
+## Evidence Base
+- Mike Israetel (Renaissance Periodization) — optimal frequency per muscle group
+- Starting Strength methodology — full body for beginners
+- PPL community consensus — 6-day optimal for bodybuilding
+
+## Reference
+- Issue: #381
+- PR: #385 (draft)
+- Decision details: `.squad/decisions/inbox/neo-adaptive-split.md`

--- a/.squad/orchestration-log/2026-04-10T10-16-39-tank.md
+++ b/.squad/orchestration-log/2026-04-10T10-16-39-tank.md
@@ -1,0 +1,29 @@
+# Agent: Tank | Task: #380 Add conditioning exercises | 2026-04-10T10:16:39Z
+
+## Outcome
+**Status:** PR #384 opened (draft)
+
+## Summary
+Tank implemented issue #380 (conditioning exercises) by adding 9 gym-based conditioning exercises to the exercise library using the existing `ExerciseCategory.CARDIO` enum:
+
+- **Exercises added:** Sled push, battle ropes, assault bike, jump rope, rowing machine, medicine ball slams, burpees, kettlebell swings, rope climbs (cardio category)
+- **Decision:** Reused existing CARDIO category rather than creating new "conditioning" category to avoid enum proliferation
+- **Rationale:** Conditioning IS cardio from training perspective (elevated HR, cardiovascular capacity, work capacity)
+- **Seed data:** Added to both `shared/data/exercises-seed.json` and `android/core/src/main/assets/exercises-seed.json`
+
+## Files Affected
+- `android/core/src/main/java/com/gymbro/core/model/Exercise.kt` — no change (enum already has CARDIO)
+- `shared/data/exercises-seed.json` — 9 exercises with `"category": "cardio"`
+- `android/core/src/main/assets/exercises-seed.json` — 9 exercises with `"category": "cardio"`
+
+## PR Status
+- **#384 (draft):** Ready for review
+- **Note:** Morpheus has lockout on unrelated PR #375; does not block Tank's PR
+
+## Follow-Up
+If future requirements demand filtering (gym-only vs outdoor), add secondary attributes (environment: gym/outdoor/pool, intensity: steady_state/intervals/hiit) rather than new categories.
+
+## Reference
+- Issue: #380
+- PR: #384 (draft)
+- Decision details: `.squad/decisions/inbox/tank-conditioning-category.md`

--- a/android/core/src/main/java/com/gymbro/core/model/WorkoutPlan.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/WorkoutPlan.kt
@@ -15,7 +15,20 @@ data class WorkoutPlan(
     val workoutDays: List<WorkoutDay>,
     val split: TrainingSplit? = null,
     val createdAt: Instant = Instant.now(),
-)
+    val isModified: Boolean = false,
+    val originalPlanId: String? = null,
+) {
+    fun createOriginalCopy(): WorkoutPlan = copy(
+        id = UUID.randomUUID().toString(),
+        isModified = false,
+        originalPlanId = null,
+    )
+
+    fun markAsModified(): WorkoutPlan = copy(
+        isModified = true,
+        originalPlanId = originalPlanId ?: id,
+    )
+}
 
 data class WorkoutDay(
     val dayNumber: Int,
@@ -24,8 +37,10 @@ data class WorkoutDay(
 )
 
 data class PlannedExercise(
+    val id: String = UUID.randomUUID().toString(),
     val exerciseName: String,
     val sets: Int,
     val repsRange: String,
     val restSeconds: Int = 90,
+    val targetWeightKg: Double? = null,
 )

--- a/android/core/src/main/java/com/gymbro/core/model/WorkoutPlan.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/WorkoutPlan.kt
@@ -17,6 +17,7 @@ data class WorkoutPlan(
     val createdAt: Instant = Instant.now(),
     val isModified: Boolean = false,
     val originalPlanId: String? = null,
+    @Transient val originalPlan: WorkoutPlan? = null,
 ) {
     fun createOriginalCopy(): WorkoutPlan = copy(
         id = UUID.randomUUID().toString(),
@@ -42,5 +43,4 @@ data class PlannedExercise(
     val sets: Int,
     val repsRange: String,
     val restSeconds: Int = 90,
-    val targetWeightKg: Double? = null,
 )


### PR DESCRIPTION
**Closes #365**

## Summary
Adds data layer foundation for editing AI-generated workout plans.

## Changes
- ✅ Added isModified: Boolean to WorkoutPlan model
- ✅ Added originalPlanId: String? for plan versioning
- ✅ Added helper methods createOriginalCopy() and markAsModified()
- ✅ Added unique id field to PlannedExercise for tracking
- ✅ Added optional 	argetWeightKg field for weight targets

## Implementation Notes
This commit establishes the data model infrastructure needed for plan editing. The model now supports:
- Tracking whether a plan has been modified from its AI-generated original
- Storing a reference to the original plan for revert functionality
- Unique IDs for exercises to enable swap/remove operations  
- Weight targets for progressive overload tracking

ViewModel and UI implementation to follow in subsequent work.

## Squad Context
Working as **Tank** (Backend Developer) — data layer changes only, no UI.