### PR TITLE
feat(workout): surface ProgressionEngine weight/rep suggestions during active workout

### DIFF
--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -514,6 +514,17 @@
     <string name="active_workout_rpe_label">RPE</string>
     <string name="active_workout_progression_up">↑ +2.5kg sugerido (RPE bajo)</string>
     <string name="active_workout_progression_down">↓ −5%% sugerido (RPE alto)</string>
+    
+    <!-- Progression Suggestions -->
+    <string name="progression_last" formatted="false">Anterior: %s × %d</string>
+    <string name="progression_last_with_rpe" formatted="false">Anterior: %s × %d (RPE %s)</string>
+    <string name="progression_suggested" formatted="false">→ Sugerido: %s</string>
+    <string name="progression_maintain" formatted="false">→ Mantener: %s</string>
+    <string name="progression_reduce" formatted="false">→ Reducir: %s</string>
+    <string name="progression_reason_progress">RPE bajo — progresa</string>
+    <string name="progression_reason_maintain">En camino — mantener</string>
+    <string name="progression_reason_regress">RPE alto — reducir</string>
+    <string name="progression_reason_no_data">Basado en último entrenamiento</string>
 
     <!-- Progress (additional new) -->
     <string name="progress_e1rm_trend">Tendencia Est. 1RM</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -508,6 +508,17 @@
     <string name="active_workout_rpe_label">RPE</string>
     <string name="active_workout_progression_up">↑ +2.5kg suggested (RPE was easy)</string>
     <string name="active_workout_progression_down">↓ −5%% suggested (RPE was high)</string>
+    
+    <!-- Progression Suggestions -->
+    <string name="progression_last" formatted="false">Last: %s × %d</string>
+    <string name="progression_last_with_rpe" formatted="false">Last: %s × %d (RPE %s)</string>
+    <string name="progression_suggested" formatted="false">→ Suggested: %s</string>
+    <string name="progression_maintain" formatted="false">→ Maintain: %s</string>
+    <string name="progression_reduce" formatted="false">→ Reduce: %s</string>
+    <string name="progression_reason_progress">RPE was low — progress</string>
+    <string name="progression_reason_maintain">On track — maintain</string>
+    <string name="progression_reason_regress">RPE trending high — reduce</string>
+    <string name="progression_reason_no_data">Based on last workout</string>
 
     <!-- Progress (additional) -->
     <string name="progress_e1rm_trend">Estimated 1RM Trend</string>

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -2,6 +2,7 @@ package com.gymbro.feature.workout
 
 import com.gymbro.core.model.Exercise
 import com.gymbro.core.model.PersonalRecord
