### PR TITLE
fix: guard quick-start without plan + PlanDayDetail UX polish

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -943,6 +943,12 @@ PR #413 completes the E2E test migration following PR #409's UX redesign. All 24
   - Fix: Replaced with collectActivePlan() observing StateFlow continuously
   - Architecture: Proper reactive pattern; eliminates need for manual refresh triggers
 - Issue #420: SpeechRecognizer lifecycle leak
+- **Scope:** Two adjacent Android bugs fixed in single PR
+- **Issue #416:** HomeScreen not refreshing when active plan changes
+  - Root cause: HomeViewModel.loadActivePlan() called getPlan() once in init — snapshot-based, not reactive
+  - Fix: Replaced with collectActivePlan() observing StateFlow continuously
+  - Architecture: Proper reactive pattern; eliminates need for manual refresh triggers
+- **Issue #420:** SpeechRecognizer lifecycle leak
   - Root cause: VoiceRecognitionService created new instance without destroying previous; no composable lifecycle cleanup
   - Fix: Added releaseRecognizer() called before new instance creation, DisposableEffect on VoiceInputButton disposal
   - Lifecycle: 500ms debounce guard prevents rapid consecutive taps; tapping while listening stops cleanly
@@ -956,6 +962,15 @@ PR #413 completes the E2E test migration following PR #409's UX redesign. All 24
   - Fix: Added bilingual string resources (EN/ES) for screen reader support
   - TalkBack: 3 HomeScreen icons, Add Set button, warmup toggle all now have descriptions
 - Issue #422: Touch targets below 48dp (gym context: sweaty hands, gloves)
+- **Code Quality:** Surgical changes, no scope creep, proper cleanup patterns
+- **Decision:** ✓ APPROVED & MERGED (squash, branch deleted)
+
+**PR #436 — Accessibility: contentDescriptions, Touch Targets, Haptic Feedback (Closes #421, #422, #425, Trinity)**
+- **Scope:** Three related accessibility issues fixed
+- **Issue #421:** Missing contentDescriptions on HomeScreen + ActiveWorkoutScreen icons
+  - Fix: Added bilingual string resources (EN/ES) for screen reader support
+  - TalkBack: 3 HomeScreen icons, Add Set button, warmup toggle all now have descriptions
+- **Issue #422:** Touch targets below 48dp (gym context: sweaty hands, gloves)
   - VoiceInputButton: 32dp → 56dp (critical for gym environment)
   - Delete exercise button: 32dp → 48dp
   - Warmup toggle: 40dp → 48dp square
@@ -985,17 +1000,43 @@ PR #413 completes the E2E test migration following PR #409's UX redesign. All 24
 **PR #438 — Phase-Aware ProgressionEngine + Volume Multiplier Wiring (Closes #414, #415, Neo)**
 - Scope: Critical wiring gap fix — TrainingPhase was defined but unused
 - Issue #414: ProgressionEngine ignores TrainingPhase
+- **Issue #425:** Training phase selector haptic + accessibility
+  - Added: HapticFeedbackType.TextHandleMove on all 3 SegmentedButton clicks (Bulk/Cut/Maintenance)
+  - Semantics: contentDescription on selector row for TalkBack; improves discoverability
+- **Decision:** ✓ APPROVED & MERGED (squash, branch deleted)
+
+**PR #437 — Test Compilation Fix + 28 New Unit Tests (Closes #426, #428, Switch)**
+- **Scope:** Test infrastructure unblock + coverage expansion
+- **Issue #428:** ActiveWorkoutViewModelTest compilation failure
+  - Root cause: Missing TooltipManager mock (4th constructor param), incomplete FakeWorkoutRepository
+  - Fix: Added TooltipManager mock, implemented missing repository methods
+- **Issue #429:** RecoveryViewModelTest compilation failure
+  - Root cause: Missing UserPreferences mock (2nd constructor param) across all 15 test methods
+  - Fix: Added UserPreferences mock to all test methods
+- **Issue #426:** Missing unit test coverage (28 new tests)
+  - VoiceInputParserTest (14 tests): English/Spanish parsing, x/for/at formats, unit detection (kg/lbs), decimal weights, invalid input, format confirmation
+  - PlanDayDetailViewModelTest (6 tests): Load plan day, null plan error, invalid day error, retry behavior, per-day data validation
+  - HomeViewModelTest (8 tests): Active plan reactive updates, empty state, clearing plan, navigation effects, days since last workout
+- **Code Quality:** Focused test infrastructure work; no scope creep; proper mock setup; essential coverage
+- **Decision:** ✓ APPROVED & MERGED (squash, branch deleted)
+
+**PR #438 — Phase-Aware ProgressionEngine + Volume Multiplier Wiring (Closes #414, #415, Neo)**
+- **Scope:** Critical wiring gap fix — TrainingPhase was defined but unused
+- **Issue #414:** ProgressionEngine ignores TrainingPhase
   - Before: Identical RPE thresholds regardless of phase
   - After: Phase-aware thresholds (BULK: RPE ≤8 → progress, CUT: RPE ≤6 → progress, MAINTENANCE: RPE ≤7 → progress)
   - Tests: 9 new tests (3 phases × 3 RPE scenarios)
   - Architecture: Wiring complete from UserPreferences through ProgressionEngine
 - Issue #415: WorkoutPlanGenerator volume multiplier dead code
