### PR TITLE
fix: Persist active workout state across app lifecycle

### DIFF
--- a/android/core/schemas/com.gymbro.core.database.GymBroDatabase/5.json
+++ b/android/core/schemas/com.gymbro.core.database.GymBroDatabase/5.json
@@ -1,0 +1,444 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "a4d629719dad4519337420371d6364c6",
+    "entities": [
+      {
+        "tableName": "exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `muscleGroup` TEXT NOT NULL, `category` TEXT NOT NULL, `equipment` TEXT NOT NULL, `description` TEXT NOT NULL, `youtubeUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleGroup",
+            "columnName": "muscleGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipment",
+            "columnName": "equipment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtubeUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `completedAt` INTEGER, `durationSeconds` INTEGER NOT NULL, `notes` TEXT NOT NULL, `completed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "workout_sets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `workoutId` TEXT NOT NULL, `exerciseId` TEXT NOT NULL, `setNumber` INTEGER NOT NULL, `weight` REAL NOT NULL, `reps` INTEGER NOT NULL, `rpe` REAL, `isWarmup` INTEGER NOT NULL, `completedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`workoutId`) REFERENCES `workouts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`exerciseId`) REFERENCES `exercises`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setNumber",
+            "columnName": "setNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rpe",
+            "columnName": "rpe",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "isWarmup",
+            "columnName": "isWarmup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_sets_workoutId",
+            "unique": false,
+            "columnNames": [
+              "workoutId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_sets_workoutId` ON `${TABLE_NAME}` (`workoutId`)"
+          },
+          {
+            "name": "index_workout_sets_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_sets_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workouts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "workoutId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "exercises",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exerciseId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "workout_templates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER, `isBuiltIn` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isBuiltIn",
+            "columnName": "isBuiltIn",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "template_exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `templateId` TEXT NOT NULL, `exerciseId` TEXT NOT NULL, `exerciseName` TEXT NOT NULL, `muscleGroup` TEXT NOT NULL, `targetSets` INTEGER NOT NULL, `targetReps` INTEGER NOT NULL, `targetWeightKg` REAL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`templateId`) REFERENCES `workout_templates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`exerciseId`) REFERENCES `exercises`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "templateId",
+            "columnName": "templateId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseName",
+            "columnName": "exerciseName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleGroup",
+            "columnName": "muscleGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSets",
+            "columnName": "targetSets",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetReps",
+            "columnName": "targetReps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetWeightKg",
+            "columnName": "targetWeightKg",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_template_exercises_templateId",
+            "unique": false,
+            "columnNames": [
+              "templateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_template_exercises_templateId` ON `${TABLE_NAME}` (`templateId`)"
+          },
+          {
+            "name": "index_template_exercises_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_template_exercises_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workout_templates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "templateId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "exercises",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exerciseId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "in_progress_workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workoutId` TEXT NOT NULL, `exercisesJson` TEXT NOT NULL, `elapsedSeconds` INTEGER NOT NULL, `totalVolume` REAL NOT NULL, `totalSets` INTEGER NOT NULL, `restTimerSeconds` INTEGER NOT NULL, `restTimerTotal` INTEGER NOT NULL, `isRestTimerActive` INTEGER NOT NULL, `lastSavedAt` INTEGER NOT NULL, PRIMARY KEY(`workoutId`))",
+        "fields": [
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exercisesJson",
+            "columnName": "exercisesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedSeconds",
+            "columnName": "elapsedSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalVolume",
+            "columnName": "totalVolume",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSets",
+            "columnName": "totalSets",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerSeconds",
+            "columnName": "restTimerSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerTotal",
+            "columnName": "restTimerTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRestTimerActive",
+            "columnName": "isRestTimerActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSavedAt",
+            "columnName": "lastSavedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "workoutId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a4d629719dad4519337420371d6364c6')"
+    ]
+  }
+}

--- a/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
@@ -6,6 +6,7 @@ import com.gymbro.core.database.dao.ExerciseDao
 import com.gymbro.core.database.dao.WorkoutDao
 import com.gymbro.core.database.dao.WorkoutTemplateDao
 import com.gymbro.core.database.entity.ExerciseEntity
+import com.gymbro.core.database.entity.InProgressWorkoutEntity
 import com.gymbro.core.database.entity.TemplateExerciseEntity
 import com.gymbro.core.database.entity.WorkoutEntity
 import com.gymbro.core.database.entity.WorkoutSetEntity
@@ -18,8 +19,9 @@ import com.gymbro.core.database.entity.WorkoutTemplateEntity
         WorkoutSetEntity::class,
         WorkoutTemplateEntity::class,
         TemplateExerciseEntity::class,
+        InProgressWorkoutEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class GymBroDatabase : RoomDatabase() {

--- a/android/core/src/main/java/com/gymbro/core/database/Migrations.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/Migrations.kt
@@ -119,4 +119,24 @@ object Migrations {
             db.execSQL("CREATE INDEX IF NOT EXISTS index_template_exercises_exerciseId ON template_exercises (exerciseId)")
         }
     }
+    
+    val MIGRATION_4_5 = object : Migration(4, 5) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // Create in_progress_workouts table for persisting active workout state
+            db.execSQL("""
+                CREATE TABLE IF NOT EXISTS in_progress_workouts (
+                    workoutId TEXT NOT NULL,
+                    exercisesJson TEXT NOT NULL,
+                    elapsedSeconds INTEGER NOT NULL,
+                    totalVolume REAL NOT NULL,
+                    totalSets INTEGER NOT NULL,
+                    restTimerSeconds INTEGER NOT NULL,
+                    restTimerTotal INTEGER NOT NULL,
+                    isRestTimerActive INTEGER NOT NULL,
+                    lastSavedAt INTEGER NOT NULL,
+                    PRIMARY KEY(workoutId)
+                )
+            """.trimIndent())
+        }
+    }
 }

