### PR TITLE
fix: accessibility — contentDescriptions, touch targets, haptic feedback

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -875,3 +875,57 @@ Makes incremental progress on issue #334 (eliminate 32 total unsafe `!!` usages)
 2. **Trinity:** Ensure Home screen quick-start UX polish matches intent (new flow validates happy path)
 3. **Tank:** Monitor E2E test execution in CI; 33 flows may exceed timeout thresholds—consider parallel execution or time budgeting
 4. **All:** Master branch now in optimal shape for next feature iteration (logging, AI coach, periodization)
+
+---
+
+### 2026-04-11: Code Review & Merge — PR #413 (Switch) — Maestro E2E Flow Migration for New Nav
+
+**Context:** Switch (Tester) completed migration of all 24 Maestro E2E flows to align with new 4-tab navigation structure introduced in PR #409 (Home screen redesign, closes #335).
+
+**PR #413 — Maestro E2E Flows for New Home Screen Navigation (Closes #413, Switch)**
+
+**Scope:** 24 flow files updated; navigation test IDs and screen assertions migrated from old 5-tab structure to new 4-tab structure.
+
+**Changes Summary:**
+- **Old Navigation (5 tabs):** Exercise Library, History, Progress, Recovery, Profile
+- **New Navigation (4 tabs):** Home, Programs, History, Profile
+- **Test ID Updates:** All flows updated with new tab identifiers
+  - `nav_exercise_library` → `nav_home`
+  - `nav_progress` & `nav_recovery` removed
+  - New test IDs: `quick_start_card`, `quick_start_button`
+- **Landing Screen Assertions:** All landing assertions changed from "Biblioteca de Ejercicios" to "Inicio|Home"
+- **Exercise Library Access:** Refactored to access via exercise picker within workout flows (not primary tab)
+- **Documentation:** README.md and tab structure reference updated with new 4-tab layout
+
+**Files Modified:**
+- Documentation: `.squad/decisions/decisions.md` (142 insertions documenting home screen redesign, nav structure, onboarding auto-program, RPE progression, and user directive)
+- Test Infrastructure: `.maestro/README.md` (updated tab IDs and landing screen info)
+- Accessibility: `a11y-content-descriptions.yaml`, `a11y-keyboard-navigation.yaml` (updated for new nav)
+- E2E Flows (20 files): Core flows updated—smoke-test, navigation-smoke, full-e2e, browse-library, search filters, workout logging, history checks, profile settings, etc.
+
+**Quality Assurance:**
+- ✅ Smoke test (smoke-test.yaml) — passing on emulator
+- ✅ Navigation smoke test (navigation-smoke.yaml) — passing on emulator
+- ✅ All 24 flows updated consistently (search+replace applied cleanly across codebase)
+- ✅ No breaking changes; flows remain idempotent and composable
+
+**Known Pre-Existing Issue (Documented):**
+Exercise picker card taps don't trigger Compose `clickable` handlers via Maestro. This existed before PR #413—old flows would have failed due to exercise name changes (e.g., "Bench Press" → "Barbell Bench Press"). Not introduced by this PR; affects start-workout, complete-workout, and other exercise selection flows. Requires investigation of Maestro/Compose interaction model (not blocking this release).
+
+**Architectural Assessment:**
+- ✅ Navigation migration is complete and consistent across all test flows
+- ✅ Test IDs follow squad naming conventions (kebab-case, semantic meaning)
+- ✅ Bilingual support maintained (Spanish "Inicio" + English "Home")
+- ✅ No loss of test coverage—all 24 flows preserved and updated (not removed)
+- ✅ Smoke tests validated on emulator—quick sanity check confirms navigation flow works end-to-end
+
+**Decision:** ✅ APPROVED & MERGED (squash, branch deleted)
+
+**Board Status After Merge:**
+- ✅ PR #413 merged (commit squashed, local + remote branches deleted)
+- ✅ All stale local branches cleaned (14 branches with "gone" remotes removed)
+- ✅ Master branch HEAD: fresh, work tree clean
+- ✅ Navigation test migration complete; E2E flows now aligned with new product UX
+
+**Summary for Team:**
+PR #413 completes the E2E test migration following PR #409's UX redesign. All 24 Maestro flows now validate the new 4-tab navigation structure. Smoke tests pass. Team can now confidently deploy the home screen redesign knowing that automated E2E tests verify the navigation experience end-to-end. No regression risk from this PR—it's purely a test infrastructure update to match new product UX.

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -1186,3 +1186,64 @@ After onboarding completes, the app now auto-generates a personalized workout pl
 **By:** Copilot (via user request)  
 **What:** Ralph NEVER stops. Context is at 18%, user will /compact if needed. Continue until the board is completely empty. No excuses. Emulator available for Android testing issues.  
 **Why:** User request — captured for team memory during Round 5 completion sprint.
