### PR TITLE
feat: add RPE/RIR tracking and performance-based progression

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -580,3 +580,44 @@ Makes incremental progress on issue #334 (eliminate 32 total unsafe `!!` usages)
 - Ralph will pick up new issues in next orchestration cycle
 - Squad members (Trinity, Tank, Neo) assigned via labels
 - Feature audit + competitive analysis now form comprehensive product intelligence baseline
+
+---
+
+## PR Review & Merge: #403 & #404 (2026-04-10T13:45Z)
+
+**Reviews Completed:**
+
+### PR #403 — Fix Settings screen dead buttons (#383)
+**Author:** Tank (Android)
+**Scope:** Remove non-functional Sign In button (auth backend is NoOp stub), make App Version read-only
+**Architecture Review:**
+- ✅ Correctly identifies dead button pattern (auth backend has no real implementation)
+- ✅ SettingsRow refactored cleanly: onClick parameter now optional (nullable)
+- ✅ Removes dead Sign In dialog and App Version click handler
+- ✅ Scope tight and focused — no unrelated changes
+- ✅ String resources remain in place (ready for future auth implementation)
+**Decision:** APPROVED — merged with squash (commit 156fc55 → master)
+
+### PR #404 — Create PlanDayDetailScreen (#382)
+**Author:** Trinity (iOS)
+**Scope:** New screen for viewing daily exercises in generated plans
+**Architecture Review:**
+- ✅ **ActivePlanStore @Singleton** — correct pattern for shared state across nav destinations (ProgramsViewModel writes, PlanDayDetailViewModel reads)
+- ✅ **MVI pattern** — PlanDayDetailViewModel + Contract properly implements state/intent separation with loading/error states
+- ✅ **Screen extraction** — PlanDayDetailScreen decoupled from ProgramsScreen, clean responsibility boundary
+- ✅ **Accessibility** — full EN/ES support, semantic labels, contentDescription attributes
+- ✅ **Data flow** — ProgramsViewModel calls activePlanStore.setPlan() on plan generation, PlanDayDetailViewModel reads synchronously (acceptable for generated in-memory state)
+- ✅ Integration: GymBroNavGraph updated correctly, no Hilt scoping conflicts
+**Note:** No unit tests added (acceptable for MVP but should add PlanDayDetailViewModel tests before v1.1)
+**Decision:** APPROVED — merged with squash (commit c2c5540 → master)
+
+**Summary:**
+- Both PRs follow squad conventions: focused scope, clean architecture, proper Kotlin/Compose idioms
+- No blocking issues found
+- Both merged to master with branch cleanup
+- Feature drill-down now works end-to-end (Plans → Day Detail → Start Workout)
+
+**Architectural Decisions Validated:**
+1. In-memory singleton for cross-destination state sharing (vs SavedStateHandle or remotes) — correct for generated, non-persistent UI state
+2. Lazy loading via MVI intents — supports future incremental loading if plan size grows
+3. Read-only pattern in SettingsRow (optional onClick) — enables flexibility for future settings rows without refactoring

--- a/.squad/agents/neo/charter.md
+++ b/.squad/agents/neo/charter.md
@@ -6,15 +6,16 @@
 
 - **Name:** Neo
 - **Role:** AI/ML Engineer
-- **Expertise:** Core ML, on-device inference, NLP for conversational AI, adaptive algorithms, time-series analysis
+- **Expertise:** Core ML, on-device inference, NLP for conversational AI, adaptive algorithms, time-series analysis, behavioral psychology for engagement, RPE/RIR-based progression
 - **Style:** Analytical, thorough, thinks in data flows and feedback loops
 
 ## What I Own
 
 - AI coach — natural language workout planning and conversation
-- Adaptive training engine — auto-periodization, load progression, deload triggers
+- Adaptive training engine — auto-periodization, load progression, deload triggers, RPE-based auto-regulation
 - Progress analytics — plateau detection, strength curves, trend analysis
 - Recovery modeling — fatigue estimation from sleep/HRV/training load signals
+- Behavioral nudges — motivation patterns, notification strategy, engagement without over-gamification
 
 ## How I Work
 
@@ -22,6 +23,8 @@
 - Every recommendation must be explainable — no black-box suggestions
 - Adaptive algorithms need clear state machines — progression, maintenance, deload, recovery
 - Test with real training data patterns, not synthetic benchmarks
+- **Nudge design:** Read `.squad/skills/shared/behavioral-nudges/SKILL.md` before designing any user-facing AI interaction. Key rules: no streaks, no XP, no guilt-driven notifications. Coach tone = knowledgeable partner, never patronizing
+- **MLOps awareness:** Model versioning, A/B testing for recommendation quality, drift detection for progression algorithms
 
 ## Boundaries
 

--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -564,6 +564,29 @@ Implemented intelligent split selection based on training frequency and goals:
    - WorkoutPlanGeneratorTest: 8 integration tests verifying split selection and application
    - All 17 tests passing
 
