### PR TITLE
feat: connect RPE to AI coach + add picker color animation

### DIFF
--- a/android/core/src/main/java/com/gymbro/core/ai/AiCoachService.kt
+++ b/android/core/src/main/java/com/gymbro/core/ai/AiCoachService.kt
@@ -8,6 +8,7 @@ import com.gymbro.core.model.PersonalRecord
 import com.gymbro.core.model.RecordType
 import com.gymbro.core.repository.WorkoutRepository
 import com.gymbro.core.service.PersonalRecordService
+import com.gymbro.core.service.RpeTrendService
 import kotlinx.coroutines.flow.first
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -18,6 +19,7 @@ import javax.inject.Singleton
 class AiCoachService @Inject constructor(
     private val workoutRepository: WorkoutRepository,
     private val personalRecordService: PersonalRecordService,
+    private val rpeTrendService: RpeTrendService,
 ) {
     private val chatHistory = mutableListOf<ChatMessage>()
     
@@ -121,6 +123,23 @@ class AiCoachService @Inject constructor(
             }
         }
 
+        // Gather RPE trends and fatigue warnings
+        val rpeTrends = exerciseIds.take(5).mapNotNull { exerciseId ->
+            try {
+                rpeTrendService.getTrend(exerciseId.toString())
+            } catch (e: Exception) {
+                null
+            }
+        }
+        val fatigueWarnings = rpeTrends.filter { it.isFatigueWarning }
+
+        // Compute overall average RPE from recent sets
+        val recentRpeSets = recentWorkouts.flatMap { it.sets }
+            .filter { !it.isWarmup && it.rpe != null }
+        val overallAvgRpe = if (recentRpeSets.isNotEmpty()) {
+            recentRpeSets.mapNotNull { it.rpe }.average()
+        } else null
+
         return buildString {
             append("USER CONTEXT:\n")
             
@@ -140,6 +159,25 @@ class AiCoachService @Inject constructor(
                     append("- Total volume (recent): ${String.format("%.0f", totalVolume)} kg\n")
                 } catch (e: Exception) {
                     // Skip volume calculation if error
+                }
+            }
+
+            // RPE trends
+            if (overallAvgRpe != null) {
+                append("- Recent average RPE: ${String.format("%.1f", overallAvgRpe)}\n")
+            }
+            if (fatigueWarnings.isNotEmpty()) {
+                append("- ⚠ Fatigue warnings (RPE trending up):\n")
+                fatigueWarnings.forEach { trend ->
+                    val prev = trend.previousAvgRpe?.let { String.format("%.1f", it) } ?: "N/A"
+                    append("  * Exercise ${trend.exerciseId}: avg RPE ${String.format("%.1f", trend.currentAvgRpe)} (was $prev)\n")
+                }
+            }
+            if (rpeTrends.isNotEmpty()) {
+                val risingCount = rpeTrends.count { it.trend == RpeTrendService.TrendDirection.RISING }
+                val fallingCount = rpeTrends.count { it.trend == RpeTrendService.TrendDirection.FALLING }
+                if (risingCount > 0 || fallingCount > 0) {
+                    append("- RPE trends: $risingCount exercises rising, $fallingCount falling\n")
                 }
             }
             

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -1,6 +1,7 @@
 package com.gymbro.feature.workout
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -1020,12 +1021,17 @@ private fun RpeQuickPicker(
     val currentIndex = rpeValues.indexOf(selectedRpe).coerceAtLeast(0)
 
     val displayText = if (selectedRpe.isEmpty()) "—" else selectedRpe
-    val rpeColor = when (selectedRpe.toIntOrNull()) {
+    val targetRpeColor = when (selectedRpe.toIntOrNull()) {
         in 6..7 -> AccentGreenStart
         8 -> AccentAmberStart
         in 9..10 -> AccentRed
         else -> Color.White.copy(alpha = 0.4f)
     }
+    val rpeColor by animateColorAsState(
+        targetValue = targetRpeColor,
+        animationSpec = tween(durationMillis = 300),
+        label = "rpeColor",
+    )
 
     Box(
         modifier = modifier

--- a/ios/Packages/GymBroCore/Sources/GymBroCore/Services/AI/AICoachService.swift
+++ b/ios/Packages/GymBroCore/Sources/GymBroCore/Services/AI/AICoachService.swift
@@ -63,12 +63,14 @@ public struct ExerciseSnapshot {
     public let sets: Int
     public let bestWeight: Double
     public let bestReps: Int
+    public let avgRpe: Double?
 
-    public init(name: String, sets: Int, bestWeight: Double, bestReps: Int) {
+    public init(name: String, sets: Int, bestWeight: Double, bestReps: Int, avgRpe: Double? = nil) {
         self.name = name
         self.sets = sets
         self.bestWeight = bestWeight
         self.bestReps = bestReps
+        self.avgRpe = avgRpe
     }
 }
 

--- a/ios/Packages/GymBroCore/Sources/GymBroCore/Services/AI/PromptBuilder.swift
+++ b/ios/Packages/GymBroCore/Sources/GymBroCore/Services/AI/PromptBuilder.swift
@@ -16,6 +16,10 @@ public struct PromptBuilder {
 
         if !context.recentWorkouts.isEmpty {
             parts.append(recentWorkoutsSection(context.recentWorkouts))
+            let rpeSection = rpeTrendsSection(context.recentWorkouts)
+            if !rpeSection.isEmpty {
+                parts.append(rpeSection)
+            }
         }
 
         if let program = context.activeProgram {
@@ -64,7 +68,13 @@ public struct PromptBuilder {
         var lines = ["## Recent Workouts (last \(workouts.count))"]
         for workout in workouts.prefix(5) {
             let dateStr = formatter.string(from: workout.date)
-            let exercises = workout.exercises.map { "\($0.name) \($0.sets)×\($0.bestReps)@\(String(format: "%.1f", $0.bestWeight))kg" }
+            let exercises = workout.exercises.map { ex in
+                var desc = "\(ex.name) \(ex.sets)×\(ex.bestReps)@\(String(format: "%.1f", ex.bestWeight))kg"
+                if let rpe = ex.avgRpe {
+                    desc += " RPE \(String(format: "%.0f", rpe))"
+                }
+                return desc
+            }
             let duration = workout.durationMinutes.map { " (\(Int($0))min)" } ?? ""
             lines.append("- \(dateStr)\(duration): \(exercises.joined(separator: ", "))")
         }
@@ -89,6 +99,33 @@ public struct PromptBuilder {
             let dateStr = formatter.string(from: pr.date)
             lines.append("- \(pr.exerciseName): \(String(format: "%.1f", pr.weightKg))kg × \(pr.reps) (\(dateStr))")
         }
+        return lines.joined(separator: "\n")
+    }
+
+    private func rpeTrendsSection(_ workouts: [WorkoutSnapshot]) -> String {
+        let exercisesWithRpe = workouts.flatMap(\.exercises).filter { $0.avgRpe != nil }
+        guard !exercisesWithRpe.isEmpty else { return "" }
+
+        let allRpes = exercisesWithRpe.compactMap(\.avgRpe)
+        let overallAvg = allRpes.reduce(0, +) / Double(allRpes.count)
+
+        var lines = ["## RPE Trends"]
+        lines.append("- Overall average RPE (recent): \(String(format: "%.1f", overallAvg))")
+
+        // Flag high-RPE exercises (avg ≥ 8.5 = potential fatigue)
+        let fatigued = Dictionary(grouping: exercisesWithRpe, by: \.name)
+            .compactMap { name, snapshots -> (String, Double)? in
+                let avg = snapshots.compactMap(\.avgRpe).reduce(0, +) / Double(snapshots.count)
+                return avg >= 8.5 ? (name, avg) : nil
+            }
+
+        if !fatigued.isEmpty {
+            lines.append("- ⚠ High-effort exercises (avg RPE ≥ 8.5):")
+            for (name, avg) in fatigued {
+                lines.append("  * \(name): avg RPE \(String(format: "%.1f", avg))")
+            }
+        }
+
         return lines.joined(separator: "\n")
     }
 

--- a/ios/Packages/GymBroUI/Sources/GymBroUI/ViewModels/CoachChatViewModel.swift
+++ b/ios/Packages/GymBroUI/Sources/GymBroUI/ViewModels/CoachChatViewModel.swift
@@ -287,11 +287,14 @@ public final class CoachChatViewModel {
                 guard !sets.isEmpty else { return nil }
                 let bestWeight = sets.map(\.weightKg).max() ?? 0
                 let bestReps = sets.map(\.reps).max() ?? 0
+                let rpeSets = sets.compactMap(\.rpe)
+                let avgRpe = rpeSets.isEmpty ? nil : rpeSets.reduce(0, +) / Double(rpeSets.count)
                 return ExerciseSnapshot(
                     name: name,
                     sets: sets.count,
                     bestWeight: bestWeight,
-                    bestReps: bestReps
+                    bestReps: bestReps,
+                    avgRpe: avgRpe
                 )
             }
             

--- a/ios/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/ActiveWorkoutView.swift
+++ b/ios/Packages/GymBroUI/Sources/GymBroUI/Views/Workout/ActiveWorkoutView.swift
@@ -249,7 +249,20 @@ public struct ActiveWorkoutView: View {
                 }
             }
             .font(GymBroTypography.subheadline)
-            .foregroundStyle(viewModel.currentRPE != nil ? GymBroColors.accentAmber : GymBroColors.textSecondary)
+            .foregroundStyle(rpeColor)
+        }
+        .animation(.easeInOut(duration: 0.3), value: viewModel.currentRPE)
+    }
+
+    private var rpeColor: Color {
+        guard let rpe = viewModel.currentRPE else {
+            return GymBroColors.textSecondary
+        }
+        switch Int(rpe) {
+        case 6...7: return GymBroColors.accentGreen
+        case 8: return GymBroColors.accentAmber
+        case 9...10: return GymBroColors.accentRed
+        default: return GymBroColors.accentAmber
         }
     }
 


### PR DESCRIPTION
## Summary

**Closes #433** — RPE picker: add color transition animation  
**Closes #434** — RPE data not connected to AI coach recommendations

### Changes

**#433 — RPE picker color animation (Android + iOS)**
- **Android:** Replaced static \peColor\ with \nimateColorAsState\ (300ms tween) in \RpeQuickPicker\ so colors transition smoothly between green→amber→red as the user cycles through RPE values
- **iOS:** Added \peColor\ computed property with RPE-based color mapping (green 6-7, amber 8, red 9-10) and \.animation(.easeInOut(duration: 0.3))\ modifier for smooth color transitions

**#434 — Connect RPE data to AI coach (Android + iOS)**
- **Android:** Injected \RpeTrendService\ into \AiCoachService\, added RPE trends (avg RPE, fatigue warnings, rising/falling trend counts) to the \uildContext()\ prompt
- **iOS:** Added \vgRpe\ field to \ExerciseSnapshot\, computed per-exercise avg RPE in \CoachChatViewModel.fetchRecentWorkouts()\, added \peTrendsSection()\ to \PromptBuilder\ that surfaces overall avg RPE and flags high-effort exercises (≥8.5)

### Files changed (6)
- \ndroid/core/.../AiCoachService.kt\ — RPE trends in coach context
- \ndroid/feature/.../ActiveWorkoutScreen.kt\ — animateColorAsState
- \ios/.../AICoachService.swift\ — ExerciseSnapshot.avgRpe
- \ios/.../PromptBuilder.swift\ — rpeTrendsSection
- \ios/.../CoachChatViewModel.swift\ — compute avgRpe
- \ios/.../ActiveWorkoutView.swift\ — color animation + rpeColor