### PR TITLE
feat: redesign home screen with workout plans and quick-start

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -18,10 +19,12 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.FitnessCenter
 import androidx.compose.material.icons.outlined.History
+import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.MonitorHeart
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Person
@@ -58,6 +61,7 @@ import com.gymbro.core.model.MuscleGroup
 import com.gymbro.core.preferences.UserPreferences
 import com.gymbro.feature.exerciselibrary.CreateExerciseRoute
 import com.gymbro.feature.exerciselibrary.ExerciseLibraryRoute
+import com.gymbro.feature.home.HomeRoute
 import com.gymbro.feature.history.HistoryDetailRoute
 import com.gymbro.feature.history.HistoryListRoute
 import com.gymbro.feature.onboarding.OnboardingRoute
@@ -86,16 +90,16 @@ private enum class BottomNavTab(
     val selectedIcon: ImageVector,
     val unselectedIcon: ImageVector,
 ) {
-    LIBRARY("exercise_library", R.string.nav_library, Icons.Filled.FitnessCenter, Icons.Outlined.FitnessCenter),
-    HISTORY("history", R.string.nav_history, Icons.Filled.History, Icons.Outlined.History),
-    PROGRESS("progress", R.string.nav_progress, Icons.AutoMirrored.Filled.ShowChart, Icons.AutoMirrored.Outlined.ShowChart),
+    HOME("home", R.string.nav_home, Icons.Filled.Home, Icons.Outlined.Home),
     PROGRAMS("programs", R.string.nav_programs, Icons.Filled.CalendarMonth, Icons.Outlined.CalendarMonth),
+    HISTORY("history", R.string.nav_history, Icons.Filled.History, Icons.Outlined.History),
     PROFILE("profile", R.string.nav_profile, Icons.Filled.Person, Icons.Outlined.Person),
 }
 
 @Composable
 fun GymBroNavGraph(
     userPreferences: UserPreferences = hiltViewModel<GymBroNavGraphViewModel>().userPreferences,
+    onFullyDrawn: () -> Unit = {},
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -103,8 +107,23 @@ fun GymBroNavGraph(
 
     val showBottomBar = currentDestination?.route in BottomNavTab.entries.map { it.route }
 
-    val hasCompletedOnboarding by userPreferences.hasCompletedOnboarding.collectAsStateWithLifecycle(initialValue = false)
-    val startDestination = if (hasCompletedOnboarding) "exercise_library" else "onboarding"
+    // Use null initial value to distinguish "not yet loaded" from "false"
+    val hasCompletedOnboarding by userPreferences.hasCompletedOnboarding.collectAsStateWithLifecycle(initialValue = null)
+
+    // Wait for DataStore to load before deciding start destination — avoids flashing wrong screen
+    val resolvedOnboarding = hasCompletedOnboarding
+    if (resolvedOnboarding == null) {
+        // Show nothing while preferences load — splash screen covers this gap
+        Box(modifier = Modifier.fillMaxSize())
+        return
+    }
+
+    val startDestination = if (resolvedOnboarding) "home" else "onboarding"
+
+    // Report fully drawn once we know which screen to show
+    LaunchedEffect(Unit) {
+        onFullyDrawn()
+    }
 
     Scaffold(
         modifier = Modifier.semantics {
@@ -173,9 +192,28 @@ fun GymBroNavGraph(
         composable("onboarding") {
             OnboardingRoute(
                 onNavigateToMain = {
-                    navController.navigate("programs") {
+                    navController.navigate("home") {
                         popUpTo("onboarding") { inclusive = true }
                     }
+                },
+            )
+        }
+        composable("home") {
+            HomeRoute(
+                onNavigateToActiveWorkout = {
+                    navController.navigate("active_workout")
+                },
+                onNavigateToPrograms = {
+                    navController.navigate("programs") {
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                onNavigateToWorkoutDetail = { workoutId ->
+                    navController.navigate("history/$workoutId")
                 },
             )
         }
@@ -306,8 +344,8 @@ fun GymBroNavGraph(
                 exerciseCount = exercises,
                 personalRecords = prs,
                 onDone = {
-                    navController.navigate("exercise_library") {
-                        popUpTo("exercise_library") { inclusive = true }
+                    navController.navigate("home") {
+                        popUpTo("home") { inclusive = true }
                     }
                 },
             )

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -8,6 +8,7 @@
     <string name="stats_widget_description">Ver tus estadísticas semanales de entrenamiento</string>
 
     <!-- Bottom Navigation -->
+    <string name="nav_home">Inicio</string>
     <string name="nav_library">Biblioteca</string>
     <string name="nav_history">Historial</string>
     <string name="nav_progress">Progreso</string>
@@ -231,4 +232,19 @@
     <string name="programs_total_sets_desc" formatted="false">%d series totales</string>
     <string name="programs_exercise_accessibility" formatted="false">%s: %d series de %s repeticiones, %d segundos de descanso</string>
     <string name="common_retry">Reintentar</string>
+
+    <!-- Home Screen -->
+    <string name="home_title">Inicio</string>
+    <string name="home_quick_start">Inicio Rápido</string>
+    <string name="home_quick_start_first">¿Listo para tu primer entrenamiento?</string>
+    <string name="home_quick_start_today">Ya entrenaste hoy — ¿otra vez?</string>
+    <string name="home_quick_start_yesterday">Último entrenamiento fue ayer</string>
+    <string name="home_quick_start_days_ago">Último entrenamiento hace %d días</string>
+    <string name="home_todays_workout">Entrenamiento de Hoy</string>
+    <string name="home_start">Iniciar</string>
+    <string name="home_view_all_programs">Ver todos los programas →</string>
+    <string name="home_create_program_title">Crea Tu Primer Programa</string>
+    <string name="home_create_program_subtitle">Obtén un plan de entrenamiento personalizado basado en tus objetivos</string>
+    <string name="home_recent_workouts">Entrenamientos Recientes</string>
+    <string name="home_exercises_count">%d ejercicios</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="stats_widget_description">View your weekly workout stats</string>
 
     <!-- Bottom Navigation -->
+    <string name="nav_home">Home</string>
     <string name="nav_library">Library</string>
     <string name="nav_history">History</string>
     <string name="nav_progress">Progress</string>
@@ -231,4 +232,19 @@
     <string name="programs_total_sets_desc" formatted="false">%d total sets</string>
     <string name="programs_exercise_accessibility" formatted="false">%s: %d sets of %s reps, %d seconds rest</string>
     <string name="common_retry">Retry</string>
+
+    <!-- Home Screen -->
+    <string name="home_title">Home</string>
+    <string name="home_quick_start">Quick Start</string>
+    <string name="home_quick_start_first">Ready for your first workout?</string>
+    <string name="home_quick_start_today">Already trained today — go again?</string>
+    <string name="home_quick_start_yesterday">Last workout was yesterday</string>
+    <string name="home_quick_start_days_ago">Last workout %d days ago</string>
+    <string name="home_todays_workout">Today\'s Workout</string>
+    <string name="home_start">Start</string>
+    <string name="home_view_all_programs">View all programs →</string>
+    <string name="home_create_program_title">Create Your First Program</string>
+    <string name="home_create_program_subtitle">Get a personalized training plan based on your goals</string>
+    <string name="home_recent_workouts">Recent Workouts</string>
+    <string name="home_exercises_count">%d exercises</string>
 </resources>

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -8,6 +8,7 @@
     <string name="stats_widget_description">Ver tus estadísticas semanales de entrenamiento</string>
 
     <!-- Bottom Navigation -->
+    <string name="nav_home">Inicio</string>
     <string name="nav_library">Biblioteca</string>
     <string name="nav_history">Historial</string>
     <string name="nav_progress">Progreso</string>
@@ -542,4 +543,19 @@
     <string name="voice_input_not_available">Reconocimiento de voz no disponible en este dispositivo</string>
     <string name="voice_input_parse_error">No se pudo entender \"%1$s\". Intenta \"100 kilos 5 repeticiones\".</string>
     <string name="voice_input_confirmed">Serie llenada: %1$s</string>
+
+    <!-- Home Screen -->
+    <string name="home_title">Inicio</string>
+    <string name="home_quick_start">Inicio Rápido</string>
+    <string name="home_quick_start_first">¿Listo para tu primer entrenamiento?</string>
+    <string name="home_quick_start_today">Ya entrenaste hoy — ¿otra vez?</string>
+    <string name="home_quick_start_yesterday">Último entrenamiento fue ayer</string>
+    <string name="home_quick_start_days_ago">Último entrenamiento hace %d días</string>
+    <string name="home_todays_workout">Entrenamiento de Hoy</string>
+    <string name="home_start">Iniciar</string>
+    <string name="home_view_all_programs">Ver todos los programas →</string>
+    <string name="home_create_program_title">Crea Tu Primer Programa</string>
+    <string name="home_create_program_subtitle">Obtén un plan de entrenamiento personalizado basado en tus objetivos</string>
+    <string name="home_recent_workouts">Entrenamientos Recientes</string>
+    <string name="home_exercises_count">%d ejercicios</string>
 </resources>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="stats_widget_description">View your weekly workout stats</string>
 
     <!-- Bottom Navigation -->
+    <string name="nav_home">Home</string>
     <string name="nav_library">Library</string>
     <string name="nav_history">History</string>
     <string name="nav_progress">Progress</string>
@@ -542,4 +543,19 @@
     <string name="voice_input_not_available">Speech recognition not available on this device</string>
     <string name="voice_input_parse_error">Couldn\'t understand \"%1$s\". Try \"100 kilos 5 reps\".</string>
     <string name="voice_input_confirmed">Set filled: %1$s</string>
+
+    <!-- Home Screen -->
+    <string name="home_title">Home</string>
+    <string name="home_quick_start">Quick Start</string>
+    <string name="home_quick_start_first">Ready for your first workout?</string>
+    <string name="home_quick_start_today">Already trained today — go again?</string>
+    <string name="home_quick_start_yesterday">Last workout was yesterday</string>
+    <string name="home_quick_start_days_ago">Last workout %d days ago</string>
+    <string name="home_todays_workout">Today\'s Workout</string>
+    <string name="home_start">Start</string>
+    <string name="home_view_all_programs">View all programs →</string>
+    <string name="home_create_program_title">Create Your First Program</string>
+    <string name="home_create_program_subtitle">Get a personalized training plan based on your goals</string>
+    <string name="home_recent_workouts">Recent Workouts</string>
+    <string name="home_exercises_count">%d exercises</string>
 </resources>

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeContract.kt
@@ -1,0 +1,36 @@
+package com.gymbro.feature.home
+
+import com.gymbro.core.model.WorkoutPlan
+import com.gymbro.core.model.WorkoutDay
+
+data class HomeState(
+    val activePlan: WorkoutPlan? = null,
+    val todayWorkout: WorkoutDay? = null,
+    val recentWorkouts: List<RecentWorkoutItem> = emptyList(),
+    val isLoading: Boolean = true,
+    val isGeneratingPlan: Boolean = false,
+    val daysSinceLastWorkout: Int? = null,
+)
+
+data class RecentWorkoutItem(
+    val workoutId: String,
+    val date: Long,
+    val durationSeconds: Long,
+    val exerciseCount: Int,
+    val totalSets: Int,
+    val totalVolume: Double,
+)
+
+sealed interface HomeEvent {
+    data object QuickStartWorkout : HomeEvent
+    data object CreateFirstProgram : HomeEvent
+    data class StartTodayWorkout(val dayNumber: Int) : HomeEvent
+    data class ViewWorkoutDetail(val workoutId: String) : HomeEvent
+    data object ViewAllPrograms : HomeEvent
+}
+
+sealed interface HomeEffect {
+    data object NavigateToActiveWorkout : HomeEffect
+    data object NavigateToPrograms : HomeEffect
+    data class NavigateToWorkoutDetail(val workoutId: String) : HomeEffect
+}

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
@@ -1,0 +1,562 @@
+package com.gymbro.feature.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.gymbro.core.R
+import com.gymbro.core.model.WorkoutDay
+import com.gymbro.core.model.WorkoutPlan
+import com.gymbro.feature.common.FullScreenLoading
+import com.gymbro.feature.common.ObserveErrors
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+private val AccentGreen = Color(0xFF00FF87)
+private val AccentCyan = Color(0xFF00E5FF)
+
+@Composable
+fun HomeRoute(
+    viewModel: HomeViewModel = hiltViewModel(),
+    onNavigateToActiveWorkout: () -> Unit = {},
+    onNavigateToPrograms: () -> Unit = {},
+    onNavigateToWorkoutDetail: (String) -> Unit = {},
+) {
+    val state = viewModel.state.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    ObserveErrors(
+        errorFlow = viewModel.errorEvents,
+        snackbarHostState = snackbarHostState,
+    )
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is HomeEffect.NavigateToActiveWorkout -> onNavigateToActiveWorkout()
+                is HomeEffect.NavigateToPrograms -> onNavigateToPrograms()
+                is HomeEffect.NavigateToWorkoutDetail -> onNavigateToWorkoutDetail(effect.workoutId)
+            }
+        }
+    }
+
+    HomeScreen(
+        state = state.value,
+        onEvent = viewModel::onEvent,
+        snackbarHostState = snackbarHostState,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(
+    state: HomeState,
+    onEvent: (HomeEvent) -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.home_title),
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.onBackground,
+                ),
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { innerPadding ->
+        if (state.isLoading && state.recentWorkouts.isEmpty() && state.activePlan == null) {
+            FullScreenLoading()
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // Quick Start Button — the hero action
+                item {
+                    QuickStartCard(
+                        daysSinceLastWorkout = state.daysSinceLastWorkout,
+                        onQuickStart = { onEvent(HomeEvent.QuickStartWorkout) },
+                    )
+                }
+
+                // Today's Workout (if active plan exists)
+                if (state.activePlan != null && state.todayWorkout != null) {
+                    item {
+                        TodayWorkoutCard(
+                            plan = state.activePlan,
+                            todayWorkout = state.todayWorkout,
+                            onStartWorkout = {
+                                onEvent(HomeEvent.StartTodayWorkout(state.todayWorkout.dayNumber))
+                            },
+                            onViewPrograms = { onEvent(HomeEvent.ViewAllPrograms) },
+                        )
+                    }
+                } else {
+                    // No active plan — CTA to create one
+                    item {
+                        CreateProgramCta(
+                            onCreateProgram = { onEvent(HomeEvent.CreateFirstProgram) },
+                        )
+                    }
+                }
+
+                // Recent Workouts
+                if (state.recentWorkouts.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(R.string.home_recent_workouts),
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontWeight = FontWeight.Bold,
+                            ),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            modifier = Modifier.semantics { heading() },
+                        )
+                    }
+
+                    items(
+                        items = state.recentWorkouts,
+                        key = { it.workoutId },
+                    ) { workout ->
+                        RecentWorkoutCard(
+                            workout = workout,
+                            onClick = { onEvent(HomeEvent.ViewWorkoutDetail(workout.workoutId)) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickStartCard(
+    daysSinceLastWorkout: Int?,
+    onQuickStart: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("quick_start_card"),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    brush = Brush.horizontalGradient(
+                        colors = listOf(
+                            AccentGreen.copy(alpha = 0.15f),
+                            AccentCyan.copy(alpha = 0.10f),
+                        )
+                    ),
+                    shape = RoundedCornerShape(16.dp),
+                )
+                .padding(24.dp),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                val subtitle = when {
+                    daysSinceLastWorkout == null -> stringResource(R.string.home_quick_start_first)
+                    daysSinceLastWorkout == 0 -> stringResource(R.string.home_quick_start_today)
+                    daysSinceLastWorkout == 1 -> stringResource(R.string.home_quick_start_yesterday)
+                    else -> stringResource(R.string.home_quick_start_days_ago, daysSinceLastWorkout)
+                }
+
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Button(
+                    onClick = onQuickStart,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .testTag("quick_start_button"),
+                    shape = RoundedCornerShape(14.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = AccentGreen,
+                        contentColor = Color.Black,
+                    ),
+                ) {
+                    Icon(
+                        Icons.Default.PlayArrow,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.home_quick_start),
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TodayWorkoutCard(
+    plan: WorkoutPlan,
+    todayWorkout: WorkoutDay,
+    onStartWorkout: () -> Unit,
+    onViewPrograms: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("today_workout_card"),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.home_todays_workout),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = AccentGreen,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = todayWorkout.name,
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.Bold,
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = plan.name,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Button(
+                    onClick = onStartWorkout,
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = AccentGreen,
+                        contentColor = Color.Black,
+                    ),
+                ) {
+                    Icon(
+                        Icons.Default.PlayArrow,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = stringResource(R.string.home_start),
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                InfoChip(
+                    label = stringResource(R.string.programs_exercises_count, todayWorkout.exercises.size),
+                    color = AccentCyan,
+                )
+                InfoChip(
+                    label = stringResource(R.string.programs_day_number, todayWorkout.dayNumber),
+                    color = AccentGreen,
+                )
+            }
+
+            // Show first 3 exercises as preview
+            if (todayWorkout.exercises.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                todayWorkout.exercises.take(3).forEach { exercise ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Default.FitnessCenter,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "${exercise.exerciseName} — ${exercise.sets} × ${exercise.repsRange}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                if (todayWorkout.exercises.size > 3) {
+                    Text(
+                        text = stringResource(
+                            R.string.programs_more_exercises,
+                            todayWorkout.exercises.size - 3,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 22.dp, top = 2.dp),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.home_view_all_programs),
+                style = MaterialTheme.typography.labelMedium,
+                color = AccentCyan,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier
+                    .clickable(onClick = onViewPrograms)
+                    .padding(vertical = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CreateProgramCta(
+    onCreateProgram: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onCreateProgram)
+            .testTag("create_program_cta"),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                Icons.Default.CalendarMonth,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = AccentGreen,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.home_create_program_title),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.home_create_program_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecentWorkoutCard(
+    workout: RecentWorkoutItem,
+    onClick: () -> Unit,
+) {
+    val dateFormatter = remember {
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+    }
+    val formattedDate = remember(workout.date) {
+        Instant.ofEpochMilli(workout.date)
+            .atZone(ZoneId.systemDefault())
+            .format(dateFormatter)
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = formattedDate,
+                    style = MaterialTheme.typography.titleSmall.copy(
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    StatLabel(
+                        icon = Icons.Default.FitnessCenter,
+                        text = stringResource(R.string.home_exercises_count, workout.exerciseCount),
+                    )
+                    StatLabel(
+                        icon = Icons.Default.Timer,
+                        text = formatDuration(workout.durationSeconds),
+                    )
+                }
+            }
+
+            Text(
+                text = "%.0f kg".format(workout.totalVolume),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                ),
+                color = AccentGreen,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatLabel(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    text: String,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun InfoChip(
+    label: String,
+    color: Color,
+) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium.copy(
+                fontWeight = FontWeight.SemiBold,
+            ),
+            color = color,
+        )
+    }
+}
+
+private fun formatDuration(seconds: Long): String {
+    val hours = seconds / 3600
+    val minutes = (seconds % 3600) / 60
+    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeViewModel.kt
@@ -1,0 +1,128 @@
+package com.gymbro.feature.home
+
+import com.gymbro.core.repository.WorkoutRepository
+import com.gymbro.core.service.ActivePlanStore
+import com.gymbro.core.service.PersonalRecordService
+import com.gymbro.feature.common.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val workoutRepository: WorkoutRepository,
+    private val activePlanStore: ActivePlanStore,
+    private val personalRecordService: PersonalRecordService,
+) : BaseViewModel() {
+
+    private val _state = MutableStateFlow(HomeState())
+    val state: StateFlow<HomeState> = _state.asStateFlow()
+
+    private val _effect = Channel<HomeEffect>(Channel.BUFFERED)
+    val effect = _effect.receiveAsFlow()
+
+    init {
+        loadActivePlan()
+        loadRecentWorkouts()
+        loadDaysSinceLastWorkout()
+    }
+
+    fun onEvent(event: HomeEvent) {
+        when (event) {
+            is HomeEvent.QuickStartWorkout -> {
+                viewModelScope.launch {
+                    _effect.send(HomeEffect.NavigateToActiveWorkout)
+                }
+            }
+            is HomeEvent.CreateFirstProgram -> {
+                viewModelScope.launch {
+                    _effect.send(HomeEffect.NavigateToPrograms)
+                }
+            }
+            is HomeEvent.StartTodayWorkout -> {
+                viewModelScope.launch {
+                    _effect.send(HomeEffect.NavigateToActiveWorkout)
+                }
+            }
+            is HomeEvent.ViewWorkoutDetail -> {
+                viewModelScope.launch {
+                    _effect.send(HomeEffect.NavigateToWorkoutDetail(event.workoutId))
+                }
+            }
+            is HomeEvent.ViewAllPrograms -> {
+                viewModelScope.launch {
+                    _effect.send(HomeEffect.NavigateToPrograms)
+                }
+            }
+        }
+    }
+
+    private fun loadActivePlan() {
+        val plan = activePlanStore.getPlan()
+        if (plan != null) {
+            val dayIndex = (java.time.LocalDate.now().dayOfWeek.value - 1) % plan.workoutDays.size
+            val todayWorkout = plan.workoutDays.getOrNull(dayIndex)
+            _state.update {
+                it.copy(
+                    activePlan = plan,
+                    todayWorkout = todayWorkout,
+                )
+            }
+        }
+    }
+
+    private fun loadRecentWorkouts() {
+        safeLaunch(
+            onError = { error ->
+                _state.update { it.copy(isLoading = false) }
+                handleError(error) { loadRecentWorkouts() }
+            }
+        ) {
+            _state.update { it.copy(isLoading = true) }
+
+            val historyItems = personalRecordService.getWorkoutHistory()
+
+            val recentItems = historyItems
+                .sortedByDescending { it.date }
+                .take(3)
+                .map { historyItem ->
+                    val workout = workoutRepository.getWorkout(historyItem.workoutId)
+                    val sets = workout?.sets?.filter { !it.isWarmup } ?: emptyList()
+
+                    RecentWorkoutItem(
+                        workoutId = historyItem.workoutId,
+                        date = historyItem.date.toEpochMilli(),
+                        durationSeconds = historyItem.durationSeconds,
+                        exerciseCount = historyItem.exerciseCount,
+                        totalSets = sets.size,
+                        totalVolume = historyItem.totalVolume,
+                    )
+                }
+
+            _state.update {
+                it.copy(
+                    recentWorkouts = recentItems,
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    private fun loadDaysSinceLastWorkout() {
+        safeLaunch {
+            val days = workoutRepository.getDaysSinceLastWorkout()
+            _state.update { it.copy(daysSinceLastWorkout = days) }
+        }
+    }
+
+    override fun setLoading(loading: Boolean) {
+        _state.update { it.copy(isLoading = loading) }
+    }
+}


### PR DESCRIPTION
## Summary

Redesigns the Android home screen to answer "What should I do today?" instead of showing the exercise library.

### Changes

**New HomeScreen (default landing):**
- Active program with today's workout preview + 1-tap Start button
- Prominent Quick Start card with days-since-last-workout context
- Recent workouts summary (last 3)
- Create Your First Program CTA when no plan exists

**Navigation restructure:**
- Bottom nav: Home > Programs > History > Profile
- Exercise Library moved to secondary navigation
- Workout summary now returns to Home

**Bilingual support:** All new strings in EN and ES

Closes #335

Working as Trinity (Mobile Dev)