### PR TITLE
feat: connect onboarding data to auto-generate first workout program

### DIFF
--- a/.squad/agents/neo/history.md
+++ b/.squad/agents/neo/history.md
@@ -583,6 +583,24 @@ Implemented intelligent split selection based on training frequency and goals:
 
 **Architecture notes:**
 - ProgressionEngine injected via Hilt constructor injection (WorkoutDao dependency)
+
+### 2026-04-10: Onboarding → Auto-Generated First Program (Issue #394, PR #408)
+**What was built:**
+- Connected onboarding data (goal, experience, frequency) to WorkoutPlanGenerator to auto-generate a personalized plan on onboarding completion
+- OnboardingViewModel now injects WorkoutPlanGenerator + ActivePlanStore, generates plan after saving preferences
+- ActivePlanStore gained `isFromOnboarding` flag for distinguishing onboarding-generated plans
+- ProgramsViewModel loads active plan from store on init, shows welcome banner when from onboarding
+- Post-onboarding navigation changed from Exercise Library to Programs screen
+- Added FirstProgramBanner composable with encouraging "Based on your goals" message
+- Plan generation is gracefully degraded — failure doesn't block onboarding completion
+- Updated Maestro E2E tests (onboarding-flow, ensure-post-onboarding, edge-cases) to expect Programs screen
+
+**Key learnings:**
+- Onboarding data should always have an immediate payoff — collecting info without using it feels like busywork
+- The WorkoutPlanGenerator already accepted exactly the data onboarding collects (goal, experience, daysPerWeek) — zero new ML logic needed
+- ActivePlanStore's in-memory singleton pattern works well as a bridge between ViewModels across navigation boundaries
+- Plan generation try/catch is critical — ExerciseRepository may return empty list on fresh install before seeding completes
+- The `nav_programs` string was missing (pre-existing bug) — the Programs bottom nav tab wouldn't have rendered correctly
 - SmartDefaultsService now has 2 dependencies (WorkoutDao + ProgressionEngine)
 - Trend analysis uses 7-day windows, comparing recent vs previous 7 days (14-day lookback total)
 - Fatigue warning threshold: rising trend AND current average ≥ 8.5 (avoids false positives)

--- a/.squad/decisions/inbox/neo-onboarding-program.md
+++ b/.squad/decisions/inbox/neo-onboarding-program.md
@@ -1,0 +1,30 @@
+# Decision: Onboarding Data → Auto-Generated First Program
+
+**By:** Neo (AI/ML Engineer)  
+**Date:** 2026-04-10  
+**Issue:** #394  
+**PR:** #408
+
+## Decision
+
+After onboarding completes, the app now auto-generates a personalized workout plan using the collected data (goal, experience level, training frequency) and routes the user to the Programs screen instead of the Exercise Library.
+
+## Rationale
+
+- Onboarding collected valuable data (goal, experience, frequency) but discarded it — user landed on an empty Exercise Library with no guidance
+- The `WorkoutPlanGenerator` already existed and accepted exactly the data onboarding collects
+- Routing to Programs with a pre-generated plan creates an immediate payoff for completing onboarding
+- Plan generation is fire-and-forget with graceful degradation — if generation fails, onboarding still completes normally
+
+## Architecture
+
+- `OnboardingViewModel` now injects `WorkoutPlanGenerator` + `ActivePlanStore` (both are already Hilt-provided singletons)
+- `ActivePlanStore` gained an `isFromOnboarding` flag to distinguish onboarding-generated plans from manual generation
+- `ProgramsViewModel` loads the active plan from the store on init, so it's immediately visible on navigation
+- Plan is named "Your First Program" to differentiate from manually generated plans
+
+## Implications
+
+- **Trinity (UX):** The post-onboarding destination changed from Exercise Library to Programs. Any onboarding flow changes should verify this routing.
+- **Tank (Architecture):** `ActivePlanStore` is in-memory only. If plan persistence to database is needed later, this is the hook point.
+- **Switch (QA):** Maestro E2E tests updated to expect Programs screen after onboarding. The `waitForAnimationToEnd` timeout was increased to 5s to account for plan generation time.

