### PR TITLE
fix: Add actionable CTAs to empty states

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -329,6 +329,9 @@ fun GymBroNavGraph(
                 onNavigateToDetail = { workoutId ->
                     navController.navigate("history/$workoutId")
                 },
+                onNavigateToActiveWorkout = {
+                    navController.navigate("active_workout")
+                },
             )
         }
         composable("progress") {
@@ -339,6 +342,9 @@ fun GymBroNavGraph(
                         ?.savedStateHandle
                         ?.set("coach_initial_prompt", prompt)
                     navController.navigate("coach")
+                },
+                onNavigateToActiveWorkout = {
+                    navController.navigate("active_workout")
                 }
             )
         }

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -32,6 +32,7 @@
     <string name="exercise_library_search">Buscar ejercicios…</string>
     <string name="exercise_library_empty_title">No se encontraron ejercicios</string>
     <string name="exercise_library_empty_subtitle">Intenta ajustar tu búsqueda o filtros</string>
+    <string name="exercise_library_empty_cta">Crear Ejercicio Personalizado</string>
     <string name="exercise_library_loading">Cargando ejercicios...</string>
     <string name="exercise_library_view_details">Ver detalles del ejercicio</string>
 
@@ -73,6 +74,7 @@
     <string name="history_title">Historial de Entrenamientos</string>
     <string name="history_empty_title">Sin Entrenamientos Aún</string>
     <string name="history_empty_subtitle">¡Empieza a entrenar para construir tu historial!</string>
+    <string name="history_empty_cta">Inicia Tu Primer Entrenamiento</string>
     <string name="history_loading">Cargando historial...</string>
     <string name="history_error_title">Error</string>
     <string name="history_exercises_count">%d ejercicios</string>
@@ -82,7 +84,8 @@
     <!-- Progress -->
     <string name="progress_title">Progreso</string>
     <string name="progress_empty_title">Sin entrenamientos aún</string>
-    <string name="progress_empty_subtitle">¡Empieza a entrenar para rastrear tu progreso!</string>
+    <string name="progress_empty_subtitle">Registra 3 entrenamientos para ver tendencias y análisis</string>
+    <string name="progress_empty_cta">Iniciar Entrenamiento</string>
     <string name="progress_loading">Cargando progreso...</string>
     <string name="progress_total_workouts">Total de Entrenamientos</string>
     <string name="progress_total_volume">Volumen Total</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="exercise_library_search">Search exercises…</string>
     <string name="exercise_library_empty_title">No exercises found</string>
     <string name="exercise_library_empty_subtitle">Try adjusting your search or filters</string>
+    <string name="exercise_library_empty_cta">Create Custom Exercise</string>
     <string name="exercise_library_loading">Loading exercises...</string>
     <string name="exercise_library_view_details">View exercise details</string>
 
@@ -73,6 +74,7 @@
     <string name="history_title">Workout History</string>
     <string name="history_empty_title">No Workouts Yet</string>
     <string name="history_empty_subtitle">Start training to build your history!</string>
+    <string name="history_empty_cta">Start Your First Workout</string>
     <string name="history_loading">Loading history...</string>
     <string name="history_error_title">Error</string>
     <string name="history_exercises_count">%d exercises</string>
@@ -82,7 +84,8 @@
     <!-- Progress -->
     <string name="progress_title">Progress</string>
     <string name="progress_empty_title">No workouts yet</string>