--- a/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
@@ -84,4 +84,19 @@ interface WorkoutDao {
 
     @Query("SELECT * FROM workout_sets WHERE workoutId = :workoutId")
     suspend fun getSetsForWorkout(workoutId: String): List<WorkoutSetEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun saveInProgressWorkout(inProgressWorkout: com.gymbro.core.database.entity.InProgressWorkoutEntity)
+
+    @Query("SELECT * FROM in_progress_workouts WHERE workoutId = :workoutId")
+    suspend fun getInProgressWorkout(workoutId: String): com.gymbro.core.database.entity.InProgressWorkoutEntity?
+
+    @Query("SELECT * FROM in_progress_workouts LIMIT 1")
+    suspend fun getAnyInProgressWorkout(): com.gymbro.core.database.entity.InProgressWorkoutEntity?
+
+    @Query("DELETE FROM in_progress_workouts WHERE workoutId = :workoutId")
+    suspend fun clearInProgressWorkout(workoutId: String)
+
+    @Query("DELETE FROM in_progress_workouts")
+    suspend fun clearAllInProgressWorkouts()
 }

--- a/android/core/src/main/java/com/gymbro/core/database/entity/InProgressWorkoutEntity.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/entity/InProgressWorkoutEntity.kt
@@ -1,0 +1,18 @@
+package com.gymbro.core.database.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "in_progress_workouts")
+data class InProgressWorkoutEntity(
+    @PrimaryKey
+    val workoutId: String,
+    val exercisesJson: String, // JSON serialization of WorkoutExerciseUi list
+    val elapsedSeconds: Long,
+    val totalVolume: Double,
+    val totalSets: Int,
+    val restTimerSeconds: Int,
+    val restTimerTotal: Int,
+    val isRestTimerActive: Boolean,
+    val lastSavedAt: Long = System.currentTimeMillis(),
+)

--- a/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.google.gson.Gson
 import com.gymbro.core.database.GymBroDatabase
 import com.gymbro.core.database.Migrations
 import com.gymbro.core.database.dao.ExerciseDao
