### PR TITLE
feat: surface RPE fatigue warnings + voice RPE parsing

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -929,3 +929,104 @@ Exercise picker card taps don't trigger Compose `clickable` handlers via Maestro
 
 **Summary for Team:**
 PR #413 completes the E2E test migration following PR #409's UX redesign. All 24 Maestro flows now validate the new 4-tab navigation structure. Smoke tests pass. Team can now confidently deploy the home screen redesign knowing that automated E2E tests verify the navigation experience end-to-end. No regression risk from this PR—it's purely a test infrastructure update to match new product UX.
+
+---
+
+### 2026-04-11: Code Review & Merge — PRs #435, #436, #437, #438 (Tank, Trinity, Switch, Neo)
+
+**Oversight:** Lead review and merge of 4 integrated fix PRs addressing critical integration gaps and infrastructure work.
+
+**PR #435 — HomeScreen Reactive Refresh + SpeechRecognizer Lifecycle Leak (Closes #416, #420, Tank)**
+- Scope: Two adjacent Android bugs fixed in single PR
+- Issue #416: HomeScreen not refreshing when active plan changes
+  - Root cause: HomeViewModel.loadActivePlan() called getPlan() once in init — snapshot-based, not reactive
+  - Fix: Replaced with collectActivePlan() observing StateFlow continuously
+  - Architecture: Proper reactive pattern; eliminates need for manual refresh triggers
+- Issue #420: SpeechRecognizer lifecycle leak
+  - Root cause: VoiceRecognitionService created new instance without destroying previous; no composable lifecycle cleanup
+  - Fix: Added releaseRecognizer() called before new instance creation, DisposableEffect on VoiceInputButton disposal
+  - Lifecycle: 500ms debounce guard prevents rapid consecutive taps; tapping while listening stops cleanly
+  - Architecture: DisposableEffect is the correct Compose idiom for side-effect cleanup
+- Code Quality: Surgical changes, no scope creep, proper cleanup patterns
+- Decision: ✅ APPROVED & MERGED (squash, branch deleted)
+
+**PR #436 — Accessibility: contentDescriptions, Touch Targets, Haptic Feedback (Closes #421, #422, #425, Trinity)**
+- Scope: Three related accessibility issues fixed
+- Issue #421: Missing contentDescriptions on HomeScreen + ActiveWorkoutScreen icons
+  - Fix: Added bilingual string resources (EN/ES) for screen reader support
+  - TalkBack: 3 HomeScreen icons, Add Set button, warmup toggle all now have descriptions
+- Issue #422: Touch targets below 48dp (gym context: sweaty hands, gloves)
+  - VoiceInputButton: 32dp → 56dp (critical for gym environment)
+  - Delete exercise button: 32dp → 48dp
+  - Warmup toggle: 40dp → 48dp square
+  - Rest timer ±15s buttons: Explicit 48dp height
+  - Mic icon: 18dp → 24dp for visibility
+  - Architecture: User-centric fixes, not cosmetic; functional necessity for target demographic
+- Issue #425: Training phase selector haptic + accessibility
+  - Added: HapticFeedbackType.TextHandleMove on all 3 SegmentedButton clicks (Bulk/Cut/Maintenance)
+  - Semantics: contentDescription on selector row for TalkBack; improves discoverability
+- Decision: ✅ APPROVED & MERGED (squash, branch deleted)
+
+**PR #437 — Test Compilation Fix + 28 New Unit Tests (Closes #426, #428, Switch)**
+- Scope: Test infrastructure unblock + coverage expansion
+- Issue #428: ActiveWorkoutViewModelTest compilation failure
+  - Root cause: Missing TooltipManager mock (4th constructor param), incomplete FakeWorkoutRepository
+  - Fix: Added TooltipManager mock, implemented missing repository methods
+- Issue #429: RecoveryViewModelTest compilation failure
+  - Root cause: Missing UserPreferences mock (2nd constructor param) across all 15 test methods
+  - Fix: Added UserPreferences mock to all test methods
+- Issue #426: Missing unit test coverage (28 new tests)
+  - VoiceInputParserTest (14 tests): English/Spanish parsing, x/for/at formats, unit detection (kg/lbs), decimal weights, invalid input, format confirmation
+  - PlanDayDetailViewModelTest (6 tests): Load plan day, null plan error, invalid day error, retry behavior, per-day data validation
+  - HomeViewModelTest (8 tests): Active plan reactive updates, empty state, clearing plan, navigation effects, days since last workout
+- Code Quality: Focused test infrastructure work; no scope creep; proper mock setup; essential coverage
+- Decision: ✅ APPROVED & MERGED (squash, branch deleted)
+
+**PR #438 — Phase-Aware ProgressionEngine + Volume Multiplier Wiring (Closes #414, #415, Neo)**
+- Scope: Critical wiring gap fix — TrainingPhase was defined but unused
+- Issue #414: ProgressionEngine ignores TrainingPhase
+  - Before: Identical RPE thresholds regardless of phase
+  - After: Phase-aware thresholds (BULK: RPE ≤8 → progress, CUT: RPE ≤6 → progress, MAINTENANCE: RPE ≤7 → progress)
+  - Tests: 9 new tests (3 phases × 3 RPE scenarios)
+  - Architecture: Wiring complete from UserPreferences through ProgressionEngine
+- Issue #415: WorkoutPlanGenerator volume multiplier dead code
+  - Before: volumeMultiplier calculated but never applied to set counts
+  - After: Applied via applyVolumeMultiplier() to all plan generation paths (BULK: 1.2×, CUT: 0.8×, MAINTENANCE: 1.0×)
+  - Integration: OnboardingViewModel and ProgramsViewModel now pass TrainingPhase
+  - Tests: 4 new volume multiplier tests
+- Code Quality: Materializes previously-dead feature; proper end-to-end integration; comprehensive test coverage
+- Decision: ✅ APPROVED & MERGED (squash, branch deleted)
+
+---
+
+**Merged PR Summary:**
+✅ PR #435 (Tank): HomeScreen reactive + SpeechRecognizer lifecycle
+✅ PR #436 (Trinity): Accessibility (touch targets, contentDescriptions, haptics)
+✅ PR #437 (Switch): Test infrastructure + 28 new unit tests
+✅ PR #438 (Neo): TrainingPhase wiring + volume multiplier application
+
+**Board Status After Merges:**
+- All 4 PRs squashed and merged to master
+- Local feature branches deleted
+- Remote branches deleted
+- Master branch fresh, work tree clean
+- Integration gaps closed; infrastructure unblocked; accessibility improved
+
+**Architecture Validation:**
+- HomeScreen now properly reactive (StateFlow pattern, no manual refreshes)
+- SpeechRecognizer lifecycle managed correctly (DisposableEffect cleanup)
+- Accessibility improvements align with gym context (sweaty hands, gloves—48dp targets essential)
+- Test infrastructure unblocked (compilation fixes + essential coverage)
+- TrainingPhase fully materialized (from user selection through progression and volume calculations)
+
+**Team Impact:**
+- Infrastructure work (Switch, PR #437) unblocks further feature development
+- Integration gaps (Neo, PR #438) restore confidence in TrainingPhase features
+- Accessibility fixes (Trinity, PR #436) improve usability for target demographic
+- Lifecycle fixes (Tank, PR #435) stabilize HomeScreen experience
+
+**Next Steps:**
+- Monitor master branch stability; no regressions expected (surgical changes, comprehensive testing)
+- Team can now proceed with confidence that integration gaps are closed and infrastructure is sound
+- Consider follow-up optimization work (e.g., AI coach personalization based on training phase, persistent plan storage)
+

--- a/android/core/src/main/java/com/gymbro/core/voice/VoiceInputParser.kt
+++ b/android/core/src/main/java/com/gymbro/core/voice/VoiceInputParser.kt
@@ -6,6 +6,7 @@ data class ParsedVoiceInput(
     val weight: Double,
     val reps: Int,
     val unit: UserPreferences.WeightUnit,
+    val rpe: Double? = null,
 )
 
 class VoiceInputParser {
@@ -27,15 +28,19 @@ class VoiceInputParser {
     fun parse(transcript: String, defaultUnit: UserPreferences.WeightUnit = UserPreferences.WeightUnit.KG): ParsedVoiceInput? {
         val normalized = transcript.lowercase().trim()
         
+        // Extract RPE before removing it from the string for weight/reps parsing
+        val rpe = extractRpe(normalized)
+        val withoutRpe = removeRpeSegment(normalized)
+
         // Extract unit from keywords
         val unit = when {
-            normalized.contains("kilo") || normalized.contains("kg") -> UserPreferences.WeightUnit.KG
-            normalized.contains("pound") || normalized.contains("lbs") || normalized.contains("lb") -> UserPreferences.WeightUnit.LBS
+            withoutRpe.contains("kilo") || withoutRpe.contains("kg") -> UserPreferences.WeightUnit.KG
+            withoutRpe.contains("pound") || withoutRpe.contains("lbs") || withoutRpe.contains("lb") -> UserPreferences.WeightUnit.LBS
             else -> defaultUnit
         }
 
         // Extract numbers
-        val numbers = extractNumbers(normalized)
+        val numbers = extractNumbers(withoutRpe)
         if (numbers.isEmpty()) return null
 
         // Pattern matching for different formats
@@ -46,7 +51,7 @@ class VoiceInputParser {
 
         // Check for "x" format: "100x5" or "100 x 5"
         val xPattern = Regex("""(\d+\.?\d*)\s*[x×]\s*(\d+)""")
-        val xMatch = xPattern.find(normalized)
+        val xMatch = xPattern.find(withoutRpe)
         if (xMatch != null) {
             weight = xMatch.groupValues[1].toDoubleOrNull()
             reps = xMatch.groupValues[2].toIntOrNull()
@@ -55,7 +60,7 @@ class VoiceInputParser {
         // Check for "for" format: "100 for 5"
         if (weight == null || reps == null) {
             val forPattern = Regex("""(\d+\.?\d*)\s+for\s+(\d+)""")
-            val forMatch = forPattern.find(normalized)
+            val forMatch = forPattern.find(withoutRpe)
             if (forMatch != null) {
                 weight = forMatch.groupValues[1].toDoubleOrNull()
                 reps = forMatch.groupValues[2].toIntOrNull()
@@ -65,7 +70,7 @@ class VoiceInputParser {
         // Check for "at" format: "5 reps at 100"
         if (weight == null || reps == null) {
             val atPattern = Regex("""(\d+)\s+(?:reps?)?\s*at\s+(\d+\.?\d*)""")
-            val atMatch = atPattern.find(normalized)
+            val atMatch = atPattern.find(withoutRpe)
             if (atMatch != null) {
                 reps = atMatch.groupValues[1].toIntOrNull()
                 weight = atMatch.groupValues[2].toDoubleOrNull()
@@ -85,7 +90,7 @@ class VoiceInputParser {
                 }
             } else if (numbers.size == 1) {
                 // Only one number - check context
-                if (normalized.contains("rep")) {
+                if (withoutRpe.contains("rep")) {
                     reps = numbers[0].toInt()
                 } else {
                     weight = numbers[0]
@@ -95,7 +100,7 @@ class VoiceInputParser {
 
         // Validate and return
         if (weight != null && weight > 0 && reps != null && reps > 0) {
-            return ParsedVoiceInput(weight, reps, unit)
+            return ParsedVoiceInput(weight, reps, unit, rpe)
         }
 
         return null
@@ -128,6 +133,52 @@ class VoiceInputParser {
             UserPreferences.WeightUnit.KG -> "kg"
             UserPreferences.WeightUnit.LBS -> "lbs"
         }
-        return "${input.weight.toInt()}$unitSymbol × ${input.reps}"
+        val base = "${input.weight.toInt()}$unitSymbol × ${input.reps}"
+        return if (input.rpe != null) {
+            "$base @ RPE ${formatRpe(input.rpe)}"
+        } else {
+            base
+        }
+    }
+
+    private fun formatRpe(rpe: Double): String {
+        return if (rpe == rpe.toLong().toDouble()) rpe.toLong().toString() else rpe.toString()
+    }
+
+    /**
+     * Extracts RPE value from phrases like "RPE 8", "RPE ocho", "rpe 9.5".
+     * Supports English and Spanish number words.
+     */
+    private fun extractRpe(text: String): Double? {
+        // Match "rpe" followed by a number (digit or word)
+        val digitPattern = Regex("""rpe\s+(\d+\.?\d*)""")
+        val digitMatch = digitPattern.find(text)
+        if (digitMatch != null) {
+            val value = digitMatch.groupValues[1].toDoubleOrNull()
+            if (value != null && value in 1.0..10.0) return value
+        }
+
+        // Match "rpe" followed by a number word
+        val wordPattern = Regex("""rpe\s+(\w+)""")
+        val wordMatch = wordPattern.find(text)
+        if (wordMatch != null) {
+            val word = wordMatch.groupValues[1]
+            val value = numberWords[word]
+            if (value != null && value in 1..10) return value.toDouble()
+        }
+
+        return null
+    }
+
+    /**
+     * Removes the RPE segment from input so RPE numbers don't interfere
+     * with weight/reps extraction.
+     */
+    private fun removeRpeSegment(text: String): String {
+        // Remove "rpe <number>" or "rpe <word>"
+        return text
+            .replace(Regex("""rpe\s+\d+\.?\d*"""), "")
+            .replace(Regex("""rpe\s+\w+"""), "")
+            .trim()
     }
 }

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -544,6 +544,11 @@
     <string name="voice_input_parse_error">No se pudo entender \"%1$s\". Intenta \"100 kilos 5 repeticiones\".</string>
     <string name="voice_input_confirmed">Serie llenada: %1$s</string>
 
+    <!-- Fatigue Warnings -->
+    <string name="fatigue_warning_title">⚠️ Alerta de Fatiga</string>
+    <string name="fatigue_warning_dismiss">Descartar alertas de fatiga</string>
+    <string name="fatigue_warning_detail">%1$s: RPE promedio %2$s%3$s — considera reducir la carga</string>
+
     <!-- Home Screen -->
     <string name="home_title">Inicio</string>
     <string name="home_quick_start">Inicio Rápido</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -544,6 +544,11 @@
     <string name="voice_input_parse_error">Couldn\'t understand \"%1$s\". Try \"100 kilos 5 reps\".</string>
     <string name="voice_input_confirmed">Set filled: %1$s</string>
 
+    <!-- Fatigue Warnings -->
+    <string name="fatigue_warning_title">⚠️ Fatigue Alert</string>
+    <string name="fatigue_warning_dismiss">Dismiss fatigue warnings</string>
+    <string name="fatigue_warning_detail">%1$s: avg RPE %2$s%3$s — consider reducing load</string>
+
     <!-- Home Screen -->
     <string name="home_title">Home</string>
     <string name="home_quick_start">Quick Start</string>

--- a/android/core/src/test/java/com/gymbro/core/voice/VoiceInputParserTest.kt
+++ b/android/core/src/test/java/com/gymbro/core/voice/VoiceInputParserTest.kt
@@ -123,4 +123,68 @@ class VoiceInputParserTest {
         assertEquals(100.0, result!!.weight, 0.01)
         assertEquals(5, result.reps)
     }
+
+    // --- RPE voice parsing tests (#419) ---
+
+    @Test
+    fun `parse RPE from digit`() {
+        val result = parser.parse("100 kilos 5 reps RPE 8")
+        assertNotNull(result)
+        assertEquals(100.0, result!!.weight, 0.01)
+        assertEquals(5, result.reps)
+        assertEquals(8.0, result.rpe!!, 0.01)
+    }
+
+    @Test
+    fun `parse RPE from decimal digit`() {
+        val result = parser.parse("80 kg 6 reps rpe 8.5")
+        assertNotNull(result)
+        assertEquals(80.0, result!!.weight, 0.01)
+        assertEquals(6, result.reps)
+        assertEquals(8.5, result.rpe!!, 0.01)
+    }
+
+    @Test
+    fun `parse RPE from Spanish word`() {
+        val result = parser.parse("100 kilos 5 reps RPE ocho")
+        assertNotNull(result)
+        assertEquals(100.0, result!!.weight, 0.01)
+        assertEquals(5, result.reps)
+        assertEquals(8.0, result.rpe!!, 0.01)
+    }
+
+    @Test
+    fun `parse RPE from English word`() {
+        val result = parser.parse("100x5 rpe nine")
+        assertNotNull(result)
+        assertEquals(100.0, result!!.weight, 0.01)
+        assertEquals(5, result.reps)
+        assertEquals(9.0, result.rpe!!, 0.01)
+    }
+
+    @Test
+    fun `RPE is null when not mentioned`() {
+        val result = parser.parse("100 kg 5 reps")
+        assertNotNull(result)
+        assertNull(result!!.rpe)
+    }
+
+    @Test
+    fun `RPE out of range is ignored`() {
+        val result = parser.parse("100 kg 5 reps rpe 15")
+        assertNotNull(result)
+        assertNull(result!!.rpe)
+    }
+
+    @Test
+    fun `formatConfirmation includes RPE when present`() {
+        val input = ParsedVoiceInput(weight = 100.0, reps = 5, unit = UserPreferences.WeightUnit.KG, rpe = 8.0)
+        assertEquals("100kg × 5 @ RPE 8", parser.formatConfirmation(input))
+    }
+
+    @Test
+    fun `formatConfirmation excludes RPE when null`() {
+        val input = ParsedVoiceInput(weight = 100.0, reps = 5, unit = UserPreferences.WeightUnit.KG, rpe = null)
+        assertEquals("100kg × 5", parser.formatConfirmation(input))
+    }
 }

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -16,6 +16,14 @@ data class ActiveWorkoutState(
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
     val hasInProgressWorkout: Boolean = false,
+    val fatigueWarnings: List<FatigueWarningUi> = emptyList(),
+)
+
+data class FatigueWarningUi(
+    val exerciseId: String,
+    val exerciseName: String,
+    val currentAvgRpe: Double,
+    val rpeDelta: Double?,
 )
 
 data class WorkoutExerciseUi(
@@ -45,13 +53,14 @@ sealed interface ActiveWorkoutEvent {
     data class QuickCompleteSet(val exerciseIndex: Int, val setIndex: Int) : ActiveWorkoutEvent
     data class RemoveSet(val exerciseIndex: Int, val setIndex: Int) : ActiveWorkoutEvent
     data class RemoveExercise(val exerciseIndex: Int) : ActiveWorkoutEvent
-    data class VoiceInput(val exerciseIndex: Int, val setIndex: Int, val weight: String, val reps: String) : ActiveWorkoutEvent
+    data class VoiceInput(val exerciseIndex: Int, val setIndex: Int, val weight: String, val reps: String, val rpe: String = "") : ActiveWorkoutEvent
     data object StartRestTimer : ActiveWorkoutEvent
     data object SkipRestTimer : ActiveWorkoutEvent
     data class AdjustRestTimer(val deltaSeconds: Int) : ActiveWorkoutEvent
     data object CompleteWorkout : ActiveWorkoutEvent
     data object DiscardWorkout : ActiveWorkoutEvent
     data object ClearError : ActiveWorkoutEvent
+    data object DismissFatigueWarnings : ActiveWorkoutEvent
     data object RetryStartWorkout : ActiveWorkoutEvent
     data object ResumeWorkout : ActiveWorkoutEvent
     data object StartNewWorkout : ActiveWorkoutEvent

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -331,6 +331,16 @@ fun ActiveWorkoutScreen(
                     }
                 }
 
+                // Fatigue warnings banner (#418)
+                if (state.fatigueWarnings.isNotEmpty()) {
+                    item {
+                        FatigueWarningBanner(
+                            warnings = state.fatigueWarnings,
+                            onDismiss = { onEvent(ActiveWorkoutEvent.DismissFatigueWarnings) },
+                        )
+                    }
+                }
+
                 // Exercise cards
                 itemsIndexed(
                     items = state.exercises,
@@ -396,6 +406,64 @@ private fun StatItem(label: String, value: String, color: Color) {
             style = MaterialTheme.typography.labelSmall,
             color = Color.White.copy(alpha = 0.6f),
         )
+    }
+}
+
+@Composable
+private fun FatigueWarningBanner(
+    warnings: List<FatigueWarningUi>,
+    onDismiss: () -> Unit,
+) {
+    val warningColor = Color(0xFFFF9800)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(warningColor.copy(alpha = 0.15f))
+            .border(1.dp, warningColor.copy(alpha = 0.4f), RoundedCornerShape(12.dp))
+            .padding(12.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.fatigue_warning_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = warningColor,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.size(24.dp),
+            ) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.fatigue_warning_dismiss),
+                    tint = Color.White.copy(alpha = 0.6f),
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        warnings.forEach { warning ->
+            val deltaText = warning.rpeDelta?.let { d ->
+                " (+${String.format("%.1f", d)})"
+            } ?: ""
+            Text(
+                text = stringResource(
+                    R.string.fatigue_warning_detail,
+                    warning.exerciseName,
+                    String.format("%.1f", warning.currentAvgRpe),
+                    deltaText,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White.copy(alpha = 0.8f),
+                modifier = Modifier.padding(bottom = 2.dp),
+            )
+        }
     }
 }
 
@@ -594,6 +662,9 @@ private fun ExerciseCardContent(
                                     if (w == w.toLong().toDouble()) w.toLong().toString() else w.toString()
                                 },
                                 reps = parsed.reps.toString(),
+                                rpe = parsed.rpe?.let { r ->
+                                    if (r == r.toLong().toDouble()) r.toLong().toString() else r.toString()
+                                } ?: "",
                             )
                         )
                         voiceToast = parser.formatConfirmation(parsed)

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.viewModelScope
 import com.gymbro.core.error.toUserMessage
 import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.ExerciseSet
+import com.gymbro.core.repository.ExerciseRepository
 import com.gymbro.core.repository.WorkoutRepository
+import com.gymbro.core.service.RpeTrendService
 import com.gymbro.core.service.PersonalRecordService
 import com.gymbro.core.service.SmartDefaultsService
 import com.gymbro.feature.common.BaseViewModel
@@ -27,6 +29,8 @@ class ActiveWorkoutViewModel @Inject constructor(
     private val workoutRepository: WorkoutRepository,
     private val personalRecordService: PersonalRecordService,
     private val smartDefaultsService: SmartDefaultsService,
+    private val rpeTrendService: RpeTrendService,
+    private val exerciseRepository: ExerciseRepository,
     val tooltipManager: TooltipManager,
 ) : BaseViewModel() {
 
@@ -42,6 +46,7 @@ class ActiveWorkoutViewModel @Inject constructor(
 
     init {
         checkForInProgressWorkout()
+        loadFatigueWarnings()
     }
 
     private fun checkForInProgressWorkout() {
@@ -96,6 +101,29 @@ class ActiveWorkoutViewModel @Inject constructor(
         }
     }
 
+    private fun loadFatigueWarnings() {
+        viewModelScope.launch {
+            try {
+                val warnings = rpeTrendService.getFatigueWarnings()
+                if (warnings.isNotEmpty()) {
+                    val warningUis = warnings.mapNotNull { trend ->
+                        val exercise = exerciseRepository.getExerciseById(trend.exerciseId)
+                        val name = exercise?.name ?: return@mapNotNull null
+                        FatigueWarningUi(
+                            exerciseId = trend.exerciseId,
+                            exerciseName = name,
+                            currentAvgRpe = trend.currentAvgRpe,
+                            rpeDelta = trend.previousAvgRpe?.let { trend.currentAvgRpe - it },
+                        )
+                    }
+                    _state.update { it.copy(fatigueWarnings = warningUis) }
+                }
+            } catch (_: Exception) {
+                // Non-critical — silently ignore if fatigue data unavailable
+            }
+        }
+    }
+
     fun onEvent(event: ActiveWorkoutEvent) {
         when (event) {
             is ActiveWorkoutEvent.ResumeWorkout -> resumeWorkout()
@@ -125,7 +153,8 @@ class ActiveWorkoutViewModel @Inject constructor(
             is ActiveWorkoutEvent.RemoveExercise -> removeExercise(event.exerciseIndex)
             is ActiveWorkoutEvent.VoiceInput -> {
                 updateSetField(event.exerciseIndex, event.setIndex) {
-                    it.copy(weight = event.weight, reps = event.reps)
+                    val updated = it.copy(weight = event.weight, reps = event.reps)
+                    if (event.rpe.isNotBlank()) updated.copy(rpe = event.rpe) else updated
                 }
             }
             is ActiveWorkoutEvent.StartRestTimer -> startRestTimer()
@@ -134,6 +163,7 @@ class ActiveWorkoutViewModel @Inject constructor(
             is ActiveWorkoutEvent.CompleteWorkout -> completeWorkout()
             is ActiveWorkoutEvent.DiscardWorkout -> discardWorkout()
             is ActiveWorkoutEvent.ClearError -> _state.update { it.copy(errorMessage = null) }
+            is ActiveWorkoutEvent.DismissFatigueWarnings -> _state.update { it.copy(fatigueWarnings = emptyList()) }
             is ActiveWorkoutEvent.RetryStartWorkout -> startWorkout()
         }
     }


### PR DESCRIPTION
## Summary

Fixes two related RPE features in a single PR.

### #418 — RPE fatigue warnings surfaced in ActiveWorkout UI
- **RpeTrendService** already tracks 7-day rolling RPE trends and flags exercises with rising RPE >= 8.5
- **New:** ViewModel loads fatigue warnings on init via \loadFatigueWarnings()\
- **New:** Dismissible amber banner shown in ActiveWorkoutScreen between stats card and exercise cards
- Shows exercise name, current avg RPE, and delta from previous period
- Uses string resources (EN + ES) for all text

### #419 — Voice input now parses RPE
- **VoiceInputParser** extended with \xtractRpe()\ and \emoveRpeSegment()\ methods
- Parses \RPE 8\, \pe 8.5\, \RPE ocho\, \pe nine\ from voice transcripts (EN + ES number words)
- RPE segment stripped before weight/reps extraction to avoid number confusion
- \ParsedVoiceInput\ now includes optional \pe: Double?\ field
- \VoiceInput\ event updated to carry RPE to ViewModel -> auto-fills RPE field
- \ormatConfirmation()\ shows RPE in voice feedback toast: \100kg × 5 @ RPE 8\
- 8 new unit tests covering digit, decimal, word (EN/ES), null, out-of-range, and format

### Files changed (7)
- \VoiceInputParser.kt\ — RPE extraction + formatting
- \VoiceInputParserTest.kt\ — 8 new RPE tests
- \ActiveWorkoutContract.kt\ — \FatigueWarningUi\ model, state field, \DismissFatigueWarnings\ event, \VoiceInput.rpe\
- \ActiveWorkoutViewModel.kt\ — inject \RpeTrendService\ + \ExerciseRepository\, load warnings, handle voice RPE
- \ActiveWorkoutScreen.kt\ — \FatigueWarningBanner\ composable, voice RPE passthrough
- \strings.xml\ (EN + ES) — fatigue warning strings

Closes #418
Closes #419