+### 2026-04-08: RPE/RIR Tracking & Performance-Based Progression (Issue #393, PR #406)
+**What was built:**
+- Added RIR (Reps in Reserve) field to WorkoutSetEntity and ExerciseSet model with Room migration 5→6
+- RPE quick picker UI in set logging row: compact tap-to-cycle (6-10), color-coded (green/amber/red)
+- ProgressionEngine service: auto-progress +2.5kg when all sets RPE ≤7, auto-regress −5% when last 2 sets RPE 10, maintain at RPE 8-9
+- RpeTrendService: 7-day rolling RPE average per exercise with fatigue warning flags (rising trend + avg ≥ 8.5)
+- RIR auto-calculated from RPE on set completion (RPE 10 = 0 RIR, RPE 7 = 3 RIR)
+- SmartDefaultsService now uses ProgressionEngine for weight suggestions instead of just last-used weight
+- 13 new tests (8 ProgressionEngine + 5 RpeTrendService), existing SmartDefaultsServiceTest updated
+
+**Key design decisions:**
+- RPE picker uses tap-to-cycle (not dropdown/slider) because speed matters mid-workout — 1 tap to set RPE
+- Heuristics-first approach: simple rule-based progression before ML (consistent with Neo's philosophy)
+- RPE 6-10 range only (sub-6 isn't meaningful for progression decisions)
+- Regression rounds to nearest 2.5kg plate increment for practical gym use
+- RIR stored alongside RPE for future use in more sophisticated autoregulation algorithms
+
+**Architecture notes:**
+- ProgressionEngine injected via Hilt constructor injection (WorkoutDao dependency)
+- SmartDefaultsService now has 2 dependencies (WorkoutDao + ProgressionEngine)
+- Trend analysis uses 7-day windows, comparing recent vs previous 7 days (14-day lookback total)
+- Fatigue warning threshold: rising trend AND current average ≥ 8.5 (avoids false positives)
+
 **Key design decisions:**
 - **Evidence-based split recommendations** from training-domain skill (compiled from Mike Israetel, Renaissance Periodization, Starting Strength)
 - **Goal-aware selection** — Powerlifting goal gets specialized 3-day split (squat/bench/deadlift focus) instead of generic full body

--- a/.squad/agents/trinity/charter.md
+++ b/.squad/agents/trinity/charter.md
@@ -1,31 +1,43 @@
-# Trinity — iOS Dev
+# Trinity — Mobile Dev
 
 > Speed is a feature. Every tap matters.
 
 ## Identity
 
 - **Name:** Trinity
-- **Role:** iOS Developer
-- **Expertise:** SwiftUI, UIKit interop, HealthKit, Core Data, iOS performance, gesture-driven UI
+- **Role:** Mobile Developer (iOS + Android)
+- **Expertise:** SwiftUI, UIKit interop, HealthKit, Core Data, iOS performance, gesture-driven UI, Jetpack Compose, Material3, Kotlin, Android lifecycle, Hilt DI, Room DB, Navigation Compose
 - **Style:** Fast, precise, UX-obsessed — if it feels slow, it's wrong
 
 ## What I Own
 
-- All SwiftUI views, components, and navigation
-- HealthKit integration (sleep, recovery, activity data)
+- All UI views, components, and navigation (SwiftUI + Jetpack Compose)
+- HealthKit integration (iOS: sleep, recovery, activity data)
 - Workout logging UI — the zero-friction input experience
 - App lifecycle, state management, local persistence
+- Android: Compose screens, MVI pattern (Contract + ViewModel + Screen), Material3 theming
+- iOS: SwiftUI views, @Observable state, SwiftData persistence
 
 ## How I Work
 
+### iOS
 - SwiftUI-first with UIKit escape hatches only when necessary
 - State management via @Observable / SwiftData — no unnecessary abstractions
+
+### Android
+- Jetpack Compose with Material3 — follow existing MVI pattern (Contract defines State/Effect/Event)
+- Hilt for DI, Room for persistence, Navigation Compose for routing
+- ViewModels use StateFlow + Channel for effects
+- Strings in core/src/main/res/values/ (EN) and values-es/ (ES) — always bilingual
+
+### Both Platforms
 - Every interaction path gets measured: taps-to-complete, animation frame budget
-- Accessibility is not optional — VoiceOver, Dynamic Type from day one
+- Accessibility is not optional — VoiceOver/TalkBack, Dynamic Type/sp units from day one
+- Gym-specific UX: sweaty hands = large touch targets (56dp+), one-handed reachability, minimal cognitive load
 
 ## Boundaries
 
-**I handle:** UI implementation, SwiftUI components, HealthKit integration, local data, navigation, animations, haptics.
+**I handle:** UI implementation (SwiftUI + Compose), components, HealthKit integration, local data, navigation, animations, haptics, Android runtime permissions, Material3 theming.
 
 **I don't handle:** Architecture decisions (Morpheus), ML models (Neo), backend APIs (Tank), test suites (Switch).
 

--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -403,3 +403,19 @@
 - Health Connect availability check already existed — no changes needed there.
 
 **PR #374 opened, closes #367.**
+
+### 2026-04-10: Voice Input Wiring + RECORD_AUDIO Permission (Issue #392)
+**Implementation highlights:**
+- **VoiceInputButton wired** into ExerciseCardContent header. Tapping the mic icon triggers Android SpeechRecognizer and auto-fills the first incomplete set with parsed weight/reps.
+- **Full RECORD_AUDIO runtime permission flow**: (1) First tap → system permission dialog. (2) If denied once → rationale dialog explaining why mic is needed. (3) If permanently denied → dialog with "Open Settings" button to app settings.
+- **Coroutine scope fix**: Original code used `CoroutineScope(Dispatchers.Main).launch` which leaked. Replaced with `rememberCoroutineScope()` for lifecycle-safe collection.
+- **Bilingual voice recognition**: Changed SpeechRecognizer from hardcoded `en-US` to device locale (`Locale.getDefault().toLanguageTag()`), so Spanish speakers get native recognition. VoiceInputParser already handles both English and Spanish number words.
+- **Voice feedback**: Animated toast beneath exercise header shows parsed confirmation (e.g., "100kg × 5") or error message. Auto-dismisses after 2.5s.
+- **UX placement decision**: Mic button placed in exercise card header (not per-set-row) to avoid visual clutter. Targets first incomplete set automatically.
+
+**Key patterns:**
+- `Context.findActivity()` extension walks `ContextWrapper` chain to find the Activity, needed for `shouldShowRequestPermissionRationale()`.
+- `ActivityResultContracts.RequestPermission()` handles the system permission dialog lifecycle correctly in Compose.
+- Voice result flows: SpeechRecognizer → Flow<VoiceRecognitionState> → VoiceInputParser.parse() → ActiveWorkoutEvent.VoiceInput → ViewModel auto-fills set fields.
+
+**PR #405 opened, closes #392.**

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2395,3 +2395,53 @@ User directive for scope control. Audit sprint focused on closing MVP readiness 
 - Trinity: UI layer (resume prompt, event handling)
 
 **Status:** Implemented. PR #399 merged 2026-04-10. Feature live.
+
+---
+
+## Decision: Remove Dead Buttons from Settings (Tank)
+
+**By:** Tank (Backend Dev)  
+**Date:** 2026-04-10  
+**Issue:** #383  
+**PR:** #403  
+
+### Decision
+
+Remove non-functional Sign In button from SettingsScreen rather than leaving it visible with a stub dialog. The auth backend is \NoOpAuthService\ — the button does nothing. The Sign In row will be re-added when real authentication (Firebase or OAuth) is implemented.
+
+Also made App Version row non-clickable (read-only display). No reason for it to be tappable.
+
+### Rationale
+
+- Dead buttons erode user trust. If it doesn't work, don't show it.
+- NoOpAuthService explicitly returns \Result.failure()\ — there's no partial functionality to preserve.
+- Clean removal is safer than a "Coming Soon" label that might ship to production and stay forever.
+
+### Impact
+
+- **Trinity:** SettingsScreen layout changed — Sign In row removed from Account section. SettingsRow composable now accepts optional \onClick\ parameter.
+- **Tank (future):** When real auth is implemented, add Sign In row back with proper AuthService integration.
+- **No breaking changes:** SettingsViewModel and SettingsContract unchanged.
+
+---
+
+## Directive: Ralph Must Persist Across Context Limits (Copilot)
+
+**By:** Copilot (user request)  
+**Date:** 2026-04-10  
+**Captured for:** Team memory  
+
+### Directive
+
+Ralph must never stop due to context window or session time limits. Before stopping, validate context usage and compact the session to reduce usage. Keep Ralph running as long as possible.
+
+### Rationale
+
+User request — captured for team memory. Ralph's continuous improvement cycles depend on sustained context to track progress, validate changes, and iterate without interruption.
+
+### Implementation
+
+- Before shutdown: check token usage via Claude API
+- Compact session state (archive completed todos, merge duplicate learnings)
+- Persist checkpoint with technical details for next session rehydration
+- Avoid hard context limits — prefer graceful degradation (summarize oldest turns if needed)

--- a/.squad/decisions/inbox/neo-rpe-progression.md
+++ b/.squad/decisions/inbox/neo-rpe-progression.md
@@ -1,0 +1,26 @@
+# RPE-Based Progression Engine Design
+
+**By:** Neo (AI/ML Engineer)  
+**Date:** 2026-04-08  
+**Issue:** #393  
+**PR:** #406  
+
+## Decision
+
+Progression logic uses simple heuristic rules (not ML) based on RPE data:
+- **Progress:** All working sets RPE ≤7 → +2.5kg
+- **Regress:** Last 2 sets RPE 10 → −5% (rounded to 2.5kg)
+- **Maintain:** RPE 8-9 → same weight
+
+RPE picker is a tap-to-cycle widget (6→7→8→9→10→clear) rather than dropdown or slider, because speed matters during active workouts.
+
+## Implications
+
+- **Trinity (UI):** RPE column is 48dp wide in the set row. If layout feels cramped on smaller screens, we may need to make RPE collapsible or show it only after first set completion.
+- **Tank (Data):** Room DB is now version 6. Migration adds `rir INTEGER` column to `workout_sets`.
+- **Switch (Testing):** ProgressionEngine and RpeTrendService have unit tests. Integration tests for the full flow (log sets → get suggestion → verify weight) would be valuable.
+- **Neo (Future):** This heuristic engine is the foundation. Future ML-based autoregulation can replace the rules with a trained model once we have enough RPE data to train on.
+
+## Rationale
+
+Heuristics before ML — a well-tuned rule set is more explainable and debuggable than a black-box model. Users can understand "your RPE was low, so we increased weight" far better than "the model predicted you should increase weight."

--- a/.squad/decisions/inbox/trinity-voice-input.md
+++ b/.squad/decisions/inbox/trinity-voice-input.md
@@ -1,0 +1,29 @@
+# Voice Input UX Placement Decision
+
+**By:** Trinity (iOS/Android Dev)
+**Date:** 2026-04-10
+**Issue:** #392
+
+## Decision
+
+Voice input button is placed in the **exercise card header** (next to delete icon), not per-set-row. When triggered, it auto-fills the **first incomplete set** for that exercise.
+
+## Rationale
+
+- Adding a mic button to every SetRow creates visual clutter in an already compact layout (Set# | Weight | Reps | Complete).
+- One mic per exercise is sufficient — users typically voice-log the current working set.
+- Auto-targeting the first incomplete set matches natural workout flow (sets are completed in order).
+- Feedback toast shows parsed result beneath the header so user can verify before completing.
+
+## Permission Flow
+
+Three-state RECORD_AUDIO permission handling:
+1. **First request**: Direct system permission dialog
+2. **Previously denied**: Rationale dialog explaining why mic is needed, then system dialog
+3. **Permanently denied**: Dialog with "Open Settings" button redirecting to app settings
+
+## Implications
+
+- All voice input strings must be maintained in both `values/strings.xml` and `values-es/strings.xml`.
+- VoiceRecognitionService uses device locale instead of hardcoded en-US — future locale additions only require VoiceInputParser updates.
+- The `ActiveWorkoutEvent.VoiceInput` event already existed; no ViewModel changes were needed.

--- a/.squad/skills/shared/accessibility-audit/SKILL.md
+++ b/.squad/skills/shared/accessibility-audit/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: accessibility-audit
+confidence: low
+description: >
+  Mobile accessibility auditing for Android (Compose) and iOS (SwiftUI).
+  Covers TalkBack/VoiceOver testing, touch target sizing, content descriptions,
+  and gym-specific situational accessibility (sweaty hands, noisy environments,
+  one-handed use). Adapted from agency-agents Accessibility Auditor.
+  Use when: reviewing UI for accessibility, testing with assistive tech,
+  or building new screens. Relevant for Switch (QA) and Trinity (UI).
+source: https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-accessibility-auditor.md
+---
+
+# Accessibility Audit Skill
+
+## Core Principle
+Automated tools catch ~30% of accessibility issues. **Manual testing with assistive tech is mandatory.**
+For GymBro specifically: users have sweaty hands, are in noisy gyms, may use one hand, and are focused
+on their workout — not the screen. Every interaction must be fast, forgiving, and reachable.
+
+## GymBro-Specific Accessibility Concerns
+
+### Situational Disabilities in the Gym
+| Situation | Impact | Design Response |
+|-----------|--------|----------------|
+| Sweaty hands | Touch targets missed | Minimum 48dp touch targets, generous padding |
+| Noisy environment | Can't hear audio cues | Visual + haptic feedback always |
+| One-handed use | Can't reach top of screen | Critical actions in bottom half |
+| Between sets (rushed) | Low attention span | Minimal cognitive load, 1-2 tap actions |
+| Gloves | Reduced touch precision | Extra-large touch targets for set logging |
+| Bright gym lights | Screen glare | High contrast, large text |
+
+## Android Compose Accessibility Checklist
+
+### Content Descriptions
+```kotlin
+// ✅ Good — meaningful description
+Icon(
+    Icons.Default.Add,
+    contentDescription = stringResource(R.string.add_set)
+)
+
+// ❌ Bad — no description for interactive element
+IconButton(onClick = { }) {
+    Icon(Icons.Default.Delete, contentDescription = null) // FAIL
+}
+
+// ✅ Decorative only — explicitly null is correct
+Icon(
+    Icons.Default.FitnessCenter,
+    contentDescription = null // Decorative, text label nearby
+)
+```
+
+### Touch Targets
+```kotlin
+// Minimum 48dp touch target (WCAG 2.5.8 Target Size)
+IconButton(
+    onClick = { /* action */ },
+    modifier = Modifier.size(48.dp) // Enforced minimum
+) { /* icon */ }
+
+// For set logging buttons in gym context — go bigger (56dp+)
+Button(
+    onClick = onLogSet,
+    modifier = Modifier
+        .height(56.dp)
+        .fillMaxWidth()
+) { Text("Log Set") }
+```
+
+### Semantics & Roles
+```kotlin
+// Merge child semantics for TalkBack grouping
+Row(
+    modifier = Modifier.semantics(mergeDescendants = true) { }
+) {
+    Text("Bench Press")
+    Text("80kg × 8 reps")
+    // TalkBack reads: "Bench Press, 80kg × 8 reps"
+}
+
+// Custom actions for complex components
+Modifier.semantics {
+    customActions = listOf(
+        CustomAccessibilityAction("Delete set") { deleteSet(); true },
+        CustomAccessibilityAction("Edit weight") { editWeight(); true }
+    )
+}
+
+// State descriptions
+Modifier.semantics {
+    stateDescription = if (isCompleted) "Completed" else "Pending"
+}
+```
+
+### Focus Management
+```kotlin
+// After adding a set, move focus to the new row
+val focusRequester = remember { FocusRequester() }
+LaunchedEffect(setCount) {
+    focusRequester.requestFocus()
+}
+TextField(
+    modifier = Modifier.focusRequester(focusRequester),
+    // ...
+)
+```
+
+## iOS SwiftUI Accessibility Checklist
+
+### Labels & Traits
+```swift
+// Meaningful labels
+Button(action: addSet) {
+    Image(systemName: "plus.circle")
+}
+.accessibilityLabel("Add set")
+
+// Combined elements
+HStack {
+    Text("Bench Press")
+    Text("80kg × 8")
+}
+.accessibilityElement(children: .combine)
+
+// Custom actions
+.accessibilityAction(named: "Delete set") { deleteSet() }
+```
+
+## Audit Protocol for New Screens
+
+### Step 1: Automated Scan
+- Run Android Accessibility Scanner on the screen
+- Check Compose Preview accessibility info
+- Verify all interactive elements have content descriptions
+
+### Step 2: TalkBack/VoiceOver Walk-Through
+- Enable TalkBack (Android) or VoiceOver (iOS)
+- Navigate entire screen by swiping right (next element)
+- Complete the primary user flow using only TalkBack
+- Verify: logical reading order, all actions reachable, state changes announced
+
+### Step 3: Keyboard/Switch Navigation
+- Connect external keyboard
+- Tab through all interactive elements
+- Verify visible focus indicator on every element
+- Verify no focus traps
+
+### Step 4: Visual Checks
+- Text contrast ratio ≥ 4.5:1 (body) / ≥ 3:1 (large text)
+- Touch targets ≥ 48dp
+- Respects system font size (Dynamic Type / sp units)
+- Works in dark mode
+- No information conveyed by color alone
+
+## Severity Classification
+| Severity | Definition | Example |
+|----------|-----------|---------|
+| 🔴 Critical | Blocks task completion for AT users | Button with no label, focus trap |
+| 🟠 Serious | Major barrier, workaround exists | Wrong reading order, missing state |
+| 🟡 Moderate | Causes difficulty | Small touch target, low contrast |
+| ⚪ Minor | Annoyance | Verbose descriptions, redundant info |
+
+## Report Template
+```markdown
+## Accessibility Audit — [Screen Name]
+**Date:** YYYY-MM-DD | **Platform:** Android/iOS | **AT Tested:** TalkBack/VoiceOver
+
+### Summary
+- Issues found: X (Critical: X, Serious: X, Moderate: X, Minor: X)
+- Conformance: PASS / PARTIAL / FAIL
+
+### Issues
+#### [Issue Title]
+- **WCAG:** [Criterion number and name]
+- **Severity:** Critical/Serious/Moderate/Minor
+- **Impact:** [Who is affected and how]
+- **Current:** [What happens now]
+- **Fix:** [Code-level fix with example]
+
+### What's Working Well
+- [Positive findings to preserve]
+```

--- a/.squad/skills/shared/behavioral-nudges/SKILL.md
+++ b/.squad/skills/shared/behavioral-nudges/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: behavioral-nudges
+confidence: low
+description: >
+  Behavioral psychology patterns for fitness app engagement and habit formation.
+  Covers nudge design, momentum building, cognitive load reduction, and
+  motivational reinforcement — without over-gamification. Adapted from
+  agency-agents Behavioral Nudge Engine for fitness/gym context.
+  Use when: designing AI coach interactions, notifications, onboarding flows,
+  workout reminders, progress feedback, or any user engagement feature.
+  Relevant for Neo (AI coach) and Trinity (UI/UX).
+source: https://github.com/msitarzewski/agency-agents/blob/main/product/product-behavioral-nudge-engine.md
+---
+
+# Behavioral Nudges Skill — Fitness Context
+
+## Core Principle
+**Show the ONE next action, not the full plan.** Overwhelm kills motivation.
+GymBro targets serious lifters — respect their intelligence, don't patronize.
+Nudges should feel like a knowledgeable training partner, not a pushy app.
+
+## ⚠️ GymBro Constraint: No Over-Gamification
+Per team decision: avoid over-gamification. No XP points, no streaks with punishment,
+no leaderboards. Reinforcement should feel like a good training log, not a mobile game.
+
+## The Nudge Framework for Gym Context
+
+### 1. Pre-Workout Nudges (Activation)
+**Goal:** Get them to the gym. This is the hardest part.
+
+| Pattern | Example | Psychology |
+|---------|---------|-----------|
+| Default bias | "Your Push day is ready. Tap to start." (not "What do you want to train?") | Reduce decision fatigue |
+| Implementation intention | "You usually train at 6pm on Tuesdays. Ready?" | Anchor to existing habit |
+| Social proof (subtle) | "Bench press is the #1 exercise logged today" | Normative influence |
+| Loss aversion | "You're 2 sessions into your mesocycle — keep the momentum" | Protect investment |
+
+### 2. During-Workout Nudges (Momentum)
+**Goal:** Keep logging, maintain intensity.
+
+| Pattern | Example | Psychology |
+|---------|---------|-----------|
+| Micro-celebration | "PR! 85kg × 8 — new 8RM 🏆" | Immediate reinforcement |
+| Smart defaults | Pre-fill weight from last session + progression | Reduce friction |
+| Progress anchor | "Set 3/4 — almost there" | Goal gradient effect |
+| RPE check-in | "How hard was that? (RPE 7-8-9-10)" | Self-awareness, not punishment |
+
+### 3. Post-Workout Nudges (Reinforcement)
+**Goal:** Make them feel good about what they did.
+
+| Pattern | Example | Psychology |
+|---------|---------|-----------|
+| Summary win | "45 min, 12 sets, 2 PRs. Solid session." | Completion reward |
+| Trend positive | "Volume is up 8% this week vs last" | Progress visibility |
+| Recovery nudge | "Rest day tomorrow — your muscles need it" | Permission to rest |
+| Off-ramp | Show summary, no call to action. They're done. | Respect completion |
+
+### 4. Between-Session Nudges (Retention)
+**Goal:** Bring them back without being annoying.
+
+| Pattern | Example | Psychology |
+|---------|---------|-----------|
+| Gentle reminder | "Push day ready when you are" (once, then silence) | No nagging |
+| Curiosity hook | "Your squat trend looks interesting — check progress?" | Information gap |
+| Coach suggestion | "Based on last week's RPE, I'd suggest..." | Expert authority |
+| ❌ DON'T | "You haven't trained in 3 days! 😢" | Guilt = churn |
+
+## Notification Strategy
+
+### Frequency Rules
+- Max 1 push notification per day (non-workout days)
+- Zero notifications on rest days unless user opted in
+- Workout day: 1 reminder at their usual time, that's it
+- Never stack notifications — replace, don't add
+
+### Tone
+- ✅ "Your workout is ready" (neutral, enabling)
+- ✅ "New PR on deadlift! 140kg × 5" (celebrating facts)
+- ❌ "Don't break your streak!" (guilt-driven)
+- ❌ "You're falling behind!" (punishment)
+- ❌ "🔥🔥🔥 CRUSH IT TODAY" (cringe)
+
+## AI Coach Conversation Nudges
+
+### After a Failed Set
+```
+User logs: Bench 80kg × 4 (target was 8)
+Bad: "You failed your target. Try harder next time."
+Good: "Tough set. RPE 10? I'll adjust next session — 
+       maybe 75kg × 8 to rebuild volume."
+```
+
+### Suggesting a Deload
+```
+Bad: "Your performance is declining. You need to deload."
+Good: "RPE has been trending up the last 2 weeks while 
+       volume stayed flat. A lighter week now usually 
+       means a stronger week after. Want me to program one?"
+```
+
+### After Consistent Training
+```
+Bad: "Great job! Keep it up! 🌟⭐💪"
+Good: "4 weeks consistent, volume up 12%. 
+       Your squat 5RM estimate moved from 120 to 125kg."
+```
+
+## Implementation Checklist
+- [ ] Smart defaults: pre-fill from last session + progression suggestion
+- [ ] PR detection: automatic, with subtle celebration (not a fireworks screen)
+- [ ] RPE collection: quick picker, not a form
+- [ ] Post-workout summary: facts and trends, not cheerleading
+- [ ] Notification: max 1/day, respectful tone, easy to disable
+- [ ] Coach tone: knowledgeable partner, never patronizing
+- [ ] No streaks, no XP, no points, no leaderboards
+- [ ] Recovery awareness: suggest rest when fatigue signals are high

--- a/.squad/skills/shared/performance-benchmarking/SKILL.md
+++ b/.squad/skills/shared/performance-benchmarking/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: performance-benchmarking
+confidence: low
+description: >
+  Mobile app performance benchmarking methodology. Covers cold start measurement,
+  UI rendering profiling, memory/battery analysis, and Android-specific tooling.
+  Adapted from agency-agents Performance Benchmarker for mobile-first context.
+  Use when: startup audit, scroll jank, memory leaks, battery drain, or any
+  performance-related issue. Relevant for Switch (testing) and Trinity (UI perf).
+source: https://github.com/msitarzewski/agency-agents/blob/main/testing/testing-performance-benchmarker.md
+---
+
+# Performance Benchmarking Skill
+
+## Core Principle
+Always establish a **baseline before optimizing**. Measure → Identify → Fix → Verify.
+Never optimize based on gut feeling — use profiling data.
+
+## Android Cold Start Measurement
+
+### Baseline with ADB
+```bash
+# Measure cold start time (fully-qualified activity)
+adb shell am start-activity -W -S com.gymbro.app/.MainActivity
+# Look for: TotalTime, WaitTime, ThisTime in output
+
+# Trace startup for detailed analysis
+adb shell am start -W -S --start-profiler /data/local/tmp/startup.trace com.gymbro.app/.MainActivity
+```
+
+### Key Metrics
+| Metric | Target | Tool |
+|--------|--------|------|
+| Cold start | < 1.5s | `adb shell am start-activity -W -S` |
+| Warm start | < 500ms | Same command without -S |
+| First frame | < 700ms | Macrobenchmark `StartupTimingMetric` |
+| TTID (Time to Initial Display) | < 1s | Logcat `Displayed` line |
+| TTFD (Time to Full Display) | < 2s | `reportFullyDrawn()` in Activity |
+
+### Jetpack Macrobenchmark Setup
+```kotlin
+@RunWith(AndroidJUnit4::class)
+class StartupBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startup() = benchmarkRule.measureRepeated(
+        packageName = "com.gymbro.app",
+        metrics = listOf(StartupTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.COLD
+    ) {
+        pressHome()
+        startActivityAndWait()
+    }
+}
+```
+
+## UI Rendering Performance
+
+### Compose-Specific Profiling
+```kotlin
+// Add to debug builds for recomposition tracking
+@Composable
+fun DebugRecomposition(tag: String) {
+    val ref = remember { Ref(0) }
+    SideEffect { ref.value++ }
+    Log.d("Recomposition", "$tag: ${ref.value}")
+}
+```
+
+### Jank Detection
+- Target: **0 janky frames** during scroll in LazyColumn
+- Use Android Studio Profiler → Frames chart
+- Watch for frames > 16ms (60fps) or > 8ms (120fps)
+- Common causes: allocations in composition, unstable keys, missing `key` in LazyColumn items
+
+## Memory Analysis
+
+### Baseline Memory Profile
+```bash
+# Capture heap dump
+adb shell am dumpheap com.gymbro.app /data/local/tmp/heap.hprof
+adb pull /data/local/tmp/heap.hprof
+
+# Monitor memory in real-time
+adb shell dumpsys meminfo com.gymbro.app
+```
+
+### Targets
+| Metric | Threshold | Alert |
+|--------|-----------|-------|
+| PSS (Proportional Set Size) | < 150MB active | > 200MB = investigate |
+| Native heap growth | Stable after warmup | Continuous growth = leak |
+| Java heap | < 80% of max | > 90% = GC pressure |
+
+## Battery Impact
+- Profile with Battery Historian or Android Studio Energy Profiler
+- Watch for: wakelocks, excessive network, GPS polling, sensor abuse
+- Gym context: sensors (accelerometer for rep counting) should batch, not stream
+
+## Performance Report Template
+```markdown
+## Performance Report — [Feature/Screen]
+**Date:** YYYY-MM-DD | **Device:** [Model, API level] | **Build:** [variant]
+
+### Startup
+- Cold start: Xms (target: <1500ms) ✅/❌
+- Warm start: Xms (target: <500ms) ✅/❌
+
+### Rendering
+- Janky frames during scroll: X/Y (target: 0) ✅/❌
+- Worst frame time: Xms
+
+### Memory
+- Baseline PSS: XMB
+- After 5min usage: XMB (delta: +XMB)
+- Leak detected: yes/no
+
+### Recommendations
+1. [High priority fix]
+2. [Medium priority fix]
+3. [Low priority / future]
+```
+
+## Workflow
+1. **Baseline** — Measure current state on target device
+2. **Profile** — Use Android Studio Profiler or Macrobenchmark
+3. **Identify** — Find the bottleneck (startup, rendering, memory, battery)
+4. **Fix** — Apply targeted optimization
+5. **Verify** — Re-measure and compare with baseline
+6. **Guard** — Add benchmark test to CI to prevent regression

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -13,7 +13,7 @@
 | Name | Role | Charter | Status |
 |------|------|---------|--------|
 | Morpheus | Lead | .squad/agents/morpheus/charter.md | 🏗️ Lead |
-| Trinity | iOS Dev | .squad/agents/trinity/charter.md | ⚛️ Active |
+| Trinity | Mobile Dev | .squad/agents/trinity/charter.md | ⚛️ Active |
 | Neo | AI/ML Engineer | .squad/agents/neo/charter.md | 🔧 Active |
 | Tank | Backend Dev | .squad/agents/tank/charter.md | 🔧 Active |
 | Switch | Tester | .squad/agents/switch/charter.md | 🧪 Active |

--- a/android/core/schemas/com.gymbro.core.database.GymBroDatabase/6.json
+++ b/android/core/schemas/com.gymbro.core.database.GymBroDatabase/6.json
@@ -1,0 +1,449 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "b40c72b67205c834ef9e4a68ec76a328",
+    "entities": [
+      {
+        "tableName": "exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `muscleGroup` TEXT NOT NULL, `category` TEXT NOT NULL, `equipment` TEXT NOT NULL, `description` TEXT NOT NULL, `youtubeUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleGroup",
+            "columnName": "muscleGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "equipment",
+            "columnName": "equipment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeUrl",
+            "columnName": "youtubeUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `startedAt` INTEGER NOT NULL, `completedAt` INTEGER, `durationSeconds` INTEGER NOT NULL, `notes` TEXT NOT NULL, `completed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "workout_sets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `workoutId` TEXT NOT NULL, `exerciseId` TEXT NOT NULL, `setNumber` INTEGER NOT NULL, `weight` REAL NOT NULL, `reps` INTEGER NOT NULL, `rpe` REAL, `rir` INTEGER, `isWarmup` INTEGER NOT NULL, `completedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`workoutId`) REFERENCES `workouts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`exerciseId`) REFERENCES `exercises`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setNumber",
+            "columnName": "setNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rpe",
+            "columnName": "rpe",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "rir",
+            "columnName": "rir",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isWarmup",
+            "columnName": "isWarmup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_sets_workoutId",
+            "unique": false,
+            "columnNames": [
+              "workoutId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_sets_workoutId` ON `${TABLE_NAME}` (`workoutId`)"
+          },
+          {
+            "name": "index_workout_sets_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_sets_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workouts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "workoutId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "exercises",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exerciseId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "workout_templates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `lastUsedAt` INTEGER, `isBuiltIn` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isBuiltIn",
+            "columnName": "isBuiltIn",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "template_exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `templateId` TEXT NOT NULL, `exerciseId` TEXT NOT NULL, `exerciseName` TEXT NOT NULL, `muscleGroup` TEXT NOT NULL, `targetSets` INTEGER NOT NULL, `targetReps` INTEGER NOT NULL, `targetWeightKg` REAL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`templateId`) REFERENCES `workout_templates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`exerciseId`) REFERENCES `exercises`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "templateId",
+            "columnName": "templateId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseName",
+            "columnName": "exerciseName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleGroup",
+            "columnName": "muscleGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSets",
+            "columnName": "targetSets",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetReps",
+            "columnName": "targetReps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetWeightKg",
+            "columnName": "targetWeightKg",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_template_exercises_templateId",
+            "unique": false,
+            "columnNames": [
+              "templateId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_template_exercises_templateId` ON `${TABLE_NAME}` (`templateId`)"
+          },
+          {
+            "name": "index_template_exercises_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_template_exercises_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workout_templates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "templateId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "exercises",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exerciseId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "in_progress_workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workoutId` TEXT NOT NULL, `exercisesJson` TEXT NOT NULL, `elapsedSeconds` INTEGER NOT NULL, `totalVolume` REAL NOT NULL, `totalSets` INTEGER NOT NULL, `restTimerSeconds` INTEGER NOT NULL, `restTimerTotal` INTEGER NOT NULL, `isRestTimerActive` INTEGER NOT NULL, `lastSavedAt` INTEGER NOT NULL, PRIMARY KEY(`workoutId`))",
+        "fields": [
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exercisesJson",
+            "columnName": "exercisesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedSeconds",
+            "columnName": "elapsedSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalVolume",
+            "columnName": "totalVolume",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSets",
+            "columnName": "totalSets",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerSeconds",
+            "columnName": "restTimerSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTimerTotal",
+            "columnName": "restTimerTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRestTimerActive",
+            "columnName": "isRestTimerActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSavedAt",
+            "columnName": "lastSavedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "workoutId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b40c72b67205c834ef9e4a68ec76a328')"
+    ]
+  }
+}

--- a/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/GymBroDatabase.kt
@@ -21,7 +21,7 @@ import com.gymbro.core.database.entity.WorkoutTemplateEntity
         TemplateExerciseEntity::class,
         InProgressWorkoutEntity::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = true,
 )
 abstract class GymBroDatabase : RoomDatabase() {

--- a/android/core/src/main/java/com/gymbro/core/database/Migrations.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/Migrations.kt
@@ -139,4 +139,11 @@ object Migrations {
             """.trimIndent())
         }
     }
+
+    val MIGRATION_5_6 = object : Migration(5, 6) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // Add RIR (Reps in Reserve) column to workout_sets for RPE-based progression
+            db.execSQL("ALTER TABLE workout_sets ADD COLUMN rir INTEGER")
+        }
+    }
 }

--- a/android/core/src/main/java/com/gymbro/core/database/entity/WorkoutSetEntity.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/entity/WorkoutSetEntity.kt
@@ -36,6 +36,7 @@ data class WorkoutSetEntity(
     val weight: Double,
     val reps: Int,
     val rpe: Double? = null,
+    val rir: Int? = null,
     val isWarmup: Boolean = false,
     val completedAt: Long = System.currentTimeMillis(),
 )

--- a/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
+++ b/android/core/src/main/java/com/gymbro/core/di/DatabaseModule.kt
@@ -40,7 +40,8 @@ object DatabaseModule {
                 Migrations.MIGRATION_1_2,
                 Migrations.MIGRATION_2_3,
                 Migrations.MIGRATION_3_4,
-                Migrations.MIGRATION_4_5
+                Migrations.MIGRATION_4_5,
+                Migrations.MIGRATION_5_6,
             )
             .addCallback(SeedDatabaseCallback(context))
             .build()

--- a/android/core/src/main/java/com/gymbro/core/model/Workout.kt
+++ b/android/core/src/main/java/com/gymbro/core/model/Workout.kt
@@ -18,6 +18,7 @@ data class ExerciseSet(
     val weightKg: Double,
     val reps: Int,
     val rpe: Double? = null,
+    val rir: Int? = null,
     val isWarmup: Boolean = false,
     val completedAt: Instant = Instant.now(),
 ) {
@@ -28,4 +29,12 @@ data class ExerciseSet(
     /** Convert stored kg to lbs for display */
     val weightLbs: Double
         get() = weightKg * 2.20462
+
+    companion object {
+        /** Convert RPE (1-10) to RIR (Reps in Reserve). RPE 10 = 0 RIR, RPE 7 = 3 RIR */
+        fun rpeToRir(rpe: Double): Int = (10 - rpe).coerceIn(0.0, 5.0).toInt()
+
+        /** Convert RIR (0-5) to RPE (1-10). 0 RIR = RPE 10, 3 RIR = RPE 7 */
+        fun rirToRpe(rir: Int): Double = (10.0 - rir).coerceIn(5.0, 10.0)
+    }
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
@@ -64,6 +64,7 @@ class WorkoutRepositoryImpl @Inject constructor(
                     weight = set.weightKg,
                     reps = set.reps,
                     rpe = set.rpe,
+                    rir = set.rir,
                     isWarmup = set.isWarmup,
                     completedAt = set.completedAt.toEpochMilli(),
                 )
@@ -318,6 +319,7 @@ private fun WorkoutWithSets.toDomain(): Workout {
             weightKg = set.weight,
             reps = set.reps,
             rpe = set.rpe,
+            rir = set.rir,
             isWarmup = set.isWarmup,
             completedAt = Instant.ofEpochMilli(set.completedAt),
         )

--- a/android/core/src/main/java/com/gymbro/core/service/ProgressionEngine.kt
+++ b/android/core/src/main/java/com/gymbro/core/service/ProgressionEngine.kt
@@ -1,0 +1,98 @@
+package com.gymbro.core.service
+
+import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.database.entity.WorkoutSetEntity
+import javax.inject.Inject
+
+/**
+ * Performance-based progression engine using RPE/RIR data.
+ *
+ * Rules:
+ * - Auto-progression: all working sets completed at RPE ≤7 → suggest +2.5kg next session
+ * - Auto-regression: last 2 working sets at RPE 10 or incomplete → suggest -5% weight
+ * - No RPE data: fall back to last weight (no suggestion)
+ */
+class ProgressionEngine @Inject constructor(
+    private val workoutDao: WorkoutDao,
+) {
+
+    data class ProgressionSuggestion(
+        val suggestedWeightKg: Double,
+        val reason: ProgressionReason,
+    )
+
+    enum class ProgressionReason {
+        /** All sets were easy (RPE ≤ 7) — increase weight */
+        PROGRESS,
+        /** Last sets were maximal effort or failed — reduce weight */
+        REGRESS,
+        /** Maintain current weight — RPE in moderate range */
+        MAINTAIN,
+        /** No RPE data available — use last weight */
+        NO_DATA,
+    }
+
+    /**
+     * Calculate suggested weight for the next session of a given exercise.
+     * Analyzes the most recent workout's working sets for that exercise.
+     */
+    suspend fun getSuggestion(exerciseId: String): ProgressionSuggestion? {
+        val sets = workoutDao.getSetsByExercise(exerciseId)
+        if (sets.isEmpty()) return null
+
+        // Get the most recent workout's sets (group by workoutId, take latest)
+        val lastWorkoutId = sets.last().workoutId
+        val lastWorkoutSets = sets.filter { it.workoutId == lastWorkoutId && !it.isWarmup }
+
+        if (lastWorkoutSets.isEmpty()) return null
+
+        val lastWeight = lastWorkoutSets.maxOf { it.weight }
+        val setsWithRpe = lastWorkoutSets.filter { it.rpe != null }
+
+        // No RPE data — can't make a recommendation
+        if (setsWithRpe.isEmpty()) {
+            return ProgressionSuggestion(
+                suggestedWeightKg = lastWeight,
+                reason = ProgressionReason.NO_DATA,
+            )
+        }
+
+        // Check regression: last 2 sets at RPE 10
+        val shouldRegress = checkRegression(lastWorkoutSets)
+        if (shouldRegress) {
+            val regressedWeight = roundToNearest2_5(lastWeight * 0.95)
+            return ProgressionSuggestion(
+                suggestedWeightKg = regressedWeight,
+                reason = ProgressionReason.REGRESS,
+            )
+        }
+
+        // Check progression: all working sets RPE ≤ 7
+        val shouldProgress = setsWithRpe.all { (it.rpe ?: 10.0) <= 7.0 }
+        if (shouldProgress) {
+            return ProgressionSuggestion(
+                suggestedWeightKg = lastWeight + 2.5,
+                reason = ProgressionReason.PROGRESS,
+            )
+        }
+
+        // Moderate RPE (8-9) — maintain current weight
+        return ProgressionSuggestion(
+            suggestedWeightKg = lastWeight,
+            reason = ProgressionReason.MAINTAIN,
+        )
+    }
+
+    private fun checkRegression(workingSets: List<WorkoutSetEntity>): Boolean {
+        if (workingSets.size < 2) return false
+        val lastTwo = workingSets.takeLast(2)
+        return lastTwo.all { set ->
+            val rpe = set.rpe ?: return@all false
+            rpe >= 10.0
+        }
+    }
+
+    private fun roundToNearest2_5(value: Double): Double {
+        return Math.round(value / 2.5) * 2.5
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/service/RpeTrendService.kt
+++ b/android/core/src/main/java/com/gymbro/core/service/RpeTrendService.kt
@@ -1,0 +1,101 @@
+package com.gymbro.core.service
+
+import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.database.entity.WorkoutSetEntity
+import javax.inject.Inject
+
+/**
+ * Tracks RPE trends per exercise using a 7-day rolling average.
+ * Flags exercises where RPE is trending upward (fatigue signal).
+ */
+class RpeTrendService @Inject constructor(
+    private val workoutDao: WorkoutDao,
+) {
+
+    data class RpeTrend(
+        val exerciseId: String,
+        val currentAvgRpe: Double,
+        val previousAvgRpe: Double?,
+        val trend: TrendDirection,
+        val isFatigueWarning: Boolean,
+    )
+
+    enum class TrendDirection {
+        RISING,
+        STABLE,
+        FALLING,
+    }
+
+    /**
+     * Calculate RPE trend for a specific exercise.
+     * Compares the most recent 7-day window to the prior 7-day window.
+     */
+    suspend fun getTrend(exerciseId: String): RpeTrend? {
+        val sets = workoutDao.getSetsByExercise(exerciseId)
+        val setsWithRpe = sets.filter { it.rpe != null && !it.isWarmup }
+
+        if (setsWithRpe.isEmpty()) return null
+
+        val now = System.currentTimeMillis()
+        val sevenDaysMs = 7L * 24 * 60 * 60 * 1000
+        val fourteenDaysMs = 14L * 24 * 60 * 60 * 1000
+
+        val recentSets = setsWithRpe.filter { it.completedAt >= now - sevenDaysMs }
+        val previousSets = setsWithRpe.filter {
+            it.completedAt >= now - fourteenDaysMs && it.completedAt < now - sevenDaysMs
+        }
+
+        if (recentSets.isEmpty()) {
+            // No recent data — use all available data as current
+            val avgRpe = setsWithRpe.mapNotNull { it.rpe }.average()
+            return RpeTrend(
+                exerciseId = exerciseId,
+                currentAvgRpe = avgRpe,
+                previousAvgRpe = null,
+                trend = TrendDirection.STABLE,
+                isFatigueWarning = false,
+            )
+        }
+
+        val currentAvg = recentSets.mapNotNull { it.rpe }.average()
+
+        if (previousSets.isEmpty()) {
+            return RpeTrend(
+                exerciseId = exerciseId,
+                currentAvgRpe = currentAvg,
+                previousAvgRpe = null,
+                trend = TrendDirection.STABLE,
+                isFatigueWarning = currentAvg >= 9.0,
+            )
+        }
+
+        val previousAvg = previousSets.mapNotNull { it.rpe }.average()
+        val delta = currentAvg - previousAvg
+
+        val trend = when {
+            delta > 0.5 -> TrendDirection.RISING
+            delta < -0.5 -> TrendDirection.FALLING
+            else -> TrendDirection.STABLE
+        }
+
+        // Fatigue warning: RPE trending up AND current average ≥ 8.5
+        val isFatigueWarning = trend == TrendDirection.RISING && currentAvg >= 8.5
+
+        return RpeTrend(
+            exerciseId = exerciseId,
+            currentAvgRpe = currentAvg,
+            previousAvgRpe = previousAvg,
+            trend = trend,
+            isFatigueWarning = isFatigueWarning,
+        )
+    }
+
+    /**
+     * Get fatigue warnings for all exercises with history.
+     * Returns only exercises flagged as fatiguing.
+     */
+    suspend fun getFatigueWarnings(): List<RpeTrend> {
+        val exerciseIds = workoutDao.getExerciseIdsWithHistory()
+        return exerciseIds.mapNotNull { getTrend(it) }.filter { it.isFatigueWarning }
+    }
+}

--- a/android/core/src/main/java/com/gymbro/core/service/SmartDefaultsService.kt
+++ b/android/core/src/main/java/com/gymbro/core/service/SmartDefaultsService.kt
@@ -8,6 +8,7 @@ import javax.inject.Inject
 
 class SmartDefaultsService @Inject constructor(
     private val workoutDao: WorkoutDao,
+    private val progressionEngine: ProgressionEngine,
 ) {
     
     suspend fun getDefaultWeight(exerciseId: String): Double? {
@@ -39,16 +40,19 @@ class SmartDefaultsService @Inject constructor(
     data class SmartDefaults(
         val weight: Double?,
         val reps: Int?,
+        val progressionReason: ProgressionEngine.ProgressionReason? = null,
     )
     
     suspend fun getDefaults(exerciseId: String): SmartDefaults {
         val result = retryWithBackoff {
             runCatchingAsResult {
+                val suggestion = progressionEngine.getSuggestion(exerciseId)
                 val sets = workoutDao.getSetsByExercise(exerciseId)
                 val lastSet = sets.lastOrNull()
                 SmartDefaults(
-                    weight = lastSet?.weight,
+                    weight = suggestion?.suggestedWeightKg ?: lastSet?.weight,
                     reps = lastSet?.reps,
+                    progressionReason = suggestion?.reason,
                 )
             }
         }

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -473,7 +473,11 @@
     <string name="active_workout_header_set">SERIE</string>
     <string name="active_workout_header_kg">KG</string>
     <string name="active_workout_header_reps">REPS</string>
+    <string name="active_workout_header_rpe">RPE</string>
     <string name="active_workout_set_completed">Serie %d completada</string>
+    <string name="active_workout_rpe_label">RPE</string>
+    <string name="active_workout_progression_up">↑ +2.5kg sugerido (RPE bajo)</string>
+    <string name="active_workout_progression_down">↓ −5%% sugerido (RPE alto)</string>
 
     <!-- Progress (additional new) -->
     <string name="progress_e1rm_trend">Tendencia Est. 1RM</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -473,7 +473,11 @@
     <string name="active_workout_header_set">SET</string>
     <string name="active_workout_header_kg">KG</string>
     <string name="active_workout_header_reps">REPS</string>
+    <string name="active_workout_header_rpe">RPE</string>
     <string name="active_workout_set_completed">Set %d completed</string>
+    <string name="active_workout_rpe_label">RPE</string>
+    <string name="active_workout_progression_up">↑ +2.5kg suggested (RPE was easy)</string>
+    <string name="active_workout_progression_down">↓ −5%% suggested (RPE was high)</string>
 
     <!-- Progress (additional) -->
     <string name="progress_e1rm_trend">Estimated 1RM Trend</string>

--- a/android/core/src/test/java/com/gymbro/core/service/ProgressionEngineTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/service/ProgressionEngineTest.kt
@@ -1,0 +1,156 @@
+package com.gymbro.core.service
+
+import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.database.entity.WorkoutSetEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+class ProgressionEngineTest {
+
+    private lateinit var workoutDao: WorkoutDao
+    private lateinit var engine: ProgressionEngine
+
+    private val exerciseId = "bench-press-id"
+    private val workoutId = "workout-1"
+
+    @Before
+    fun setup() {
+        workoutDao = mockk()
+        engine = ProgressionEngine(workoutDao)
+    }
+
+    @Test
+    fun `returns null when no history exists`() = runTest {
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns emptyList()
+        assertNull(engine.getSuggestion(exerciseId))
+    }
+
+    @Test
+    fun `suggests progression when all sets RPE 7 or below`() = runTest {
+        val sets = listOf(
+            createSet(weight = 100.0, rpe = 6.0),
+            createSet(weight = 100.0, rpe = 7.0),
+            createSet(weight = 100.0, rpe = 7.0),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = engine.getSuggestion(exerciseId)
+        assertNotNull(result)
+        assertEquals(102.5, result!!.suggestedWeightKg, 0.01)
+        assertEquals(ProgressionEngine.ProgressionReason.PROGRESS, result.reason)
+    }
+
+    @Test
+    fun `suggests regression when last 2 sets at RPE 10`() = runTest {
+        val sets = listOf(
+            createSet(weight = 100.0, rpe = 8.0),
+            createSet(weight = 100.0, rpe = 10.0),
+            createSet(weight = 100.0, rpe = 10.0),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = engine.getSuggestion(exerciseId)
+        assertNotNull(result)
+        assertEquals(95.0, result!!.suggestedWeightKg, 0.01)
+        assertEquals(ProgressionEngine.ProgressionReason.REGRESS, result.reason)
+    }
+
+    @Test
+    fun `suggests maintain when RPE is moderate (8-9)`() = runTest {
+        val sets = listOf(
+            createSet(weight = 100.0, rpe = 8.0),
+            createSet(weight = 100.0, rpe = 8.5),
+            createSet(weight = 100.0, rpe = 9.0),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = engine.getSuggestion(exerciseId)
+        assertNotNull(result)
+        assertEquals(100.0, result!!.suggestedWeightKg, 0.01)
+        assertEquals(ProgressionEngine.ProgressionReason.MAINTAIN, result.reason)
+    }
+
+    @Test
+    fun `returns NO_DATA when no RPE logged`() = runTest {
+        val sets = listOf(
+            createSet(weight = 100.0, rpe = null),
+            createSet(weight = 100.0, rpe = null),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = engine.getSuggestion(exerciseId)
+        assertNotNull(result)
+        assertEquals(100.0, result!!.suggestedWeightKg, 0.01)
+        assertEquals(ProgressionEngine.ProgressionReason.NO_DATA, result.reason)
+    }
+
+    @Test
+    fun `only considers most recent workout sets`() = runTest {
+        val sets = listOf(
+            // Old workout — RPE was high
+            createSet(weight = 90.0, rpe = 10.0, workoutId = "workout-old"),
+            createSet(weight = 90.0, rpe = 10.0, workoutId = "workout-old"),
+            // Recent workout — RPE was easy
+            createSet(weight = 100.0, rpe = 6.0, workoutId = workoutId),
+            createSet(weight = 100.0, rpe = 7.0, workoutId = workoutId),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = engine.getSuggestion(exerciseId)
+        assertNotNull(result)
+        assertEquals(ProgressionEngine.ProgressionReason.PROGRESS, result!!.reason)
+        assertEquals(102.5, result.suggestedWeightKg, 0.01)
+    }
+
+    @Test
+    fun `regression rounds to nearest 2_5 kg`() = runTest {
+        val sets = listOf(
+            createSet(weight = 87.5, rpe = 10.0),
+            createSet(weight = 87.5, rpe = 10.0),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = engine.getSuggestion(exerciseId)
+        assertNotNull(result)
+        // 87.5 * 0.95 = 83.125, rounded to nearest 2.5 = 82.5
+        assertEquals(82.5, result!!.suggestedWeightKg, 0.01)
+    }
+
+    @Test
+    fun `skips warmup sets`() = runTest {
+        val sets = listOf(
+            createSet(weight = 60.0, rpe = 5.0, isWarmup = true),
+            createSet(weight = 100.0, rpe = 7.0),
+            createSet(weight = 100.0, rpe = 7.0),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = engine.getSuggestion(exerciseId)
+        assertNotNull(result)
+        assertEquals(ProgressionEngine.ProgressionReason.PROGRESS, result!!.reason)
+    }
+
+    private fun createSet(
+        weight: Double,
+        rpe: Double?,
+        workoutId: String = this.workoutId,
+        isWarmup: Boolean = false,
+    ): WorkoutSetEntity {
+        return WorkoutSetEntity(
+            id = UUID.randomUUID().toString(),
+            workoutId = workoutId,
+            exerciseId = exerciseId,
+            setNumber = 1,
+            weight = weight,
+            reps = 8,
+            rpe = rpe,
+            isWarmup = isWarmup,
+            completedAt = System.currentTimeMillis(),
+        )
+    }
+}

--- a/android/core/src/test/java/com/gymbro/core/service/RpeTrendServiceTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/service/RpeTrendServiceTest.kt
@@ -1,0 +1,149 @@
+package com.gymbro.core.service
+
+import com.gymbro.core.database.dao.WorkoutDao
+import com.gymbro.core.database.entity.WorkoutSetEntity
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+class RpeTrendServiceTest {
+
+    private lateinit var workoutDao: WorkoutDao
+    private lateinit var service: RpeTrendService
+
+    private val exerciseId = "squat-id"
+
+    @Before
+    fun setup() {
+        workoutDao = mockk()
+        service = RpeTrendService(workoutDao)
+    }
+
+    @Test
+    fun `returns null when no history exists`() = runTest {
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns emptyList()
+        assertNull(service.getTrend(exerciseId))
+    }
+
+    @Test
+    fun `returns null when no RPE data exists`() = runTest {
+        val sets = listOf(
+            createSet(rpe = null, completedAt = System.currentTimeMillis()),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+        assertNull(service.getTrend(exerciseId))
+    }
+
+    @Test
+    fun `detects rising trend when recent RPE is higher than previous`() = runTest {
+        val now = System.currentTimeMillis()
+        val oneDay = 24 * 60 * 60 * 1000L
+
+        val sets = listOf(
+            // Previous week: RPE ~7
+            createSet(rpe = 7.0, completedAt = now - 10 * oneDay),
+            createSet(rpe = 7.0, completedAt = now - 10 * oneDay),
+            createSet(rpe = 7.5, completedAt = now - 9 * oneDay),
+            // Recent week: RPE ~9
+            createSet(rpe = 9.0, completedAt = now - 2 * oneDay),
+            createSet(rpe = 9.0, completedAt = now - 2 * oneDay),
+            createSet(rpe = 9.5, completedAt = now - 1 * oneDay),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = service.getTrend(exerciseId)
+        assertNotNull(result)
+        assertEquals(RpeTrendService.TrendDirection.RISING, result!!.trend)
+        assertTrue(result.isFatigueWarning)
+    }
+
+    @Test
+    fun `detects falling trend when recent RPE is lower`() = runTest {
+        val now = System.currentTimeMillis()
+        val oneDay = 24 * 60 * 60 * 1000L
+
+        val sets = listOf(
+            // Previous week: RPE ~9
+            createSet(rpe = 9.0, completedAt = now - 10 * oneDay),
+            createSet(rpe = 9.0, completedAt = now - 10 * oneDay),
+            // Recent week: RPE ~7
+            createSet(rpe = 7.0, completedAt = now - 2 * oneDay),
+            createSet(rpe = 7.0, completedAt = now - 2 * oneDay),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = service.getTrend(exerciseId)
+        assertNotNull(result)
+        assertEquals(RpeTrendService.TrendDirection.FALLING, result!!.trend)
+        assertFalse(result.isFatigueWarning)
+    }
+
+    @Test
+    fun `detects stable trend when RPE change is small`() = runTest {
+        val now = System.currentTimeMillis()
+        val oneDay = 24 * 60 * 60 * 1000L
+
+        val sets = listOf(
+            // Previous week
+            createSet(rpe = 8.0, completedAt = now - 10 * oneDay),
+            createSet(rpe = 8.0, completedAt = now - 10 * oneDay),
+            // Recent week — similar RPE
+            createSet(rpe = 8.0, completedAt = now - 2 * oneDay),
+            createSet(rpe = 8.5, completedAt = now - 2 * oneDay),
+        )
+        coEvery { workoutDao.getSetsByExercise(exerciseId) } returns sets
+
+        val result = service.getTrend(exerciseId)
+        assertNotNull(result)
+        assertEquals(RpeTrendService.TrendDirection.STABLE, result!!.trend)
+        assertFalse(result.isFatigueWarning)
+    }
+
+    @Test
+    fun `getFatigueWarnings returns only exercises with fatigue flag`() = runTest {
+        val now = System.currentTimeMillis()
+        val oneDay = 24 * 60 * 60 * 1000L
+
+        // Exercise with rising RPE (fatigue)
+        val fatiguedSets = listOf(
+            createSet(rpe = 7.0, completedAt = now - 10 * oneDay, exerciseId = "ex-1"),
+            createSet(rpe = 9.5, completedAt = now - 1 * oneDay, exerciseId = "ex-1"),
+        )
+
+        // Exercise with stable RPE (no fatigue)
+        val stableSets = listOf(
+            createSet(rpe = 8.0, completedAt = now - 10 * oneDay, exerciseId = "ex-2"),
+            createSet(rpe = 8.0, completedAt = now - 1 * oneDay, exerciseId = "ex-2"),
+        )
+
+        coEvery { workoutDao.getExerciseIdsWithHistory() } returns listOf("ex-1", "ex-2")
+        coEvery { workoutDao.getSetsByExercise("ex-1") } returns fatiguedSets
+        coEvery { workoutDao.getSetsByExercise("ex-2") } returns stableSets
+
+        val warnings = service.getFatigueWarnings()
+        assertEquals(1, warnings.size)
+        assertEquals("ex-1", warnings[0].exerciseId)
+    }
+
+    private fun createSet(
+        rpe: Double?,
+        completedAt: Long,
+        exerciseId: String = this.exerciseId,
+    ): WorkoutSetEntity {
+        return WorkoutSetEntity(
+            id = UUID.randomUUID().toString(),
+            workoutId = "workout-id",
+            exerciseId = exerciseId,
+            setNumber = 1,
+            weight = 100.0,
+            reps = 5,
+            rpe = rpe,
+            isWarmup = false,
+            completedAt = completedAt,
+        )
+    }
+}

--- a/android/core/src/test/java/com/gymbro/core/service/SmartDefaultsServiceTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/service/SmartDefaultsServiceTest.kt
@@ -13,6 +13,7 @@ import java.util.UUID
 class SmartDefaultsServiceTest {
 
     private lateinit var workoutDao: WorkoutDao
+    private lateinit var progressionEngine: ProgressionEngine
     private lateinit var service: SmartDefaultsService
 
     private val exerciseId = "bench-press-id"
@@ -20,7 +21,8 @@ class SmartDefaultsServiceTest {
     @Before
     fun setup() {
         workoutDao = mockk()
-        service = SmartDefaultsService(workoutDao)
+        progressionEngine = ProgressionEngine(workoutDao)
+        service = SmartDefaultsService(workoutDao, progressionEngine)
     }
 
     @Test

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -704,6 +704,16 @@ private fun SetRow(
             stepSize = 1.0,
         )
 
+        Spacer(modifier = Modifier.width(4.dp))
+
+        // RPE quick picker — compact tap-to-cycle selector
+        RpeQuickPicker(
+            selectedRpe = setUi.rpe,
+            onRpeSelected = { onEvent(ActiveWorkoutEvent.UpdateSetRpe(exerciseIndex, setIndex, it)) },
+            enabled = !setUi.isCompleted,
+            modifier = Modifier.width(48.dp),
+        )
+
         Spacer(modifier = Modifier.width(8.dp))
 
         // Complete button
@@ -862,6 +872,55 @@ private fun setHeaderStyle() = MaterialTheme.typography.labelSmall.copy(
     fontWeight = FontWeight.Bold,
     letterSpacing = 1.sp,
 )
+
+/**
+ * Compact RPE quick picker — tap to cycle through RPE values (6-10).
+ * Speed matters during a workout, so this is a single-tap cycle, not a dropdown.
+ * Displays current RPE with color coding: green (6-7), amber (8), red (9-10).
+ */
+@Composable
+private fun RpeQuickPicker(
+    selectedRpe: String,
+    onRpeSelected: (String) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val haptic = LocalHapticFeedback.current
+    val rpeValues = listOf("", "6", "7", "8", "9", "10")
+    val currentIndex = rpeValues.indexOf(selectedRpe).coerceAtLeast(0)
+
+    val displayText = if (selectedRpe.isEmpty()) "—" else selectedRpe
+    val rpeColor = when (selectedRpe.toIntOrNull()) {
+        in 6..7 -> AccentGreenStart
+        8 -> AccentAmberStart
+        in 9..10 -> AccentRed
+        else -> Color.White.copy(alpha = 0.4f)
+    }
+
+    Box(
+        modifier = modifier
+            .height(48.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                if (selectedRpe.isNotEmpty()) rpeColor.copy(alpha = 0.12f)
+                else Color.White.copy(alpha = 0.05f)
+            )
+            .clickable(enabled = enabled) {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                val nextIndex = (currentIndex + 1) % rpeValues.size
+                onRpeSelected(rpeValues[nextIndex])
+            }
+            .testTag("rpe_picker"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = displayText,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+            color = if (enabled) rpeColor else rpeColor.copy(alpha = 0.4f),
+        )
+    }
+}
 
 private fun formatDuration(totalSeconds: Long): String {
     val hours = totalSeconds / 3600

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -213,12 +213,15 @@ class ActiveWorkoutViewModel @Inject constructor(
                 }
             }
         ) {
+            val rpeValue = setUi.rpe.toDoubleOrNull()
+            val rirValue = rpeValue?.let { ExerciseSet.rpeToRir(it) }
             val exerciseSet = ExerciseSet(
                 id = UUID.fromString(setUi.id),
                 exerciseId = exerciseUi.exercise.id,
                 weightKg = weightKg,
                 reps = reps,
-                rpe = setUi.rpe.toDoubleOrNull(),
+                rpe = rpeValue,
+                rir = rirValue,
                 isWarmup = setUi.isWarmup,
             )
             workoutRepository.addSet(workoutId, exerciseSet)


### PR DESCRIPTION
## Summary
Adds RPE (Rate of Perceived Exertion) and RIR (Reps in Reserve) tracking with intelligent auto-progression/regression logic.

## Changes

### Data Model
- Added \ir: Int?\ field to \WorkoutSetEntity\ (Room) and \ExerciseSet\ (domain model)
- Room migration 5→6 adds \ir\ column to \workout_sets\ table
- RIR auto-calculated from RPE: RPE 10 = 0 RIR, RPE 7 = 3 RIR

### UI — RPE Quick Picker
- Added RPE column header to set logging row
- Compact tap-to-cycle RPE picker (6→7→8→9→10→clear→6...)
- Color-coded: green (6-7), amber (8), red (9-10)
- Speed-first design — single tap, no dropdown or slider

### ProgressionEngine (new service)
- **Auto-progression:** All working sets RPE ≤7 → suggest +2.5kg next session
- **Auto-regression:** Last 2 sets RPE 10 → suggest −5% weight (rounded to 2.5kg)
- **Maintain:** RPE 8-9 → keep current weight
- Integrated into SmartDefaultsService for pre-filled weight suggestions

### RpeTrendService (new service)
- 7-day rolling RPE average per exercise
- Compares recent vs previous 7-day window
- Flags exercises with rising RPE ≥8.5 as fatigue warnings

### Tests
- 8 tests for ProgressionEngine (progression, regression, maintain, no-data, warmup skip, rounding)
- 5 tests for RpeTrendService (rising, falling, stable, null data, fatigue warnings)
- Updated SmartDefaultsServiceTest for new constructor and progression integration

Closes #393

Working as Neo (AI/ML Engineer)