@@ -38,7 +39,8 @@ object DatabaseModule {
             .addMigrations(
                 Migrations.MIGRATION_1_2,
                 Migrations.MIGRATION_2_3,
-                Migrations.MIGRATION_3_4
+                Migrations.MIGRATION_3_4,
+                Migrations.MIGRATION_4_5
             )
             .addCallback(SeedDatabaseCallback(context))
             .build()
@@ -57,6 +59,12 @@ object DatabaseModule {
     @Provides
     fun provideWorkoutTemplateDao(database: GymBroDatabase): WorkoutTemplateDao {
         return database.workoutTemplateDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideGson(): Gson {
+        return Gson()
     }
 }
 

--- a/android/core/src/main/java/com/gymbro/core/model/InProgressWorkout.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/InProgressWorkout.kt
@@ -1,0 +1,29 @@
+package com.gymbro.core.model
+
+import com.gymbro.core.model.Exercise
+
+data class InProgressWorkout(
+    val workoutId: String,
+    val exercises: List<InProgressExercise>,
+    val elapsedSeconds: Long,
+    val totalVolume: Double,
+    val totalSets: Int,
+    val restTimerSeconds: Int,
+    val restTimerTotal: Int,
+    val isRestTimerActive: Boolean,
+)
+
+data class InProgressExercise(
+    val exercise: Exercise,
+    val sets: List<InProgressSet>,
+)
+
+data class InProgressSet(
+    val id: String,
+    val setNumber: Int,
+    val weight: String,
+    val reps: String,
+    val rpe: String,
+    val isWarmup: Boolean,
+    val isCompleted: Boolean,
+)

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
@@ -14,4 +14,8 @@ interface WorkoutRepository {
     fun getRecentWorkouts(limit: Int = 20): Flow<List<Workout>>
     suspend fun getBestWeight(exerciseId: String, reps: Int): Double?
     suspend fun getDaysSinceLastWorkout(): Int?
+    
+    suspend fun saveInProgressWorkout(inProgressWorkout: com.gymbro.core.model.InProgressWorkout)
+    suspend fun getInProgressWorkout(): com.gymbro.core.model.InProgressWorkout?
+    suspend fun clearInProgressWorkout(workoutId: String)
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
@@ -1,14 +1,20 @@
 package com.gymbro.core.repository
 
 import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.gymbro.core.database.dao.WorkoutDao
 import com.gymbro.core.database.dao.WorkoutWithSets
+import com.gymbro.core.database.entity.InProgressWorkoutEntity
 import com.gymbro.core.database.entity.WorkoutEntity
 import com.gymbro.core.database.entity.WorkoutSetEntity
 import com.gymbro.core.error.AppResult
 import com.gymbro.core.error.retryWithBackoff
 import com.gymbro.core.error.runCatchingAsResult
 import com.gymbro.core.model.ExerciseSet
+import com.gymbro.core.model.InProgressExercise
+import com.gymbro.core.model.InProgressSet
+import com.gymbro.core.model.InProgressWorkout
 import com.gymbro.core.model.Workout
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -19,6 +25,7 @@ import javax.inject.Inject
 
 class WorkoutRepositoryImpl @Inject constructor(
     private val workoutDao: WorkoutDao,
+    private val gson: Gson,
 ) : WorkoutRepository {
 
     override suspend fun startWorkout(): Workout {
@@ -168,6 +175,132 @@ class WorkoutRepositoryImpl @Inject constructor(
             is AppResult.Error -> {
                 Log.e(TAG, "Failed to get days since last workout: ${result.error.message}")
                 null
+            }
+        }
+    }
+
+    override suspend fun saveInProgressWorkout(inProgressWorkout: InProgressWorkout) {
+        val result = retryWithBackoff {
+            runCatchingAsResult {
+                val exercisesJson = gson.toJson(inProgressWorkout.exercises.map { exercise ->
+                    mapOf(
+                        "exerciseId" to exercise.exercise.id.toString(),
+                        "exerciseName" to exercise.exercise.name,
+                        "muscleGroup" to exercise.exercise.muscleGroup.name,
+                        "sets" to exercise.sets.map { set ->
+                            mapOf(
+                                "id" to set.id,
+                                "setNumber" to set.setNumber,
+                                "weight" to set.weight,
+                                "reps" to set.reps,
+                                "rpe" to set.rpe,
+                                "isWarmup" to set.isWarmup,
+                                "isCompleted" to set.isCompleted,
+                            )
+                        }
+                    )
+                })
+                
+                val entity = InProgressWorkoutEntity(
+                    workoutId = inProgressWorkout.workoutId,
+                    exercisesJson = exercisesJson,
+                    elapsedSeconds = inProgressWorkout.elapsedSeconds,
+                    totalVolume = inProgressWorkout.totalVolume,
+                    totalSets = inProgressWorkout.totalSets,
+                    restTimerSeconds = inProgressWorkout.restTimerSeconds,
+                    restTimerTotal = inProgressWorkout.restTimerTotal,
+                    isRestTimerActive = inProgressWorkout.isRestTimerActive,
+                )
+                workoutDao.saveInProgressWorkout(entity)
+            }
+        }
+        when (result) {
+            is AppResult.Success -> Unit
+            is AppResult.Error -> {
+                Log.e(TAG, "Failed to save in-progress workout: ${result.error.message}")
+                throw Exception(result.error.message)
+            }
+        }
+    }
+
+    override suspend fun getInProgressWorkout(): InProgressWorkout? {
+        val result = retryWithBackoff {
+            runCatchingAsResult {
+                workoutDao.getAnyInProgressWorkout()?.let { entity ->
+                    try {
+                        val listType = object : TypeToken<List<Map<String, Any>>>() {}.type
+                        val exercisesList: List<Map<String, Any>> = gson.fromJson(entity.exercisesJson, listType)
+                        
+                        val exercises = exercisesList.map { exerciseMap ->
+                            val exerciseId = UUID.fromString(exerciseMap["exerciseId"] as String)
+                            val exerciseName = exerciseMap["exerciseName"] as String
+                            val muscleGroupStr = exerciseMap["muscleGroup"] as String
+                            
+                            @Suppress("UNCHECKED_CAST")
+                            val setsArray = exerciseMap["sets"] as List<Map<String, Any>>
+                            
+                            InProgressExercise(
+                                exercise = com.gymbro.core.model.Exercise(
+                                    id = exerciseId,
+                                    name = exerciseName,
+                                    muscleGroup = try {
+                                        com.gymbro.core.model.MuscleGroup.valueOf(muscleGroupStr)
+                                    } catch (e: Exception) {
+                                        com.gymbro.core.model.MuscleGroup.FULL_BODY
+                                    },
+                                    category = com.gymbro.core.model.ExerciseCategory.COMPOUND,
+                                    equipment = com.gymbro.core.model.Equipment.OTHER,
+                                    description = "",
+                                ),
+                                sets = setsArray.map { setMap ->
+                                    InProgressSet(
+                                        id = setMap["id"] as String,
+                                        setNumber = (setMap["setNumber"] as Double).toInt(),
+                                        weight = setMap["weight"] as String,
+                                        reps = setMap["reps"] as String,
+                                        rpe = setMap["rpe"] as String,
+                                        isWarmup = setMap["isWarmup"] as Boolean,
+                                        isCompleted = setMap["isCompleted"] as Boolean,
+                                    )
+                                }
+                            )
+                        }
+                        
+                        InProgressWorkout(
+                            workoutId = entity.workoutId,
+                            exercises = exercises,
+                            elapsedSeconds = entity.elapsedSeconds,
+                            totalVolume = entity.totalVolume,
+                            totalSets = entity.totalSets,
+                            restTimerSeconds = entity.restTimerSeconds,
+                            restTimerTotal = entity.restTimerTotal,
+                            isRestTimerActive = entity.isRestTimerActive,
+                        )
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to deserialize in-progress workout", e)
+                        workoutDao.clearInProgressWorkout(entity.workoutId)
+                        null
+                    }
+                }
+            }
+        }
+        return when (result) {
+            is AppResult.Success -> result.data
+            is AppResult.Error -> {
+                Log.e(TAG, "Failed to get in-progress workout: ${result.error.message}")
+                null
+            }
+        }
+    }
+
+    override suspend fun clearInProgressWorkout(workoutId: String) {
+        val result = retryWithBackoff {
+            runCatchingAsResult { workoutDao.clearInProgressWorkout(workoutId) }
+        }
+        when (result) {
+            is AppResult.Success -> Unit
+            is AppResult.Error -> {
+                Log.e(TAG, "Failed to clear in-progress workout $workoutId: ${result.error.message}")
             }
         }
     }

--- a/android/core/src/test/java/com/gymbro/core/fakes/FakeWorkoutRepository.kt
+++ b/android/core/src/test/java/com/gymbro/core/fakes/FakeWorkoutRepository.kt
@@ -12,6 +12,7 @@ import java.util.UUID
 class FakeWorkoutRepository : WorkoutRepository {
     
     private val workouts = MutableStateFlow<Map<String, Workout>>(emptyMap())
+    private var inProgressWorkout: com.gymbro.core.model.InProgressWorkout? = null
     
     fun setWorkouts(vararg workouts: Workout) {
         this.workouts.value = workouts.associateBy { it.id.toString() }
@@ -99,5 +100,19 @@ class FakeWorkoutRepository : WorkoutRepository {
         val now = Instant.now()
         val daysBetween = java.time.Duration.between(lastWorkout.completedAt, now).toDays()
         return daysBetween.toInt()
+    }
+
+    override suspend fun saveInProgressWorkout(inProgressWorkout: com.gymbro.core.model.InProgressWorkout) {
+        this.inProgressWorkout = inProgressWorkout
+    }
+
+    override suspend fun getInProgressWorkout(): com.gymbro.core.model.InProgressWorkout? {
+        return inProgressWorkout
+    }
+
+    override suspend fun clearInProgressWorkout(workoutId: String) {
+        if (inProgressWorkout?.workoutId == workoutId) {
+            inProgressWorkout = null
+        }
     }
 }

--- a/android/core/src/test/java/com/gymbro/core/repository/WorkoutPersistenceTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/repository/WorkoutPersistenceTest.kt
@@ -1,0 +1,156 @@
+package com.gymbro.core.repository
+
+import com.google.gson.Gson
+import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.database.entity.InProgressWorkoutEntity
+import com.gymbro.core.model.Equipment
+import com.gymbro.core.model.Exercise
+import com.gymbro.core.model.ExerciseCategory
+import com.gymbro.core.model.InProgressExercise
+import com.gymbro.core.model.InProgressSet
+import com.gymbro.core.model.InProgressWorkout
+import com.gymbro.core.model.MuscleGroup
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+class WorkoutPersistenceTest {
+
+    private lateinit var workoutDao: WorkoutDao
+    private lateinit var gson: Gson
+    private lateinit var repository: WorkoutRepositoryImpl
+
+    @Before
+    fun setup() {
+        workoutDao = mockk(relaxed = true)
+        gson = Gson()
+        repository = WorkoutRepositoryImpl(workoutDao, gson)
+    }
+
+    @Test
+    fun `saveInProgressWorkout serializes and persists state`() = runTest {
+        val workoutId = UUID.randomUUID().toString()
+        val exercise = Exercise(
+            id = UUID.randomUUID(),
+            name = "Bench Press",
+            muscleGroup = MuscleGroup.CHEST,
+            category = ExerciseCategory.COMPOUND,
+            equipment = Equipment.BARBELL,
+            description = "Test exercise"
+        )
+        val inProgressWorkout = InProgressWorkout(
+            workoutId = workoutId,
+            exercises = listOf(
+                InProgressExercise(
+                    exercise = exercise,
+                    sets = listOf(
+                        InProgressSet(
+                            id = UUID.randomUUID().toString(),
+                            setNumber = 1,
+                            weight = "100",
+                            reps = "8",
+                            rpe = "8.5",
+                            isWarmup = false,
+                            isCompleted = true
+                        )
+                    )
+                )
+            ),
+            elapsedSeconds = 300L,
+            totalVolume = 800.0,
+            totalSets = 1,
+            restTimerSeconds = 60,
+            restTimerTotal = 90,
+            isRestTimerActive = false
+        )
+
+        repository.saveInProgressWorkout(inProgressWorkout)
+
+        coVerify {
+            workoutDao.saveInProgressWorkout(
+                withArg { entity ->
+                    assertEquals(workoutId, entity.workoutId)
+                    assertEquals(300L, entity.elapsedSeconds)
+                    assertEquals(800.0, entity.totalVolume, 0.001)
+                    assertEquals(1, entity.totalSets)
+                    assertNotNull(entity.exercisesJson)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `getInProgressWorkout returns null when no workout exists`() = runTest {
+        coEvery { workoutDao.getAnyInProgressWorkout() } returns null
+
+        val result = repository.getInProgressWorkout()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getInProgressWorkout deserializes and returns workout`() = runTest {
+        val workoutId = UUID.randomUUID().toString()
+        val exerciseId = UUID.randomUUID()
+        val setId = UUID.randomUUID().toString()
+        
+        val exercisesJson = gson.toJson(listOf(
+            mapOf(
+                "exerciseId" to exerciseId.toString(),
+                "exerciseName" to "Bench Press",
+                "muscleGroup" to "CHEST",
+                "sets" to listOf(
+                    mapOf(
+                        "id" to setId,
+                        "setNumber" to 1.0,
+                        "weight" to "100",
+                        "reps" to "8",
+                        "rpe" to "8.5",
+                        "isWarmup" to false,
+                        "isCompleted" to true
+                    )
+                )
+            )
+        ))
+
+        val entity = InProgressWorkoutEntity(
+            workoutId = workoutId,
+            exercisesJson = exercisesJson,
+            elapsedSeconds = 300L,
+            totalVolume = 800.0,
+            totalSets = 1,
+            restTimerSeconds = 60,
+            restTimerTotal = 90,
+            isRestTimerActive = false
+        )
+
+        coEvery { workoutDao.getAnyInProgressWorkout() } returns entity
+
+        val result = repository.getInProgressWorkout()
+
+        assertNotNull(result)
+        assertEquals(workoutId, result!!.workoutId)
+        assertEquals(300L, result.elapsedSeconds)
+        assertEquals(800.0, result.totalVolume, 0.001)
+        assertEquals(1, result.exercises.size)
+        assertEquals("Bench Press", result.exercises[0].exercise.name)
+        assertEquals(1, result.exercises[0].sets.size)
+        assertEquals(setId, result.exercises[0].sets[0].id)
+        assertEquals("100", result.exercises[0].sets[0].weight)
+        assertTrue(result.exercises[0].sets[0].isCompleted)
+    }
+
+    @Test
+    fun `clearInProgressWorkout removes persisted state`() = runTest {
+        val workoutId = UUID.randomUUID().toString()
+
+        repository.clearInProgressWorkout(workoutId)
+
+        coVerify { workoutDao.clearInProgressWorkout(workoutId) }
+    }
+}

--- a/android/core/src/test/java/com/gymbro/core/repository/WorkoutRepositoryFailureTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/repository/WorkoutRepositoryFailureTest.kt
@@ -29,7 +29,7 @@ class WorkoutRepositoryFailureTest {
     @Before
     fun setup() {
         workoutDao = mockk()
-        repository = WorkoutRepositoryImpl(workoutDao)
+        repository = WorkoutRepositoryImpl(workoutDao, com.google.gson.Gson())
     }
 
     // ============ startWorkout Failure Tests ============

--- a/android/core/src/test/java/com/gymbro/core/repository/WorkoutRepositoryImplTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/repository/WorkoutRepositoryImplTest.kt
@@ -28,7 +28,7 @@ class WorkoutRepositoryImplTest {
     @Before
     fun setup() {
         workoutDao = mockk()
-        repository = WorkoutRepositoryImpl(workoutDao)
+        repository = WorkoutRepositoryImpl(workoutDao, com.google.gson.Gson())
     }
 
     @Test

--- a/android/core/src/test/java/com/gymbro/core/sync/OfflineModeTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/sync/OfflineModeTest.kt
@@ -35,7 +35,7 @@ class OfflineModeTest {
         workoutDao = mockk(relaxed = true)
         cloudSyncService = mockk(relaxed = true)
         connectivityObserver = FakeConnectivityObserver()
-        workoutRepository = WorkoutRepositoryImpl(workoutDao)
+        workoutRepository = WorkoutRepositoryImpl(workoutDao, com.google.gson.Gson())
     }
 
     @Test

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -15,6 +15,7 @@ data class ActiveWorkoutState(
     val isCompleting: Boolean = false,
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
+    val hasInProgressWorkout: Boolean = false,
 )
 
 data class WorkoutExerciseUi(
@@ -52,6 +53,8 @@ sealed interface ActiveWorkoutEvent {
     data object DiscardWorkout : ActiveWorkoutEvent
     data object ClearError : ActiveWorkoutEvent
     data object RetryStartWorkout : ActiveWorkoutEvent
+    data object ResumeWorkout : ActiveWorkoutEvent
+    data object StartNewWorkout : ActiveWorkoutEvent
 }
 
 sealed interface ActiveWorkoutEffect {

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -38,9 +38,35 @@ class ActiveWorkoutViewModel @Inject constructor(
 
     private var timerJob: Job? = null
     private var restTimerJob: Job? = null
+    private var shouldAutoSave = true
 
     init {
-        startWorkout()
+        checkForInProgressWorkout()
+    }
+
+    private fun checkForInProgressWorkout() {
+        safeLaunch(
+            onError = { error ->
+                _state.update { 
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = "Failed to check for in-progress workout: ${error.toUserMessage()}"
+                    )
+                }
+            }
+        ) {
+            val inProgress = workoutRepository.getInProgressWorkout()
+            if (inProgress != null) {
+                _state.update { 
+                    it.copy(
+                        hasInProgressWorkout = true,
+                        isLoading = false,
+                    )
+                }
+            } else {
+                startWorkout()
+            }
+        }
     }
 
     private fun startWorkout() {
@@ -72,6 +98,8 @@ class ActiveWorkoutViewModel @Inject constructor(
 
     fun onEvent(event: ActiveWorkoutEvent) {
         when (event) {
+            is ActiveWorkoutEvent.ResumeWorkout -> resumeWorkout()
+            is ActiveWorkoutEvent.StartNewWorkout -> startNewWorkout()
             is ActiveWorkoutEvent.AddExerciseClicked -> {
                 viewModelScope.launch {
                     _effect.send(ActiveWorkoutEffect.ShowExercisePicker)
@@ -127,6 +155,7 @@ class ActiveWorkoutViewModel @Inject constructor(
                 )
                 current.copy(exercises = current.exercises + newExercise)
             }
+            autoSaveState()
         }
     }
 
@@ -147,6 +176,7 @@ class ActiveWorkoutViewModel @Inject constructor(
             exercises[exerciseIndex] = exerciseUi.copy(sets = exerciseUi.sets + newSet)
             current.copy(exercises = exercises)
         }
+        autoSaveState()
     }
 
     private fun updateSetField(exerciseIndex: Int, setIndex: Int, transform: (WorkoutSetUi) -> WorkoutSetUi) {
@@ -197,6 +227,9 @@ class ActiveWorkoutViewModel @Inject constructor(
 
             // Recalculate totals
             recalculateTotals()
+
+            // Auto-save state
+            autoSaveState()
 
             // Auto-start rest timer
             startRestTimer()
@@ -266,6 +299,7 @@ class ActiveWorkoutViewModel @Inject constructor(
             _state.update { it.copy(isRestTimerActive = false) }
             _effect.send(ActiveWorkoutEffect.RestTimerFinished)
         }
+        autoSaveState()
     }
 
     private fun skipRestTimer() {
@@ -302,6 +336,10 @@ class ActiveWorkoutViewModel @Inject constructor(
                 durationSeconds = currentState.elapsedSeconds,
                 notes = "",
             )
+            
+            // Clear in-progress state
+            workoutRepository.clearInProgressWorkout(workoutId)
+            
             timerJob?.cancel()
             restTimerJob?.cancel()
 
@@ -334,10 +372,127 @@ class ActiveWorkoutViewModel @Inject constructor(
     }
 
     private fun discardWorkout() {
+        val workoutId = _state.value.workoutId
         timerJob?.cancel()
         restTimerJob?.cancel()
         viewModelScope.launch {
+            if (workoutId != null) {
+                workoutRepository.clearInProgressWorkout(workoutId)
+            }
             _effect.send(ActiveWorkoutEffect.NavigateBack)
+        }
+    }
+
+    private fun resumeWorkout() {
+        safeLaunch(
+            onError = { error ->
+                _state.update { 
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = "Failed to resume workout: ${error.toUserMessage()}"
+                    )
+                }
+            }
+        ) {
+            val inProgress = workoutRepository.getInProgressWorkout()
+            if (inProgress != null) {
+                shouldAutoSave = false
+                _state.update { current ->
+                    current.copy(
+                        workoutId = inProgress.workoutId,
+                        exercises = inProgress.exercises.map { ex ->
+                            WorkoutExerciseUi(
+                                exercise = ex.exercise,
+                                sets = ex.sets.map { set ->
+                                    WorkoutSetUi(
+                                        id = set.id,
+                                        setNumber = set.setNumber,
+                                        weight = set.weight,
+                                        reps = set.reps,
+                                        rpe = set.rpe,
+                                        isWarmup = set.isWarmup,
+                                        isCompleted = set.isCompleted,
+                                    )
+                                }
+                            )
+                        },
+                        elapsedSeconds = inProgress.elapsedSeconds,
+                        totalVolume = inProgress.totalVolume,
+                        totalSets = inProgress.totalSets,
+                        restTimerSeconds = inProgress.restTimerSeconds,
+                        restTimerTotal = inProgress.restTimerTotal,
+                        isRestTimerActive = inProgress.isRestTimerActive,
+                        hasInProgressWorkout = false,
+                        isLoading = false,
+                    )
+                }
+                shouldAutoSave = true
+                startElapsedTimer()
+                if (inProgress.isRestTimerActive) {
+                    startRestTimer()
+                }
+            } else {
+                startWorkout()
+            }
+        }
+    }
+
+    private fun startNewWorkout() {
+        safeLaunch(
+            onError = { error ->
+                _state.update { 
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = "Failed to clear old workout: ${error.toUserMessage()}"
+                    )
+                }
+            }
+        ) {
+            val inProgress = workoutRepository.getInProgressWorkout()
+            if (inProgress != null) {
+                workoutRepository.clearInProgressWorkout(inProgress.workoutId)
+            }
+            startWorkout()
+        }
+    }
+
+    private fun autoSaveState() {
+        if (!shouldAutoSave) return
+        val currentState = _state.value
+        val workoutId = currentState.workoutId ?: return
+
+        viewModelScope.launch {
+            try {
+                val inProgressWorkout = com.gymbro.core.model.InProgressWorkout(
+                    workoutId = workoutId,
+                    exercises = currentState.exercises.map { ex ->
+                        com.gymbro.core.model.InProgressExercise(
+                            exercise = ex.exercise,
+                            sets = ex.sets.map { set ->
+                                com.gymbro.core.model.InProgressSet(
+                                    id = set.id,
+                                    setNumber = set.setNumber,
+                                    weight = set.weight,
+                                    reps = set.reps,
+                                    rpe = set.rpe,
+                                    isWarmup = set.isWarmup,
+                                    isCompleted = set.isCompleted,
+                                )
+                            }
+                        )
+                    },
+                    elapsedSeconds = currentState.elapsedSeconds,
+                    totalVolume = currentState.totalVolume,
+                    totalSets = currentState.totalSets,
+                    restTimerSeconds = currentState.restTimerSeconds,
+                    restTimerTotal = currentState.restTimerTotal,
+                    isRestTimerActive = currentState.isRestTimerActive,
+                )
+                workoutRepository.saveInProgressWorkout(inProgressWorkout)
+            } catch (e: Exception) {
+                // Silent failure - don't interrupt user's workout
+                android.util.Log.e("ActiveWorkoutViewModel", "Failed to auto-save workout state", e)
+            }
         }
     }
 


### PR DESCRIPTION
Closes #390

## Problem
ActiveWorkoutViewModel held state in memory only. Users lost 30-45 min of logged data from phone calls, app kills, or accidental back presses.

## Solution
Implemented Room-based persistence with auto-save on critical mutations:
- Set completion → auto-save
- Exercise add → auto-save  
- Rest timer start → auto-save

## Architecture
```
InProgressWorkoutEntity (Room)
  ├─ exercisesJson (Gson serialization)
  ├─ elapsedSeconds, totalVolume, totalSets
  └─ restTimer state (seconds, total, isActive)

WorkoutRepository
  ├─ saveInProgressWorkout()    // JSON encode + persist
  ├─ getInProgressWorkout()     // Deserialize + restore
  └─ clearInProgressWorkout()   // On complete/discard

ActiveWorkoutViewModel
  ├─ init → checkForInProgressWorkout()
  ├─ ResumeWorkout event → restores full state
  ├─ StartNewWorkout event → clears old + creates fresh
  └─ autoSaveState() on mutations
```

## Edge Cases
- **Corrupt JSON**: Silent clear with log (no user interruption)
- **Enum deserialization**: Fallbacks (MuscleGroup → FULL_BODY)
- **Save loops**: `shouldAutoSave` flag prevents loops during restoration
- **Multiple in-progress**: Table uses `workoutId` as PK (enforces single row)

## Testing
- 4 unit tests for persistence layer
- Updated FakeWorkoutRepository with in-progress state
- All existing tests passing

## UI Layer
Trinity will handle the Resume Workout prompt in a follow-up PR. This PR provides the data layer foundation:
- `state.hasInProgressWorkout` flag exposes resume availability
- `onEvent(ResumeWorkout)` and `onEvent(StartNewWorkout)` handle user choice