+import com.gymbro.core.service.ProgressionEngine
 
 data class ActiveWorkoutState(
     val workoutId: String? = null,
@@ -29,6 +30,15 @@ data class FatigueWarningUi(
 data class WorkoutExerciseUi(
     val exercise: Exercise,
     val sets: List<WorkoutSetUi> = emptyList(),
+    val progressionSuggestion: ProgressionSuggestionUi? = null,
+)
+
+data class ProgressionSuggestionUi(
+    val lastWeight: Double,
+    val lastReps: Int,
+    val lastRpe: Double?,
+    val suggestedWeight: Double,
+    val reason: ProgressionEngine.ProgressionReason,
 )
 
 data class WorkoutSetUi(

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -798,6 +798,15 @@ private fun ExerciseCardContent(
             style = MaterialTheme.typography.bodySmall,
             color = Color.White.copy(alpha = 0.5f),
         )
+        
+        // Progression suggestion chip
+        exerciseUi.progressionSuggestion?.let { suggestion ->
+            Spacer(modifier = Modifier.height(8.dp))
+            ProgressionSuggestionChip(
+                suggestion = suggestion,
+                defaultWeightUnit = defaultWeightUnit,
+            )
+        }
 
         Spacer(modifier = Modifier.height(12.dp))
 
@@ -1101,6 +1110,89 @@ private fun RpeQuickPicker(
             fontWeight = FontWeight.Bold,
             color = if (enabled) rpeColor else rpeColor.copy(alpha = 0.4f),
         )
+    }
+}
+
+@Composable
+private fun ProgressionSuggestionChip(
+    suggestion: ProgressionSuggestionUi,
+    defaultWeightUnit: com.gymbro.core.preferences.UserPreferences.WeightUnit,
+) {
+    val unitLabel = when (defaultWeightUnit) {
+        com.gymbro.core.preferences.UserPreferences.WeightUnit.KG -> stringResource(R.string.common_kg)
+        com.gymbro.core.preferences.UserPreferences.WeightUnit.LBS -> stringResource(R.string.common_lbs)
+    }
+    
+    val (chipColor, suggestionText, reasonText) = when (suggestion.reason) {
+        com.gymbro.core.service.ProgressionEngine.ProgressionReason.PROGRESS -> Triple(
+            AccentGreenStart,
+            stringResource(R.string.progression_suggested, "${suggestion.suggestedWeight} $unitLabel"),
+            stringResource(R.string.progression_reason_progress),
+        )
+        com.gymbro.core.service.ProgressionEngine.ProgressionReason.REGRESS -> Triple(
+            com.gymbro.core.ui.theme.AccentRed,
+            stringResource(R.string.progression_reduce, "${suggestion.suggestedWeight} $unitLabel"),
+            stringResource(R.string.progression_reason_regress),
+        )
+        com.gymbro.core.service.ProgressionEngine.ProgressionReason.MAINTAIN -> Triple(
+            AccentAmberStart,
+            stringResource(R.string.progression_maintain, "${suggestion.lastWeight} $unitLabel"),
+            stringResource(R.string.progression_reason_maintain),
+        )
+        com.gymbro.core.service.ProgressionEngine.ProgressionReason.NO_DATA -> Triple(
+            Color.White.copy(alpha = 0.6f),
+            stringResource(R.string.progression_maintain, "${suggestion.lastWeight} $unitLabel"),
+            stringResource(R.string.progression_reason_no_data),
+        )
+    }
+    
+    val lastWorkoutText = if (suggestion.lastRpe != null) {
+        stringResource(
+            R.string.progression_last_with_rpe,
+            "${suggestion.lastWeight} $unitLabel",
+            suggestion.lastReps,
+            String.format("%.1f", suggestion.lastRpe)
+        )
+    } else {
+        stringResource(
+            R.string.progression_last,
+            "${suggestion.lastWeight} $unitLabel",
+            suggestion.lastReps
+        )
+    }
+    
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(chipColor.copy(alpha = 0.1f))
+            .border(1.dp, chipColor.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        Text(
+            text = lastWorkoutText,
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.White.copy(alpha = 0.7f),
+            fontSize = 12.sp,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = suggestionText,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold,
+                color = chipColor,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = reasonText,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White.copy(alpha = 0.6f),
+                fontSize = 11.sp,
+            )
+        }
     }
 }
 

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -35,6 +35,8 @@ class ActiveWorkoutViewModel @Inject constructor(
     private val rpeTrendService: RpeTrendService,
     private val exerciseRepository: ExerciseRepository,
     private val activePlanStore: ActivePlanStore,
+    private val progressionEngine: com.gymbro.core.service.ProgressionEngine,
+    private val workoutDao: com.gymbro.core.database.dao.WorkoutDao,
     val tooltipManager: TooltipManager,
 ) : BaseViewModel() {
 
@@ -144,6 +146,7 @@ class ActiveWorkoutViewModel @Inject constructor(
                 } catch (_: Exception) {
                     null
                 }
+                val progressionSuggestion = getProgressionSuggestionUi(exercise.id.toString())
                 val sets = (1..planned.sets).map { setNum ->
                     WorkoutSetUi(
                         id = UUID.randomUUID().toString(),
@@ -158,6 +161,7 @@ class ActiveWorkoutViewModel @Inject constructor(
                         exercises = current.exercises + WorkoutExerciseUi(
                             exercise = exercise,
                             sets = sets,
+                            progressionSuggestion = progressionSuggestion,
                         ),
                     )
                 }
@@ -221,6 +225,7 @@ class ActiveWorkoutViewModel @Inject constructor(
     private fun addExercise(exercise: Exercise) {
         safeLaunch {
             val defaults = smartDefaultsService.getDefaults(exercise.id.toString())
+            val progressionSuggestion = getProgressionSuggestionUi(exercise.id.toString())
             _state.update { current ->
                 val newExercise = WorkoutExerciseUi(
                     exercise = exercise,
@@ -232,6 +237,7 @@ class ActiveWorkoutViewModel @Inject constructor(
                             reps = defaults.reps?.toString() ?: "",
                         ),
                     ),
+                    progressionSuggestion = progressionSuggestion,
                 )
                 current.copy(exercises = current.exercises + newExercise)
             }
@@ -576,6 +582,34 @@ class ActiveWorkoutViewModel @Inject constructor(
                 // Silent failure - don't interrupt user's workout
                 android.util.Log.e("ActiveWorkoutViewModel", "Failed to auto-save workout state", e)
             }
+        }
+    }
+
+    private suspend fun getProgressionSuggestionUi(exerciseId: String): ProgressionSuggestionUi? {
+        return try {
+            val suggestion = progressionEngine.getSuggestion(exerciseId) ?: return null
+            
+            // Get last workout data for display
+            val sets = workoutDao.getSetsByExercise(exerciseId)
+            if (sets.isEmpty()) return null
+            
+            val lastWorkoutId = sets.last().workoutId
+            val lastWorkoutSets = sets.filter { it.workoutId == lastWorkoutId && !it.isWarmup }
+            if (lastWorkoutSets.isEmpty()) return null
+            
+            val lastWeight = lastWorkoutSets.maxOf { it.weight }
+            val lastReps = lastWorkoutSets.maxOf { it.reps }
+            val lastRpe = lastWorkoutSets.mapNotNull { it.rpe }.maxOrNull()
+            
+            ProgressionSuggestionUi(
+                lastWeight = lastWeight,
+                lastReps = lastReps,
+                lastRpe = lastRpe,
+                suggestedWeight = suggestion.suggestedWeightKg,
+                reason = suggestion.reason,
+            )
+        } catch (e: Exception) {
+            null
         }
     }
 


### PR DESCRIPTION
Closes #507

## Summary
Surfaces ProgressionEngine's AI-driven weight/rep suggestions directly in the active workout UI so users can see exactly what to lift.

## What Changed
- **Data Model**: Added ProgressionSuggestionUi to WorkoutExerciseUi containing last workout data (weight × reps × RPE) and suggested weight with reason
- **ViewModel**: Modified ActiveWorkoutViewModel to call ProgressionEngine.getSuggestion() when loading exercises (both from planned workouts and manually added)
- **UI Component**: Created ProgressionSuggestionChip that displays:
  - Last workout performance (e.g., "Last: 100kg × 5 (RPE 7)")
  - Suggested weight with color-coded action (green = progress, amber = maintain, red = reduce)
  - Human-readable reason ("RPE was low — progress", "On track — maintain", "RPE trending high — reduce")
- **Strings**: Added full bilingual support (EN + ES) for all suggestion states
- **Position**: Placed suggestion chip prominently below exercise header, above set table for maximum visibility

## How It Works
1. When user adds an exercise or loads from a plan, ViewModel queries ProgressionEngine.getSuggestion()
2. Engine analyzes last workout's working sets and RPE data
3. Returns suggestion (progress/maintain/regress) with weight recommendation
4. UI displays this as a color-coded chip right at the top of each exercise
5. User sees exactly what to lift without guessing

## Testing
- ✅ Build passes (./gradlew :android:app:assembleDebug)
- Staged only 5 modified files (contract, viewmodel, screen, 2 string files)
- No unintended changes

## Screenshots
(Manual testing required to verify UI appearance)

Working as Trinity (Mobile Dev) for issue #507