--- a/android/.maestro/flow/ensure-post-onboarding.yaml
+++ b/android/.maestro/flow/ensure-post-onboarding.yaml
@@ -13,7 +13,7 @@ name: "Ensure Post-Onboarding State"
 - runFlow:
     when:
       visible: "GymBro"
-      notVisible: "Biblioteca de Ejercicios|Exercise Library"
+      notVisible: "Programas|Programs"
     commands:
       # We're on onboarding — complete it
       - swipe:
@@ -39,7 +39,7 @@ name: "Ensure Post-Onboarding State"
       - tapOn:
           point: "20%,69%"
       - waitForAnimationToEnd:
-          timeout: 3000
+          timeout: 5000
 
-# Verify we're now post-onboarding
-- assertVisible: "Biblioteca de Ejercicios|Exercise Library"
+# Verify we're now post-onboarding (lands on Programs after plan generation)
+- assertVisible: "Programas|Programs"

--- a/android/.maestro/onboarding-edge-cases.yaml
+++ b/android/.maestro/onboarding-edge-cases.yaml
@@ -166,7 +166,7 @@ onFlowComplete:
     timeout: 3000
 # App should handle emoji input
 
-# Verify we reached Exercise Library (no crash)
-- assertVisible: "Biblioteca de Ejercicios"
+# Verify we reached Programs screen (no crash, plan auto-generated)
+- assertVisible: "Programas|Programs"
 # Screenshot 06: Edge case tests completed, app stable
 - takeScreenshot: 06_onboarding_edge_complete

--- a/android/.maestro/onboarding-flow.yaml
+++ b/android/.maestro/onboarding-flow.yaml
@@ -4,7 +4,7 @@ name: "Onboarding - Complete 4-page onboarding flow"
 # Tests: Complete onboarding flow from welcome through name/unit selection
 # Preconditions: App launched with clearState (fresh install state)
 # Test data: USER_NAME env var (defaults to "TestUser"), units selection (kg)
-# Assertions: All 4 onboarding pages visible, name and units saved, lands on Exercise Library
+# Assertions: All 4 onboarding pages visible, name and units saved, lands on Programs with auto-generated plan
 # Cleanup: App state cleared via stopApp and clearState
 # Dependencies: None
 tags:
@@ -73,9 +73,9 @@ onFlowComplete:
 - tapOn:
     point: "20%,69%"
 - waitForAnimationToEnd:
-    timeout: 3000
+    timeout: 5000
 
-# Verify we landed on Exercise Library
-- assertVisible: "Biblioteca de Ejercicios|Exercise Library"
-# Screenshot 06: Successfully completed onboarding, landed on Exercise Library
+# Verify we landed on Programs (plan auto-generated from onboarding data)
+- assertVisible: "Programas|Programs"
+# Screenshot 06: Successfully completed onboarding, landed on Programs with first plan
 - takeScreenshot: 06_onboarding_complete