-    <string name="progress_empty_subtitle">Start training to track progress!</string>
+    <string name="progress_empty_subtitle">Log 3 workouts to see trends and analytics</string>
+    <string name="progress_empty_cta">Start Workout</string>
     <string name="progress_loading">Loading progress...</string>
     <string name="progress_total_workouts">Total Workouts</string>
     <string name="progress_total_volume">Total Volume</string>

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -236,7 +236,13 @@ fun ExerciseLibraryScreen(
                     FullScreenLoading(message = stringResource(R.string.exercise_library_loading))
                 }
                 state.exercises.isEmpty() -> {
-                    EmptyExercisesView(onNavigateToCreateExercise)
+                    EmptyState(
+                        icon = Icons.Default.Search,
+                        title = stringResource(R.string.exercise_library_empty_title),
+                        subtitle = stringResource(R.string.exercise_library_empty_subtitle),
+                        actionText = stringResource(R.string.exercise_library_empty_cta),
+                        onActionClick = onNavigateToCreateExercise,
+                    )
                 }
                 else -> {
                     LazyColumn(
@@ -429,37 +435,4 @@ private fun CategoryBadge(category: ExerciseCategory) {
     }
 }
 
-@Composable
-private fun EmptyExercisesView() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(32.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Icon(
-            Icons.Default.Search,
-            contentDescription = null,
-            modifier = Modifier.size(96.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-        )
-        
-        Spacer(modifier = Modifier.height(24.dp))
-        
-        Text(
-            text = stringResource(R.string.exercise_library_empty_title),
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onBackground,
-        )
-        
-        Spacer(modifier = Modifier.height(8.dp))
-        
-        Text(
-            text = stringResource(R.string.tooltip_exercise_not_found),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
+

--- a/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/exerciselibrary/ExerciseLibraryScreen.kt
@@ -72,6 +72,7 @@ import com.gymbro.core.model.MuscleGroup
 import com.gymbro.feature.common.FullScreenLoading
 import com.gymbro.feature.common.GlassmorphicCard
 import com.gymbro.feature.common.ObserveErrors
+import com.gymbro.feature.common.EmptyState
 import com.gymbro.feature.common.icon
 import com.gymbro.core.R
 
@@ -235,7 +236,7 @@ fun ExerciseLibraryScreen(
                     FullScreenLoading(message = stringResource(R.string.exercise_library_loading))
                 }
                 state.exercises.isEmpty() -> {
-                    EmptyExercisesView()
+                    EmptyExercisesView(onNavigateToCreateExercise)
                 }
                 else -> {
                     LazyColumn(

--- a/android/feature/src/main/java/com/gymbro/feature/history/HistoryListScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/history/HistoryListScreen.kt
@@ -80,6 +80,7 @@ private val SurfaceDark = Color(0xFF0A0A0A)
 fun HistoryListRoute(
     onNavigateBack: () -> Unit,
     onNavigateToDetail: (String) -> Unit,
+    onNavigateToActiveWorkout: () -> Unit = {},
     viewModel: HistoryListViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -121,6 +122,8 @@ fun HistoryListRoute(
                         icon = Icons.Default.History,
                         title = stringResource(R.string.history_empty_title),
                         subtitle = stringResource(R.string.history_empty_subtitle),
+                        actionText = stringResource(R.string.history_empty_cta),
+                        onActionClick = onNavigateToActiveWorkout,
                     )
                 }
                 else -> {

--- a/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/progress/ProgressScreen.kt
@@ -103,6 +103,7 @@ fun ProgressRoute(
     onNavigateToWorkoutDetail: (String) -> Unit = {},
     onNavigateToAnalytics: () -> Unit = {},
     onNavigateToCoach: (String) -> Unit = {},
+    onNavigateToActiveWorkout: () -> Unit = {},
 ) {
     val viewModel: ProgressViewModel = hiltViewModel()
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -127,6 +128,7 @@ fun ProgressRoute(
         state = state,
         onEvent = viewModel::onEvent,
         onNavigateToAnalytics = onNavigateToAnalytics,
+        onNavigateToActiveWorkout = onNavigateToActiveWorkout,
         showChartTooltip = showChartTooltip,
         onTooltipDismissed = {
             showChartTooltip = false
@@ -142,6 +144,7 @@ private fun ProgressScreen(
     state: ProgressState,
     onEvent: (ProgressEvent) -> Unit,
     onNavigateToAnalytics: () -> Unit = {},
+    onNavigateToActiveWorkout: () -> Unit = {},
     showChartTooltip: Boolean = false,
     onTooltipDismissed: () -> Unit = {},
 ) {
@@ -151,7 +154,7 @@ private fun ProgressScreen(
     }
 
     if (state.workoutHistory.isEmpty() && state.personalRecords.isEmpty()) {
-        EmptyProgressState()
+        EmptyProgressState(onNavigateToActiveWorkout)
         return
     }
 
@@ -284,11 +287,13 @@ private fun ProgressScreen(
 }
 
 @Composable
-private fun EmptyProgressState() {
+private fun EmptyProgressState(onNavigateToActiveWorkout: () -> Unit = {}) {
     EmptyState(
         icon = Icons.Default.EmojiEvents,
         title = stringResource(R.string.progress_empty_title),
-        subtitle = stringResource(R.string.progress_empty_subtitle_alt),
+        subtitle = stringResource(R.string.progress_empty_subtitle),
+        actionText = stringResource(R.string.progress_empty_cta),
+        onActionClick = onNavigateToActiveWorkout,
     )
 }
 


### PR DESCRIPTION
Closes #395

**Changes:**
- History empty state: Added 'Start Your First Workout' CTA button that navigates to Active Workout
- Progress empty state: Added 'Start Workout' CTA button, updated subtitle to 'Log 3 workouts to see trends'
- Exercise Library empty state: Added 'Create Custom Exercise' CTA button
- Programs screen already has 'Generate AI Plan' CTA (no changes needed)

**Bilingual support:**
- All new string resources added in English and Spanish

**Navigation:**
- Empty states now use existing navigation callbacks
- CTAs provide clear next steps for new users