+
+---
+
+## 2026-04-10T18:25:00Z: User Directive — Full Validation Cycle
+
+**By:** Copilot (via user request)  
+**What:** After Maestro flows pass: 1) Re-audit skills and charters, correct if needed. 2) Review all delivered features and create follow-up issues for gaps/improvements. 3) Do NOT stop under any circumstances — no context excuses. Use Ralph if needed.  
+**Why:** User request — ensure comprehensive validation and continuous improvement of team capabilities
+
+---
+
+## 2026-04-10T22:30Z: Session Audit Findings & Integration Gap Priority
+
+**Author:** Morpheus (Lead)  
+**Date:** 2026-04-10  
+**Context:** Comprehensive audit of 11 PRs merged in Ralph session; 24 Maestro flows re-validated against new navigation
+
+### Decision
+
+#### 1. Integration Gaps Are Priority Fixes (Not Features)
+
+**Decision:** The following integration gaps must be fixed before any new feature work:
+- ProgressionEngine ignoring TrainingPhase (#414)
+- WorkoutPlanGenerator volume multiplier dead code (#415)
+- HomeScreen not refreshing on plan change (#416)
+- Quick-start without plan validation (#417)
+- OnboardingData not persisted before plan generation (#418)
+
+**Rationale:** These are wiring bugs, not missing features. Users who set "Cut" mode expect the app to behave differently. Shipping features that don't actually work erodes trust. Label: `fix`, not `feat`.
+
+#### 2. Pre-Existing Build Failures Block All Testing
+
+**Decision:** Fix ActiveWorkoutViewModelTest compilation (#428) and Paparazzi baselines (#429) before ANY other test work. These are blocking issues — 14 screenshot tests are useless without baselines.
+
+**Rationale:** Test infrastructure ROI is zero until tests actually run. Priority order: fix compilation → record baselines → then add new tests.
+
+#### 3. Accessibility Is a Must-Fix for Gym Context
+
+**Decision:** Touch targets below 48dp (#422) and missing contentDescriptions (#421) are `fix` priority, not polish. The glassmorphic contrast audit (#423) requires measurement before action.
+
+**Rationale:** Our target users have sweaty hands and wear gloves. 32dp buttons are unusable. This is a functional bug for our user segment.
+
+#### 4. Skills Audit Result
+
+All three new skills (performance-benchmarking, accessibility-audit, behavioral-nudges) are accurate and useful. The accessibility-audit skill correctly predicted the gaps we found. No corrections needed.
+
+**New skill opportunity identified:** A "compose-maestro-compatibility" skill documenting known Compose modifier + Maestro selector incompatibilities would prevent future E2E authoring friction.
+
+### Team Routing & Implications
+
+**Neo:** 5 issues (#414, #415, #418, #419, #434)  
+- Priority: ProgressionEngine wiring, plan generation finalization, voice parsing
+
+**Tank:** 4 issues (#416, #420, #428, #431)  
+- Priority: HomeScreen refresh, test infrastructure unblocking, speech recognizer lifecycle
+
+**Trinity:** 8 issues (#417, #421, #422, #423, #424, #425, #432, #433)  
+- Priority: Accessibility fixes, validation, touch targets, UX clarity
+
+**Switch:** 6 issues (#426, #427, #428, #429, #430, #431)  
+- Priority: Test infrastructure, coverage expansion, naming conventions

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -558,4 +558,13 @@
     <string name="home_create_program_subtitle">Obtén un plan de entrenamiento personalizado basado en tus objetivos</string>
     <string name="home_recent_workouts">Entrenamientos Recientes</string>
     <string name="home_exercises_count">%d ejercicios</string>
+
+    <!-- Accessibility — Content Descriptions -->
+    <string name="home_cd_start_workout">Iniciar entrenamiento</string>
+    <string name="home_cd_create_program">Crear programa</string>
+    <string name="active_workout_cd_add_set">Añadir serie</string>
+    <string name="active_workout_cd_warmup_toggle">Alternar serie de calentamiento</string>
+    <string name="rest_timer_cd_subtract_time">Restar 15 segundos</string>
+    <string name="rest_timer_cd_add_time">Añadir 15 segundos</string>
+    <string name="settings_cd_training_phase">Selector de fase de entrenamiento</string>
 </resources>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -558,4 +558,13 @@
     <string name="home_create_program_subtitle">Get a personalized training plan based on your goals</string>
     <string name="home_recent_workouts">Recent Workouts</string>
     <string name="home_exercises_count">%d exercises</string>
+
+    <!-- Accessibility — Content Descriptions -->
+    <string name="home_cd_start_workout">Start workout</string>
+    <string name="home_cd_create_program">Create program</string>
+    <string name="active_workout_cd_add_set">Add set</string>
+    <string name="active_workout_cd_warmup_toggle">Toggle warmup set</string>
+    <string name="rest_timer_cd_subtract_time">Subtract 15 seconds</string>
+    <string name="rest_timer_cd_add_time">Add 15 seconds</string>
+    <string name="settings_cd_training_phase">Training phase selector</string>
 </resources>

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
@@ -249,7 +249,7 @@ private fun QuickStartCard(
                 ) {
                     Icon(
                         Icons.Default.PlayArrow,
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.home_cd_start_workout),
                         modifier = Modifier.size(24.dp),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
@@ -325,7 +325,7 @@ private fun TodayWorkoutCard(
                 ) {
                     Icon(
                         Icons.Default.PlayArrow,
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.home_cd_start_workout),
                         modifier = Modifier.size(18.dp),
                     )
                     Spacer(modifier = Modifier.width(4.dp))
@@ -426,7 +426,7 @@ private fun CreateProgramCta(
         ) {
             Icon(
                 Icons.Default.CalendarMonth,
-                contentDescription = null,
+                contentDescription = stringResource(R.string.home_cd_create_program),
                 modifier = Modifier.size(48.dp),
                 tint = AccentGreen,
             )

--- a/android/feature/src/main/java/com/gymbro/feature/settings/SettingsScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/settings/SettingsScreen.kt
@@ -59,6 +59,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -107,6 +110,8 @@ internal fun SettingsScreen(
     onNavigateBack: () -> Unit,
 ) {
     var showClearDataDialog by remember { mutableStateOf(false) }
+    val haptic = LocalHapticFeedback.current
+    val trainingPhaseSelectorDescription = stringResource(R.string.settings_cd_training_phase)
 
     Scaffold(
         topBar = {
@@ -231,25 +236,36 @@ internal fun SettingsScreen(
                         }
                         Spacer(modifier = Modifier.height(8.dp))
                         SingleChoiceSegmentedButtonRow(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .semantics { contentDescription = trainingPhaseSelectorDescription },
                         ) {
                             SegmentedButton(
                                 selected = state.trainingPhase == TrainingPhase.BULK,
-                                onClick = { onEvent(SettingsEvent.SetTrainingPhase(TrainingPhase.BULK)) },
+                                onClick = {
+                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                    onEvent(SettingsEvent.SetTrainingPhase(TrainingPhase.BULK))
+                                },
                                 shape = SegmentedButtonDefaults.itemShape(0, 3),
                             ) {
                                 Text(stringResource(R.string.settings_training_phase_bulk), style = MaterialTheme.typography.labelMedium)
                             }
                             SegmentedButton(
                                 selected = state.trainingPhase == TrainingPhase.CUT,
-                                onClick = { onEvent(SettingsEvent.SetTrainingPhase(TrainingPhase.CUT)) },
+                                onClick = {
+                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                    onEvent(SettingsEvent.SetTrainingPhase(TrainingPhase.CUT))
+                                },
                                 shape = SegmentedButtonDefaults.itemShape(1, 3),
                             ) {
                                 Text(stringResource(R.string.settings_training_phase_cut), style = MaterialTheme.typography.labelMedium)
                             }
                             SegmentedButton(
                                 selected = state.trainingPhase == TrainingPhase.MAINTENANCE,
-                                onClick = { onEvent(SettingsEvent.SetTrainingPhase(TrainingPhase.MAINTENANCE)) },
+                                onClick = {
+                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                    onEvent(SettingsEvent.SetTrainingPhase(TrainingPhase.MAINTENANCE))
+                                },
                                 shape = SegmentedButtonDefaults.itemShape(2, 3),
                             ) {
                                 Text(stringResource(R.string.settings_training_phase_maintenance), style = MaterialTheme.typography.labelMedium)

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -407,6 +407,8 @@ private fun HeroRestTimer(
     onAdjust: (Int) -> Unit,
 ) {
     val haptic = LocalHapticFeedback.current
+    val subtractTimeDescription = stringResource(R.string.rest_timer_cd_subtract_time)
+    val addTimeDescription = stringResource(R.string.rest_timer_cd_add_time)
     val progress = if (totalSeconds > 0) (totalSeconds - remainingSeconds).toFloat() / totalSeconds else 0f
     
     val infiniteTransition = rememberInfiniteTransition(label = "glow_transition")
@@ -463,8 +465,12 @@ private fun HeroRestTimer(
                     onAdjust(-15) 
                 },
                 colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.White),
+                modifier = Modifier.height(48.dp),
             ) { 
-                Text("-15s") 
+                Text(
+                    text = "-15s",
+                    modifier = Modifier.semantics { contentDescription = subtractTimeDescription },
+                )
             }
             GradientButton(text = stringResource(R.string.active_workout_skip), onClick = onSkip)
             OutlinedButton(
@@ -473,8 +479,12 @@ private fun HeroRestTimer(
                     onAdjust(15) 
                 },
                 colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.White),
+                modifier = Modifier.height(48.dp),
             ) { 
-                Text("+15s") 
+                Text(
+                    text = "+15s",
+                    modifier = Modifier.semantics { contentDescription = addTimeDescription },
+                )
             }
         }
     }
@@ -598,7 +608,7 @@ private fun ExerciseCardContent(
                     haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                     onEvent(ActiveWorkoutEvent.RemoveExercise(exerciseIndex)) 
                 },
-                modifier = Modifier.size(32.dp),
+                modifier = Modifier.size(48.dp),
             ) {
                 Icon(
                     Icons.Default.Delete,
@@ -678,7 +688,7 @@ private fun ExerciseCardContent(
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(Icons.Default.Add, contentDescription = null, tint = AccentGreenStart, modifier = Modifier.size(16.dp))
+            Icon(Icons.Default.Add, contentDescription = stringResource(R.string.active_workout_cd_add_set), tint = AccentGreenStart, modifier = Modifier.size(16.dp))
             Spacer(modifier = Modifier.width(4.dp))
             Text(stringResource(R.string.workout_add_set), color = AccentGreenStart, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
         }
@@ -695,6 +705,7 @@ private fun SetRow(
     val haptic = LocalHapticFeedback.current
     val completedDescription = stringResource(R.string.active_workout_set_completed, setUi.setNumber)
     val completeDescription = stringResource(R.string.active_workout_complete_set, setUi.setNumber)
+    val warmupToggleDescription = stringResource(R.string.active_workout_cd_warmup_toggle)
     val rowBackground = when {
         setUi.isCompleted -> AccentGreenStart.copy(alpha = 0.08f)
         setUi.isWarmup -> AccentAmberStart.copy(alpha = 0.05f)
@@ -716,11 +727,12 @@ private fun SetRow(
         // Set number + warmup indicator
         Box(
             modifier = Modifier
-                .width(40.dp)
+                .size(48.dp)
                 .clickable { 
                     haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                     onEvent(ActiveWorkoutEvent.ToggleWarmup(exerciseIndex, setIndex)) 
-                },
+                }
+                .semantics { contentDescription = warmupToggleDescription },
             contentAlignment = Alignment.Center,
         ) {
             Text(

--- a/android/feature/src/main/java/com/gymbro/feature/workout/VoiceInputButton.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/VoiceInputButton.kt
@@ -166,7 +166,7 @@ fun VoiceInputButton(
 
             Box(
                 modifier = Modifier
-                    .size(32.dp)
+                    .size(56.dp)
                     .scale(scale)
                     .alpha(pulseAlpha)
                     .background(AccentRed, CircleShape)
@@ -200,13 +200,13 @@ fun VoiceInputButton(
                     }
                 }
             },
-            modifier = Modifier.size(32.dp),
+            modifier = Modifier.size(56.dp),
         ) {
             Icon(
                 imageVector = Icons.Default.Mic,
                 contentDescription = stringResource(R.string.voice_input_button),
                 tint = if (isListening) AccentRed else Color.White.copy(alpha = 0.7f),
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.size(24.dp),
             )
         }
     }


### PR DESCRIPTION
## Summary

Fixes three related accessibility issues in a single PR:

### #421 — Missing contentDescriptions on HomeScreen icons
- Added bilingual string resources (EN/ES) for interactive icon descriptions
- Fixed 3 HomeScreen icons: Quick Start PlayArrow, Start PlayArrow, CalendarMonth
- Fixed ActiveWorkoutScreen: Add Set icon, warmup toggle semantics

### #422 — Touch targets below 48dp
- **VoiceInputButton**: 32dp → 56dp (gym context = sweaty hands, gloves)
- **Delete exercise button**: 32dp → 48dp
- **Warmup toggle**: 40dp width → 48dp square
- **Rest timer ±15s buttons**: Added explicit 48dp height
- **Mic icon**: 18dp → 24dp for better visibility

### #425 — Training phase selector needs haptic + accessibility
- Added \HapticFeedbackType.TextHandleMove\ on all 3 SegmentedButton clicks (Bulk/Cut/Maintenance)
- Added semantics \contentDescription\ on the selector row for TalkBack

### Files changed (6)
- \core/src/main/res/values/strings.xml\ — 7 new EN accessibility strings
- \core/src/main/res/values-es/strings.xml\ — 7 new ES accessibility strings
- \eature/.../home/HomeScreen.kt\ — contentDescriptions on 3 icons
- \eature/.../workout/ActiveWorkoutScreen.kt\ — touch targets + contentDescriptions
- \eature/.../workout/VoiceInputButton.kt\ — 32dp → 56dp touch target
- \eature/.../settings/SettingsScreen.kt\ — haptic + semantics on training phase

Closes #421
Closes #422
Closes #425