--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -173,7 +173,7 @@ fun GymBroNavGraph(
         composable("onboarding") {
             OnboardingRoute(
                 onNavigateToMain = {
-                    navController.navigate("exercise_library") {
+                    navController.navigate("programs") {
                         popUpTo("onboarding") { inclusive = true }
                     }
                 },

--- a/android/core/src/main/java/com/gymbro/core/service/ActivePlanStore.kt
+++ b/android/core/src/main/java/com/gymbro/core/service/ActivePlanStore.kt
@@ -18,8 +18,20 @@ class ActivePlanStore @Inject constructor() {
     private val _activePlan = MutableStateFlow<WorkoutPlan?>(null)
     val activePlan: StateFlow<WorkoutPlan?> = _activePlan.asStateFlow()
 
+    private val _isFromOnboarding = MutableStateFlow(false)
+    val isFromOnboarding: StateFlow<Boolean> = _isFromOnboarding.asStateFlow()
+
     fun setPlan(plan: WorkoutPlan?) {
         _activePlan.value = plan
+    }
+
+    fun setPlanFromOnboarding(plan: WorkoutPlan) {
+        _activePlan.value = plan
+        _isFromOnboarding.value = true
+    }
+
+    fun clearOnboardingFlag() {
+        _isFromOnboarding.value = false
     }
 
     fun getPlan(): WorkoutPlan? = _activePlan.value

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -11,6 +11,7 @@
     <string name="nav_library">Biblioteca</string>
     <string name="nav_history">Historial</string>
     <string name="nav_progress">Progreso</string>
+    <string name="nav_programs">Programas</string>
     <string name="nav_recovery">Recuperación</string>
     <string name="nav_profile">Perfil</string>
 

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="nav_library">Library</string>
     <string name="nav_history">History</string>
     <string name="nav_progress">Progress</string>
+    <string name="nav_programs">Programs</string>
     <string name="nav_recovery">Recovery</string>
     <string name="nav_profile">Profile</string>
 

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingContract.kt
@@ -11,6 +11,7 @@ data class OnboardingState(
     val selectedGoal: TrainingGoal = TrainingGoal.HYPERTROPHY,
     val selectedExperience: ExperienceLevel = ExperienceLevel.INTERMEDIATE,
     val trainingDaysPerWeek: Int = 4,
+    val isGeneratingPlan: Boolean = false,
 )
 
 sealed interface OnboardingEvent {

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
@@ -133,6 +133,7 @@ fun OnboardingScreen(
                     6 -> GetStartedPage(
                         selectedUnit = state.selectedUnit,
                         userName = state.userName,
+                        isGeneratingPlan = state.isGeneratingPlan,
                         onUnitSelected = { onEvent(OnboardingEvent.UnitSelected(it)) },
                         onNameChanged = { onEvent(OnboardingEvent.NameChanged(it)) },
                         onComplete = { onEvent(OnboardingEvent.CompleteOnboarding) },
@@ -258,6 +259,7 @@ private fun OnboardingFeaturePage(
 private fun GetStartedPage(
     selectedUnit: WeightUnit,
     userName: String,
+    isGeneratingPlan: Boolean,
     onUnitSelected: (WeightUnit) -> Unit,
     onNameChanged: (String) -> Unit,
     onComplete: () -> Unit,
@@ -331,8 +333,13 @@ private fun GetStartedPage(
         Spacer(modifier = Modifier.height(48.dp))
 
         GradientButton(
-            text = stringResource(R.string.onboarding_lets_go),
+            text = if (isGeneratingPlan) {
+                stringResource(R.string.onboarding_generating_plan)
+            } else {
+                stringResource(R.string.onboarding_lets_go)
+            },
             onClick = onComplete,
+            enabled = !isGeneratingPlan,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp)

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingViewModel.kt
@@ -3,6 +3,8 @@ package com.gymbro.feature.onboarding
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gymbro.core.preferences.UserPreferences
+import com.gymbro.core.service.ActivePlanStore
+import com.gymbro.core.service.WorkoutPlanGenerator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,6 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     private val userPreferences: UserPreferences,
+    private val workoutPlanGenerator: WorkoutPlanGenerator,
+    private val activePlanStore: ActivePlanStore,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(OnboardingState())
@@ -50,6 +54,8 @@ class OnboardingViewModel @Inject constructor(
 
     private fun completeOnboarding() {
         viewModelScope.launch {
+            _state.value = _state.value.copy(isGeneratingPlan = true)
+
             userPreferences.setWeightUnit(_state.value.selectedUnit)
             val userName = _state.value.userName.takeIf { it.isNotBlank() } ?: ""
             userPreferences.setUserName(userName)
@@ -57,6 +63,22 @@ class OnboardingViewModel @Inject constructor(
             userPreferences.setExperienceLevel(_state.value.selectedExperience)
             userPreferences.setTrainingDaysPerWeek(_state.value.trainingDaysPerWeek)
             userPreferences.setOnboardingComplete(true)
+
+            try {
+                val plan = workoutPlanGenerator.generatePlan(
+                    goal = _state.value.selectedGoal,
+                    experienceLevel = _state.value.selectedExperience,
+                    daysPerWeek = _state.value.trainingDaysPerWeek,
+                )
+                val personalizedPlan = plan.copy(
+                    name = "Your First Program",
+                )
+                activePlanStore.setPlanFromOnboarding(personalizedPlan)
+            } catch (_: Exception) {
+                // Plan generation failure should not block onboarding completion
+            }
+
+            _state.value = _state.value.copy(isGeneratingPlan = false)
             _effects.send(OnboardingEffect.NavigateToMain)
         }
     }

--- a/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsContract.kt
@@ -11,6 +11,7 @@ data class ProgramsState(
     val isGeneratingPlan: Boolean = false,
     val error: UiError? = null,
     val showCreateDialog: Boolean = false,
+    val showFirstProgramBanner: Boolean = false,
 )
 
 sealed interface ProgramsEvent {

--- a/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsScreen.kt
@@ -146,10 +146,21 @@ fun ProgramsScreen(
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                // Welcome banner for first program from onboarding
+                if (state.showFirstProgramBanner) {
+                    item {
+                        FirstProgramBanner()
+                    }
+                }
+
                 // Active Plan Section
                 item {
                     Text(
-                        text = stringResource(R.string.programs_active_plan_title),
+                        text = if (state.showFirstProgramBanner) {
+                            stringResource(R.string.programs_your_first_program)
+                        } else {
+                            stringResource(R.string.programs_active_plan_title)
+                        },
                         style = MaterialTheme.typography.titleLarge.copy(
                             fontWeight = FontWeight.Bold,
                         ),
@@ -344,6 +355,43 @@ private fun MuscleGroupChip(muscleGroup: MuscleGroup) {
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    }
+}
+
+@Composable
+private fun FirstProgramBanner() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = AccentGreen.copy(alpha = 0.12f),
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+        ) {
+            Text(
+                text = "🎯",
+                style = MaterialTheme.typography.headlineMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.programs_first_program_title),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+                color = AccentGreen,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.programs_first_program_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/programs/ProgramsViewModel.kt
@@ -36,6 +36,7 @@ class ProgramsViewModel @Inject constructor(
 
     init {
         initializeTemplates()
+        loadActivePlanFromStore()
         loadTemplates()
     }
 
@@ -95,6 +96,22 @@ class ProgramsViewModel @Inject constructor(
                     activePlan = plan,
                     isGeneratingPlan = false,
                 )
+            }
+        }
+    }
+
+    private fun loadActivePlanFromStore() {
+        val plan = activePlanStore.getPlan()
+        if (plan != null) {
+            val isFromOnboarding = activePlanStore.isFromOnboarding.value
+            _state.update {
+                it.copy(
+                    activePlan = plan,
+                    showFirstProgramBanner = isFromOnboarding,
+                )
+            }
+            if (isFromOnboarding) {
+                activePlanStore.clearOnboardingFlag()
             }
         }
     }

--- a/android/feature/src/test/java/com/gymbro/feature/onboarding/OnboardingViewModelTest.kt
+++ b/android/feature/src/test/java/com/gymbro/feature/onboarding/OnboardingViewModelTest.kt
@@ -1,15 +1,22 @@
 package com.gymbro.feature.onboarding
 
 import app.cash.turbine.test
+import com.gymbro.core.model.WorkoutPlan
 import com.gymbro.core.preferences.UserPreferences
+import com.gymbro.core.preferences.UserPreferences.ExperienceLevel
+import com.gymbro.core.preferences.UserPreferences.TrainingGoal
 import com.gymbro.core.preferences.UserPreferences.WeightUnit
+import com.gymbro.core.service.ActivePlanStore
+import com.gymbro.core.service.WorkoutPlanGenerator
 import com.gymbro.feature.MainDispatcherRule
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -20,12 +27,16 @@ class OnboardingViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private lateinit var userPreferences: UserPreferences
+    private lateinit var workoutPlanGenerator: WorkoutPlanGenerator
+    private lateinit var activePlanStore: ActivePlanStore
     private lateinit var viewModel: OnboardingViewModel
 
     @Before
     fun setup() {
         userPreferences = mockk(relaxed = true)
-        viewModel = OnboardingViewModel(userPreferences)
+        workoutPlanGenerator = mockk(relaxed = true)
+        activePlanStore = ActivePlanStore()
+        viewModel = OnboardingViewModel(userPreferences, workoutPlanGenerator, activePlanStore)
     }
 
     @Test
@@ -34,7 +45,7 @@ class OnboardingViewModelTest {
         assertEquals(0, state.currentPage)
         assertEquals(WeightUnit.KG, state.selectedUnit)
         assertEquals("", state.userName)
-        assertNull(state.selectedGoal)
+        assertEquals(TrainingGoal.HYPERTROPHY, state.selectedGoal)
     }
 
     @Test
@@ -75,6 +86,58 @@ class OnboardingViewModelTest {
             coVerify { userPreferences.setWeightUnit(WeightUnit.LBS) }
             coVerify { userPreferences.setUserName("John") }
             coVerify { userPreferences.setOnboardingComplete(true) }
+        }
+    }
+
+    @Test
+    fun `complete onboarding generates plan and stores it`() = runTest {
+        val mockPlan = WorkoutPlan(
+            name = "Hypertrophy Program",
+            description = "Test plan",
+            goal = TrainingGoal.HYPERTROPHY,
+            experienceLevel = ExperienceLevel.INTERMEDIATE,
+            daysPerWeek = 4,
+            workoutDays = emptyList(),
+        )
+        coEvery {
+            workoutPlanGenerator.generatePlan(any(), any(), any())
+        } returns mockPlan
+
+        viewModel.onEvent(OnboardingEvent.GoalSelected(TrainingGoal.HYPERTROPHY))
+        viewModel.onEvent(OnboardingEvent.ExperienceSelected(ExperienceLevel.INTERMEDIATE))
+        viewModel.onEvent(OnboardingEvent.TrainingDaysSelected(4))
+
+        viewModel.effects.test {
+            viewModel.onEvent(OnboardingEvent.CompleteOnboarding)
+            awaitItem() // NavigateToMain
+
+            coVerify {
+                workoutPlanGenerator.generatePlan(
+                    TrainingGoal.HYPERTROPHY,
+                    ExperienceLevel.INTERMEDIATE,
+                    4,
+                )
+            }
+
+            val storedPlan = activePlanStore.getPlan()
+            assertEquals("Your First Program", storedPlan?.name)
+            assertTrue(activePlanStore.isFromOnboarding.value)
+        }
+    }
+
+    @Test
+    fun `complete onboarding still navigates if plan generation fails`() = runTest {
+        coEvery {
+            workoutPlanGenerator.generatePlan(any(), any(), any())
+        } throws RuntimeException("Failed to generate plan")
+
+        viewModel.effects.test {
+            viewModel.onEvent(OnboardingEvent.CompleteOnboarding)
+
+            val effect = awaitItem()
+            assertEquals(OnboardingEffect.NavigateToMain, effect)
+
+            assertNull(activePlanStore.getPlan())
         }
     }
 }

--- a/android/feature/src/test/java/com/gymbro/feature/onboarding/screenshots/OnboardingScreenshotTest.kt
+++ b/android/feature/src/test/java/com/gymbro/feature/onboarding/screenshots/OnboardingScreenshotTest.kt
@@ -3,6 +3,8 @@ package com.gymbro.feature.onboarding.screenshots
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import com.gymbro.app.ui.theme.GymBroTheme
+import com.gymbro.core.preferences.UserPreferences.ExperienceLevel
+import com.gymbro.core.preferences.UserPreferences.TrainingGoal
 import com.gymbro.core.preferences.UserPreferences.WeightUnit
 import com.gymbro.feature.onboarding.OnboardingScreen
 import com.gymbro.feature.onboarding.OnboardingState
@@ -27,7 +29,7 @@ class OnboardingScreenshotTest {
                         currentPage = 0,
                         selectedUnit = WeightUnit.KG,
                         userName = "",
-                        selectedGoal = "both"
+                        selectedGoal = TrainingGoal.HYPERTROPHY,
                     ),
                     onEvent = {}
                 )
@@ -44,7 +46,7 @@ class OnboardingScreenshotTest {
                         currentPage = 1,
                         selectedUnit = WeightUnit.KG,
                         userName = "Alex",
-                        selectedGoal = "both"
+                        selectedGoal = TrainingGoal.HYPERTROPHY,
                     ),
                     onEvent = {}
                 )
@@ -61,7 +63,7 @@ class OnboardingScreenshotTest {
                         currentPage = 2,
                         selectedUnit = WeightUnit.LBS,
                         userName = "Alex",
-                        selectedGoal = "strength"
+                        selectedGoal = TrainingGoal.STRENGTH,
                     ),
                     onEvent = {}
                 )

--- a/android/feature/src/test/java/com/gymbro/feature/programs/ProgramsViewModelTest.kt
+++ b/android/feature/src/test/java/com/gymbro/feature/programs/ProgramsViewModelTest.kt
@@ -2,7 +2,10 @@ package com.gymbro.feature.programs
 
 import app.cash.turbine.test
 import com.gymbro.core.model.WorkoutTemplate
+import com.gymbro.core.preferences.UserPreferences
 import com.gymbro.core.repository.WorkoutTemplateRepository
+import com.gymbro.core.service.ActivePlanStore
+import com.gymbro.core.service.WorkoutPlanGenerator
 import com.gymbro.feature.MainDispatcherRule
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,14 +25,24 @@ class ProgramsViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private lateinit var templateRepository: WorkoutTemplateRepository
+    private lateinit var workoutPlanGenerator: WorkoutPlanGenerator
+    private lateinit var userPreferences: UserPreferences
+    private lateinit var activePlanStore: ActivePlanStore
     private lateinit var viewModel: ProgramsViewModel
 
     @Before
     fun setup() {
         templateRepository = mockk(relaxed = true)
+        workoutPlanGenerator = mockk(relaxed = true)
+        userPreferences = mockk(relaxed = true)
+        activePlanStore = ActivePlanStore()
         coEvery { templateRepository.observeAllTemplates() } returns flowOf(emptyList())
         coEvery { templateRepository.initializeBuiltInTemplates() } returns Unit
     }
+
+    private fun createViewModel() = ProgramsViewModel(
+        templateRepository, workoutPlanGenerator, userPreferences, activePlanStore,
+    )
 
     @Test
     fun `initial state loads templates`() = runTest {
@@ -39,7 +52,7 @@ class ProgramsViewModelTest {
         )
         coEvery { templateRepository.observeAllTemplates() } returns flowOf(templates)
         
-        viewModel = ProgramsViewModel(templateRepository)
+        viewModel = createViewModel()
         
         val state = viewModel.state.value
         assertEquals(2, state.templates.size)
@@ -48,7 +61,7 @@ class ProgramsViewModelTest {
 
     @Test
     fun `template clicked navigates to create template`() = runTest {
-        viewModel = ProgramsViewModel(templateRepository)
+        viewModel = createViewModel()
         
         val template = WorkoutTemplate(name = "Test", description = "", exercises = emptyList())
         
@@ -62,7 +75,7 @@ class ProgramsViewModelTest {
 
     @Test
     fun `create template clicked shows dialog`() = runTest {
-        viewModel = ProgramsViewModel(templateRepository)
+        viewModel = createViewModel()
         
         viewModel.onEvent(ProgramsEvent.CreateTemplateClicked)
         
@@ -72,7 +85,7 @@ class ProgramsViewModelTest {
 
     @Test
     fun `delete template calls repository`() = runTest {
-        viewModel = ProgramsViewModel(templateRepository)
+        viewModel = createViewModel()
         
         viewModel.onEvent(ProgramsEvent.DeleteTemplate("template-id"))
         
@@ -81,7 +94,7 @@ class ProgramsViewModelTest {
 
     @Test
     fun `start workout from template navigates to active workout`() = runTest {
-        viewModel = ProgramsViewModel(templateRepository)
+        viewModel = createViewModel()
         
         val template = WorkoutTemplate(name = "Test", description = "", exercises = emptyList())
         
@@ -93,5 +106,24 @@ class ProgramsViewModelTest {
             
             coVerify { templateRepository.updateLastUsed(template.id.toString()) }
         }
+    }
+
+    @Test
+    fun `loads active plan from store on init`() = runTest {
+        val plan = com.gymbro.core.model.WorkoutPlan(
+            name = "Your First Program",
+            description = "Test",
+            goal = UserPreferences.TrainingGoal.HYPERTROPHY,
+            experienceLevel = UserPreferences.ExperienceLevel.INTERMEDIATE,
+            daysPerWeek = 4,
+            workoutDays = emptyList(),
+        )
+        activePlanStore.setPlanFromOnboarding(plan)
+
+        viewModel = createViewModel()
+
+        val state = viewModel.state.value
+        assertEquals("Your First Program", state.activePlan?.name)
+        assertTrue(state.showFirstProgramBanner)
     }
 }


### PR DESCRIPTION
## Summary

After onboarding completes, the app now auto-generates a personalized workout plan from the collected data (goals, experience level, training frequency) and routes the user to the Programs screen instead of the empty Exercise Library.

**Closes #394**

Working as Neo (AI/ML Engineer)

## Changes

### Core Logic
- **OnboardingViewModel**: Injects \WorkoutPlanGenerator\ and \ActivePlanStore\. After saving preferences, generates a plan using the onboarding data and stores it via \ActivePlanStore.setPlanFromOnboarding()\
- **ActivePlanStore**: Added \isFromOnboarding\ flag to distinguish onboarding-generated plans from manual ones
- **ProgramsViewModel**: Loads active plan from \ActivePlanStore\ on init, detects onboarding origin for welcome banner

### Navigation
- **GymBroNavGraph**: Changed post-onboarding route from \xercise_library\ to \programs\

### UI/UX
- **OnboardingScreen**: Shows \Building your plan...\ state and disables button during plan generation
- **ProgramsScreen**: Added \FirstProgramBanner\ composable with encouraging message: *Based on your goals, here's your personalized plan*
- **OnboardingContract**: Added \isGeneratingPlan\ state field
- **ProgramsContract**: Added \showFirstProgramBanner\ state field

### Strings & i18n
- Added \
av_programs\, \onboarding_generating_plan\, \programs_your_first_program\, \programs_first_program_title\, \programs_first_program_subtitle\ (EN + ES)

### Tests
- Updated \OnboardingViewModelTest\: Added tests for plan generation on completion and graceful failure handling
- Updated \ProgramsViewModelTest\: Fixed pre-existing constructor param issues, added test for loading plan from store
- Fixed \OnboardingScreenshotTest\: Updated to use \TrainingGoal\ enum instead of strings

### Maestro E2E
- Updated \onboarding-flow.yaml\, \nsure-post-onboarding.yaml\, \onboarding-edge-cases.yaml\ to expect Programs screen after onboarding