+- **Issue #415:** WorkoutPlanGenerator volume multiplier dead code
   - Before: volumeMultiplier calculated but never applied to set counts
   - After: Applied via applyVolumeMultiplier() to all plan generation paths (BULK: 1.2×, CUT: 0.8×, MAINTENANCE: 1.0×)
   - Integration: OnboardingViewModel and ProgramsViewModel now pass TrainingPhase
   - Tests: 4 new volume multiplier tests
 - Code Quality: Materializes previously-dead feature; proper end-to-end integration; comprehensive test coverage
 - Decision: ✅ APPROVED & MERGED (squash, branch deleted)
+- **Code Quality:** Materializes previously-dead feature; proper end-to-end integration; comprehensive test coverage
+- **Decision:** ✓ APPROVED & MERGED (squash, branch deleted)
 
 ---
 
@@ -1004,6 +1045,10 @@ PR #413 completes the E2E test migration following PR #409's UX redesign. All 24
 ✅ PR #436 (Trinity): Accessibility (touch targets, contentDescriptions, haptics)
 ✅ PR #437 (Switch): Test infrastructure + 28 new unit tests
 ✅ PR #438 (Neo): TrainingPhase wiring + volume multiplier application
+✓ PR #435 (Tank): HomeScreen reactive + SpeechRecognizer lifecycle
+✓ PR #436 (Trinity): Accessibility (touch targets, contentDescriptions, haptics)
+✓ PR #437 (Switch): Test infrastructure + 28 new unit tests
+✓ PR #438 (Neo): TrainingPhase wiring + volume multiplier application
 
 **Board Status After Merges:**
 - All 4 PRs squashed and merged to master

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -563,6 +563,9 @@
     <string name="home_create_program_subtitle">Obtén un plan de entrenamiento personalizado basado en tus objetivos</string>
     <string name="home_recent_workouts">Entrenamientos Recientes</string>
     <string name="home_exercises_count">%d ejercicios</string>
+    <string name="home_no_plan_title">Sin Programa Activo</string>
+    <string name="home_no_plan_message">Crea un programa de entrenamiento primero para que tu sesión tenga estructura y progresión.</string>
+    <string name="home_no_plan_go_to_programs">Ir a Programas</string>
 
     <!-- Accessibility — Content Descriptions -->
     <string name="home_cd_start_workout">Iniciar entrenamiento</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -563,6 +563,9 @@
     <string name="home_create_program_subtitle">Get a personalized training plan based on your goals</string>
     <string name="home_recent_workouts">Recent Workouts</string>
     <string name="home_exercises_count">%d exercises</string>
+    <string name="home_no_plan_title">No Active Program</string>
+    <string name="home_no_plan_message">Create a training program first so your workout has structure and progression.</string>
+    <string name="home_no_plan_go_to_programs">Go to Programs</string>
 
     <!-- Accessibility — Content Descriptions -->
     <string name="home_cd_start_workout">Start workout</string>

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeContract.kt
@@ -10,6 +10,7 @@ data class HomeState(
     val isLoading: Boolean = true,
     val isGeneratingPlan: Boolean = false,
     val daysSinceLastWorkout: Int? = null,
+    val showNoPlanDialog: Boolean = false,
 )
 
 data class RecentWorkoutItem(
@@ -27,6 +28,8 @@ sealed interface HomeEvent {
     data class StartTodayWorkout(val dayNumber: Int) : HomeEvent
     data class ViewWorkoutDetail(val workoutId: String) : HomeEvent
     data object ViewAllPrograms : HomeEvent
+    data object DismissNoPlanDialog : HomeEvent
+    data object NoPlanGoToPrograms : HomeEvent
 }
 
 sealed interface HomeEffect {

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -30,6 +31,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -187,6 +189,40 @@ fun HomeScreen(
                 }
             }
         }
