### PR TITLE
test: Add Paparazzi screenshot tests for critical screens

### DIFF
--- a/android/feature/src/test/java/com/gymbro/feature/history/screenshots/HistoryListScreenshotTest.kt
+++ b/android/feature/src/test/java/com/gymbro/feature/history/screenshots/HistoryListScreenshotTest.kt
@@ -1,0 +1,178 @@
+package com.gymbro.feature.history.screenshots
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.gymbro.app.ui.theme.GymBroTheme
+import com.gymbro.core.model.MuscleGroup
+import com.gymbro.feature.history.HistoryListState
+import com.gymbro.feature.history.WorkoutGroup
+import com.gymbro.feature.history.WorkoutListItem
+import org.junit.Rule
+import org.junit.Test
+
+class HistoryListScreenshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material3.DayNight.NoActionBar",
+        showSystemUi = false,
+    )
+
+    private val sampleWorkouts = listOf(
+        WorkoutListItem(
+            workoutId = "workout-1",
+            date = 1717891200000, // 2024-06-09
+            durationSeconds = 3600,
+            exerciseCount = 4,
+            totalVolume = 5200.0,
+            totalSets = 16,
+            muscleGroups = setOf(MuscleGroup.CHEST, MuscleGroup.TRICEPS),
+            prCount = 2,
+        ),
+        WorkoutListItem(
+            workoutId = "workout-2",
+            date = 1717718400000, // 2024-06-07
+            durationSeconds = 4500,
+            exerciseCount = 5,
+            totalVolume = 6800.0,
+            totalSets = 20,
+            muscleGroups = setOf(MuscleGroup.BACK, MuscleGroup.BICEPS),
+            prCount = 0,
+        ),
+        WorkoutListItem(
+            workoutId = "workout-3",
+            date = 1717545600000, // 2024-06-05
+            durationSeconds = 2700,
+            exerciseCount = 3,
+            totalVolume = 4100.0,
+            totalSets = 12,
+            muscleGroups = setOf(MuscleGroup.QUADRICEPS, MuscleGroup.HAMSTRINGS, MuscleGroup.GLUTES),
+            prCount = 1,
+        ),
+    )
+
+    @Test
+    fun historyListState_withWorkouts() {
+        val state = HistoryListState(
+            isLoading = false,
+            error = null,
+            workouts = sampleWorkouts,
+            groupedWorkouts = listOf(
+                WorkoutGroup(
+                    monthYear = "June 2024",
+                    workouts = sampleWorkouts,
+                ),
+            ),
+        )
+
+        paparazzi.snapshot("history_with_workouts") {
+            GymBroTheme {
+                Surface {
+                    Column(
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(
+                            text = "Workout History",
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "${state.workouts.size} workouts",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        state.groupedWorkouts.forEach { group ->
+                            Text(
+                                text = group.monthYear,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            group.workouts.forEach { workout ->
+                                Surface(
+                                    tonalElevation = 2.dp,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 4.dp),
+                                ) {
+                                    Column(modifier = Modifier.padding(12.dp)) {
+                                        Row {
+                                            Text(
+                                                text = "${workout.exerciseCount} exercises • ${workout.totalSets} sets",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                            )
+                                        }
+                                        Text(
+                                            text = "${workout.totalVolume.toInt()} kg total • ${workout.durationSeconds / 60}m",
+                                            style = MaterialTheme.typography.bodySmall,
+                                        )
+                                        if (workout.prCount > 0) {
+                                            Text(
+                                                text = "⭐ ${workout.prCount} PR${if (workout.prCount > 1) "s" else ""}",
+                                                style = MaterialTheme.typography.labelMedium,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun historyListState_empty() {
+        val state = HistoryListState(
+            isLoading = false,
+            error = null,
+            workouts = emptyList(),
+            groupedWorkouts = emptyList(),
+        )
+
+        paparazzi.snapshot("history_empty") {
+            GymBroTheme {
+                Surface {
+                    Column(
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(
+                            text = "No Workouts Yet",
+                            style = MaterialTheme.typography.headlineMedium,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Start your first workout to see history here",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun historyListState_loading() {
+        paparazzi.snapshot("history_loading") {
+            GymBroTheme {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}

--- a/android/feature/src/test/java/com/gymbro/feature/profile/screenshots/ProfileScreenshotTest.kt
+++ b/android/feature/src/test/java/com/gymbro/feature/profile/screenshots/ProfileScreenshotTest.kt
@@ -1,0 +1,116 @@
+package com.gymbro.feature.profile.screenshots
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.gymbro.app.ui.theme.GymBroTheme
+import com.gymbro.core.auth.GymBroUser
+import com.gymbro.core.sync.service.SyncStatus
+import com.gymbro.feature.profile.ProfileScreen
+import com.gymbro.feature.profile.ProfileState
+import org.junit.Rule
+import org.junit.Test
+
+class ProfileScreenshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material3.DayNight.NoActionBar",
+        showSystemUi = false,
+    )
+
+    @Test
+    fun profileScreen_signedIn() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProfileScreen(
+                    state = ProfileState(
+                        user = GymBroUser(
+                            uid = "user-123",
+                            displayName = "Alex",
+                            email = "alex@gymbro.com",
+                            isAnonymous = false,
+                        ),
+                        isSignedIn = true,
+                        syncStatus = SyncStatus.SUCCESS,
+                        lastSyncTime = System.currentTimeMillis(),
+                        autoSyncEnabled = true,
+                        isLoading = false,
+                        error = null,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun profileScreen_signedOut() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProfileScreen(
+                    state = ProfileState(
+                        user = null,
+                        isSignedIn = false,
+                        syncStatus = SyncStatus.IDLE,
+                        lastSyncTime = null,
+                        autoSyncEnabled = false,
+                        isLoading = false,
+                        error = null,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun profileScreen_anonymousUser() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProfileScreen(
+                    state = ProfileState(
+                        user = GymBroUser(
+                            uid = "anon-456",
+                            displayName = null,
+                            email = null,
+                            isAnonymous = true,
+                        ),
+                        isSignedIn = true,
+                        syncStatus = SyncStatus.DISABLED,
+                        lastSyncTime = null,
+                        autoSyncEnabled = false,
+                        isLoading = false,
+                        error = null,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun profileScreen_syncing() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProfileScreen(
+                    state = ProfileState(
+                        user = GymBroUser(
+                            uid = "user-123",
+                            displayName = "Alex",
+                            email = "alex@gymbro.com",
+                            isAnonymous = false,
+                        ),
+                        isSignedIn = true,
+                        syncStatus = SyncStatus.SYNCING,
+                        lastSyncTime = System.currentTimeMillis() - 300_000,
+                        autoSyncEnabled = true,
+                        isLoading = false,
+                        error = null,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+}

--- a/android/feature/src/test/java/com/gymbro/feature/programs/screenshots/ProgramsScreenshotTest.kt
+++ b/android/feature/src/test/java/com/gymbro/feature/programs/screenshots/ProgramsScreenshotTest.kt
@@ -1,0 +1,204 @@
+package com.gymbro.feature.programs.screenshots
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.gymbro.app.ui.theme.GymBroTheme
+import com.gymbro.core.model.MuscleGroup
+import com.gymbro.core.model.PlannedExercise
+import com.gymbro.core.model.TemplateExercise
+import com.gymbro.core.model.WorkoutDay
+import com.gymbro.core.model.WorkoutPlan
+import com.gymbro.core.model.WorkoutTemplate
+import com.gymbro.core.preferences.UserPreferences.ExperienceLevel
+import com.gymbro.core.preferences.UserPreferences.TrainingGoal
+import com.gymbro.feature.programs.ProgramsScreen
+import com.gymbro.feature.programs.ProgramsState
+import org.junit.Rule
+import org.junit.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+class ProgramsScreenshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material3.DayNight.NoActionBar",
+        showSystemUi = false,
+    )
+
+    private val sampleTemplates = listOf(
+        WorkoutTemplate(
+            id = UUID.randomUUID(),
+            name = "Push Day",
+            description = "Chest, shoulders, triceps",
+            exercises = listOf(
+                TemplateExercise(
+                    exerciseId = UUID.randomUUID(),
+                    exerciseName = "Bench Press",
+                    muscleGroup = MuscleGroup.CHEST,
+                    targetSets = 4,
+                    targetReps = 8,
+                ),
+                TemplateExercise(
+                    exerciseId = UUID.randomUUID(),
+                    exerciseName = "Overhead Press",
+                    muscleGroup = MuscleGroup.SHOULDERS,
+                    targetSets = 3,
+                    targetReps = 10,
+                ),
+            ),
+            lastUsedAt = Instant.now().minus(2, ChronoUnit.DAYS),
+        ),
+        WorkoutTemplate(
+            id = UUID.randomUUID(),
+            name = "Pull Day",
+            description = "Back and biceps",
+            exercises = listOf(
+                TemplateExercise(
+                    exerciseId = UUID.randomUUID(),
+                    exerciseName = "Barbell Row",
+                    muscleGroup = MuscleGroup.BACK,
+                    targetSets = 4,
+                    targetReps = 8,
+                ),
+                TemplateExercise(
+                    exerciseId = UUID.randomUUID(),
+                    exerciseName = "Pull-ups",
+                    muscleGroup = MuscleGroup.BACK,
+                    targetSets = 3,
+                    targetReps = 10,
+                ),
+            ),
+            lastUsedAt = Instant.now().minus(1, ChronoUnit.DAYS),
+        ),
+        WorkoutTemplate(
+            id = UUID.randomUUID(),
+            name = "Leg Day",
+            description = "Quads, hamstrings, glutes",
+            exercises = listOf(
+                TemplateExercise(
+                    exerciseId = UUID.randomUUID(),
+                    exerciseName = "Squat",
+                    muscleGroup = MuscleGroup.QUADRICEPS,
+                    targetSets = 5,
+                    targetReps = 5,
+                ),
+            ),
+        ),
+    )
+
+    private val samplePlan = WorkoutPlan(
+        name = "PPL Hypertrophy",
+        description = "Push/Pull/Legs 4-week block",
+        goal = TrainingGoal.HYPERTROPHY,
+        experienceLevel = ExperienceLevel.INTERMEDIATE,
+        daysPerWeek = 6,
+        weeks = 4,
+        workoutDays = listOf(
+            WorkoutDay(
+                dayNumber = 1,
+                name = "Push A",
+                exercises = listOf(
+                    PlannedExercise(exerciseName = "Bench Press", sets = 4, repsRange = "6-8"),
+                    PlannedExercise(exerciseName = "OHP", sets = 3, repsRange = "8-10"),
+                ),
+            ),
+            WorkoutDay(
+                dayNumber = 2,
+                name = "Pull A",
+                exercises = listOf(
+                    PlannedExercise(exerciseName = "Barbell Row", sets = 4, repsRange = "6-8"),
+                    PlannedExercise(exerciseName = "Pull-ups", sets = 3, repsRange = "8-12"),
+                ),
+            ),
+            WorkoutDay(
+                dayNumber = 3,
+                name = "Legs A",
+                exercises = listOf(
+                    PlannedExercise(exerciseName = "Squat", sets = 5, repsRange = "5"),
+                    PlannedExercise(exerciseName = "RDL", sets = 3, repsRange = "8-10"),
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun programsScreen_withTemplates() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProgramsScreen(
+                    state = ProgramsState(
+                        templates = sampleTemplates,
+                        activePlan = null,
+                        isLoading = false,
+                        isGeneratingPlan = false,
+                        error = null,
+                        showCreateDialog = false,
+                        showFirstProgramBanner = false,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun programsScreen_withActivePlan() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProgramsScreen(
+                    state = ProgramsState(
+                        templates = sampleTemplates,
+                        activePlan = samplePlan,
+                        isLoading = false,
+                        isGeneratingPlan = false,
+                        error = null,
+                        showCreateDialog = false,
+                        showFirstProgramBanner = false,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun programsScreen_empty() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProgramsScreen(
+                    state = ProgramsState(
+                        templates = emptyList(),
+                        activePlan = null,
+                        isLoading = false,
+                        isGeneratingPlan = false,
+                        error = null,
+                        showCreateDialog = false,
+                        showFirstProgramBanner = true,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun programsScreen_loading() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                ProgramsScreen(
+                    state = ProgramsState(
+                        templates = emptyList(),
+                        activePlan = null,
+                        isLoading = true,
+                        isGeneratingPlan = false,
+                        error = null,
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+    }
+}

--- a/android/feature/src/test/java/com/gymbro/feature/settings/screenshots/SettingsScreenshotTest.kt
+++ b/android/feature/src/test/java/com/gymbro/feature/settings/screenshots/SettingsScreenshotTest.kt
@@ -1,0 +1,90 @@
+package com.gymbro.feature.settings.screenshots
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.gymbro.app.ui.theme.GymBroTheme
+import com.gymbro.core.preferences.UserPreferences.TrainingPhase
+import com.gymbro.core.preferences.UserPreferences.WeightUnit
+import com.gymbro.feature.settings.SettingsScreen
+import com.gymbro.feature.settings.SettingsState
+import org.junit.Rule
+import org.junit.Test
+
+class SettingsScreenshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material3.DayNight.NoActionBar",
+        showSystemUi = false,
+    )
+
+    @Test
+    fun settingsScreen_defaultState() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                SettingsScreen(
+                    state = SettingsState(
+                        weightUnit = WeightUnit.KG,
+                        trainingPhase = TrainingPhase.MAINTENANCE,
+                        defaultRestTimer = 90,
+                        autoStartRestTimer = true,
+                        notificationsEnabled = false,
+                        isHealthConnectAvailable = true,
+                        isHealthConnectConnected = false,
+                        appVersion = "1.0.0",
+                        isLoading = false,
+                    ),
+                    onEvent = {},
+                    onNavigateBack = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun settingsScreen_lbsWithBulkPhase() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                SettingsScreen(
+                    state = SettingsState(
+                        weightUnit = WeightUnit.LBS,
+                        trainingPhase = TrainingPhase.BULK,
+                        defaultRestTimer = 120,
+                        autoStartRestTimer = false,
+                        notificationsEnabled = true,
+                        isHealthConnectAvailable = true,
+                        isHealthConnectConnected = true,
+                        appVersion = "1.0.0",
+                        isLoading = false,
+                    ),
+                    onEvent = {},
+                    onNavigateBack = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun settingsScreen_cutPhaseWithShortRest() {
+        paparazzi.snapshot {
+            GymBroTheme {
+                SettingsScreen(
+                    state = SettingsState(
+                        weightUnit = WeightUnit.KG,
+                        trainingPhase = TrainingPhase.CUT,
+                        defaultRestTimer = 60,
+                        autoStartRestTimer = true,
+                        notificationsEnabled = true,
+                        isHealthConnectAvailable = false,
+                        isHealthConnectConnected = false,
+                        appVersion = "1.0.0",
+                        isLoading = false,
+                    ),
+                    onEvent = {},
+                    onNavigateBack = {},
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds Paparazzi screenshot tests for 4 additional critical screens, complementing the existing 4 tests.

### New Screenshot Tests

| Test File | Screen | Test Cases |
|-----------|--------|------------|
| HistoryListScreenshotTest | History List | With workouts, empty, loading |
| SettingsScreenshotTest | Settings | Default (KG/Maintenance), LBS/Bulk, Cut/short rest |
| ProgramsScreenshotTest | Programs | With templates, with active plan, empty, loading |
| ProfileScreenshotTest | Profile | Signed in, signed out, anonymous, syncing |

### Coverage

**Before:** 4 screenshot tests (Onboarding, ExerciseLibrary, ActiveWorkout, Progress)
**After:** 8 screenshot tests covering all critical screens

### Notes

- HistoryList uses simplified rendering (no public state-based composable available)
- Settings and Profile tests use the `internal` screen composable directly
- Programs tests use the public `ProgramsScreen` composable
- Baseline recording is blocked by pre-existing compilation failures in RecoveryViewModelTest and ActiveWorkoutViewModelTest — run `recordPaparazziDebug` after those are fixed

Working as Switch (Tester)

Closes #342