+    }
+
+    if (state.showNoPlanDialog) {
+        AlertDialog(
+            onDismissRequest = { onEvent(HomeEvent.DismissNoPlanDialog) },
+            title = {
+                Text(
+                    text = stringResource(R.string.home_no_plan_title),
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+            text = {
+                Text(text = stringResource(R.string.home_no_plan_message))
+            },
+            confirmButton = {
+                Button(
+                    onClick = { onEvent(HomeEvent.NoPlanGoToPrograms) },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = AccentGreen,
+                        contentColor = Color.Black,
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.home_no_plan_go_to_programs),
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = { onEvent(HomeEvent.DismissNoPlanDialog) }) {
+                    Text(text = stringResource(R.string.action_cancel))
+                }
+            },
+        )
     }
 }
 

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeViewModel.kt
@@ -37,8 +37,13 @@ class HomeViewModel @Inject constructor(
     fun onEvent(event: HomeEvent) {
         when (event) {
             is HomeEvent.QuickStartWorkout -> {
-                viewModelScope.launch {
-                    _effect.send(HomeEffect.NavigateToActiveWorkout)
+                val plan = activePlanStore.getPlan()
+                if (plan == null) {
+                    _state.update { it.copy(showNoPlanDialog = true) }
+                } else {
+                    viewModelScope.launch {
+                        _effect.send(HomeEffect.NavigateToActiveWorkout)
+                    }
                 }
             }
             is HomeEvent.CreateFirstProgram -> {
@@ -57,6 +62,15 @@ class HomeViewModel @Inject constructor(
                 }
             }
             is HomeEvent.ViewAllPrograms -> {
+                viewModelScope.launch {
+                    _effect.send(HomeEffect.NavigateToPrograms)
+                }
+            }
+            is HomeEvent.DismissNoPlanDialog -> {
+                _state.update { it.copy(showNoPlanDialog = false) }
+            }
+            is HomeEvent.NoPlanGoToPrograms -> {
+                _state.update { it.copy(showNoPlanDialog = false) }
                 viewModelScope.launch {
                     _effect.send(HomeEffect.NavigateToPrograms)
                 }

--- a/android/feature/src/main/java/com/gymbro/feature/programs/PlanDayDetailScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/programs/PlanDayDetailScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
@@ -154,6 +156,7 @@ private fun PlanDayContent(
 ) {
     val exerciseCount = day.exercises.size
     val totalSets = day.exercises.sumOf { it.sets }
+    val haptic = LocalHapticFeedback.current
 
     LazyColumn(
         modifier = modifier
@@ -193,8 +196,14 @@ private fun PlanDayContent(
         }
 
         // Exercise cards
-        items(day.exercises) { exercise ->
-            ExerciseCard(exercise = exercise)
+        items(
+            items = day.exercises,
+            key = { it.id },
+        ) { exercise ->
+            ExerciseCard(
+                exercise = exercise,
+                modifier = Modifier.animateItem(),
+            )
             Spacer(modifier = Modifier.height(12.dp))
         }
 
@@ -203,7 +212,10 @@ private fun PlanDayContent(
             Spacer(modifier = Modifier.height(8.dp))
 
             Card(
-                onClick = onStartWorkout,
+                onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onStartWorkout()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .semantics {
@@ -272,7 +284,11 @@ private fun SummaryItem(
 }
 
 @Composable
-private fun ExerciseCard(exercise: PlannedExercise) {
+private fun ExerciseCard(
+    exercise: PlannedExercise,
+    modifier: Modifier = Modifier,
+) {
+    val haptic = LocalHapticFeedback.current
     val exerciseDesc = stringResource(
         R.string.programs_exercise_accessibility,
         exercise.exerciseName,
@@ -282,7 +298,7 @@ private fun ExerciseCard(exercise: PlannedExercise) {
     )
 
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .semantics(mergeDescendants = true) {
                 contentDescription = exerciseDesc
@@ -291,6 +307,9 @@ private fun ExerciseCard(exercise: PlannedExercise) {
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
         ),
+        onClick = {
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        },
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
## Summary

Fixes two UX issues:

### 417 - Quick Start without active plan
Home Quick Start now checks for active plan before navigating. Shows AlertDialog with Go to Programs CTA if no plan exists.

### 424 - PlanDayDetailScreen UX polish
- Added key = { it.id } to LazyColumn items for stable recomposition
- Added Modifier.animateItem() for enter/exit animations
- Added haptic feedback on exercise cards and Start Workout button

### Files changed (6)
- HomeContract.kt - showNoPlanDialog state, new events
- HomeViewModel.kt - plan guard + event handlers
- HomeScreen.kt - AlertDialog UI
- PlanDayDetailScreen.kt - key, animateItem, haptics
- strings.xml EN + ES - bilingual dialog strings

Closes #417
Closes #424