### PR TITLE
feat(tools): plate calculator + 1RM calculator

### DIFF
--- a/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
+++ b/android/app/src/main/java/com/gymbro/app/navigation/GymBroNavGraph.kt
@@ -75,6 +75,9 @@ import com.gymbro.feature.analytics.AnalyticsRoute
 import com.gymbro.feature.coach.CoachChatRoute
 import com.gymbro.feature.recovery.RecoveryRoute
 import com.gymbro.feature.settings.SettingsRoute
+import com.gymbro.feature.tools.OneRMCalculatorRoute
+import com.gymbro.feature.tools.PlateCalculatorRoute
+import com.gymbro.feature.tools.ToolsRoute
 import com.gymbro.feature.workout.ActiveWorkoutRoute
 import com.gymbro.feature.workout.SmartWorkoutRoute
 import com.gymbro.feature.workout.WorkoutSummaryScreen
@@ -485,8 +488,38 @@ fun GymBroNavGraph(
                 onNavigateToExerciseLibrary = {
                     navController.navigate("exercise_library")
                 },
+                onNavigateToTools = {
+                    navController.navigate("tools")
+                },
                 onNavigateToRecovery = {
                     navController.navigate("recovery")
+                },
+            )
+        }
+        composable("tools") {
+            ToolsRoute(
+                onNavigateToPlateCalculator = {
+                    navController.navigate("tools/plate_calculator")
+                },
+                onNavigateToOneRMCalculator = {
+                    navController.navigate("tools/one_rm_calculator")
+                },
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
+            )
+        }
+        composable("tools/plate_calculator") {
+            PlateCalculatorRoute(
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
+            )
+        }
+        composable("tools/one_rm_calculator") {
+            OneRMCalculatorRoute(
+                onNavigateBack = {
+                    navController.popBackStack()
                 },
             )
         }

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -690,6 +690,22 @@
     <string name="profile_exercise_library">Biblioteca de Ejercicios</string>
     <string name="profile_exercise_library_subtitle">Explorar y gestionar ejercicios</string>
 
+    <!-- Tools -->
+    <string name="tools_title">Herramientas</string>
+    <string name="tools_subtitle">Calculadoras y utilidades de entrenamiento</string>
+    <string name="tools_plate_calculator">Calculadora de Discos</string>
+    <string name="tools_plate_calculator_subtitle">Carga los discos correctos en tu barra</string>
+    <string name="tools_one_rm_calculator">Calculadora 1RM</string>
+    <string name="tools_one_rm_calculator_subtitle">Estima tu máximo de una repetición</string>
+    <string name="tools_plate_target_weight">Peso Objetivo</string>
+    <string name="tools_plate_bar_weight">Peso de la Barra</string>
+    <string name="tools_plate_per_side">Por Lado</string>
+    <string name="tools_one_rm_weight_lifted">Peso Levantado</string>
+    <string name="tools_one_rm_reps_performed">Repeticiones Realizadas</string>
+    <string name="tools_one_rm_reps">reps</string>
+    <string name="tools_one_rm_estimated">1RM Estimado</string>
+    <string name="tools_one_rm_percentage_chart">Tabla de Porcentajes</string>
+
     <!-- Issue #447: Remaining hardcoded strings -->
     <string name="progress_exercises_count">%d ejercicios</string>
     <string name="history_unknown_error">Error desconocido</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -684,6 +684,22 @@
     <string name="profile_exercise_library">Exercise Library</string>
     <string name="profile_exercise_library_subtitle">Browse and manage exercises</string>
 
+    <!-- Tools -->
+    <string name="tools_title">Tools</string>
+    <string name="tools_subtitle">Workout calculators and utilities</string>
+    <string name="tools_plate_calculator">Plate Calculator</string>
+    <string name="tools_plate_calculator_subtitle">Load the right plates on your barbell</string>
+    <string name="tools_one_rm_calculator">1RM Calculator</string>
+    <string name="tools_one_rm_calculator_subtitle">Estimate your one rep max</string>
+    <string name="tools_plate_target_weight">Target Weight</string>
+    <string name="tools_plate_bar_weight">Bar Weight</string>
+    <string name="tools_plate_per_side">Per Side</string>
+    <string name="tools_one_rm_weight_lifted">Weight Lifted</string>
+    <string name="tools_one_rm_reps_performed">Reps Performed</string>
+    <string name="tools_one_rm_reps">reps</string>
+    <string name="tools_one_rm_estimated">Estimated 1RM</string>
+    <string name="tools_one_rm_percentage_chart">Percentage Chart</string>
+
     <!-- Issue #447: Remaining hardcoded strings -->
     <string name="progress_exercises_count">%d exercises</string>
     <string name="history_unknown_error">Unknown error</string>

--- a/android/feature/src/main/java/com/gymbro/feature/profile/ProfileScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/profile/ProfileScreen.kt
@@ -87,6 +87,7 @@ fun ProfileRoute(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToCoach: () -> Unit = {},
     onNavigateToExerciseLibrary: () -> Unit = {},
+    onNavigateToTools: () -> Unit = {},
     onNavigateToRecovery: () -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
@@ -107,6 +108,7 @@ fun ProfileRoute(
         onNavigateToSettings = onNavigateToSettings,
         onNavigateToCoach = onNavigateToCoach,
         onNavigateToExerciseLibrary = onNavigateToExerciseLibrary,
+        onNavigateToTools = onNavigateToTools,
         onNavigateToRecovery = onNavigateToRecovery,
     )
 }
@@ -118,6 +120,7 @@ internal fun ProfileScreen(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToCoach: () -> Unit = {},
     onNavigateToExerciseLibrary: () -> Unit = {},
+    onNavigateToTools: () -> Unit = {},
     onNavigateToRecovery: () -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -245,6 +248,22 @@ internal fun ProfileScreen(
                 subtitle = stringResource(R.string.profile_exercise_library_subtitle),
                 iconTint = AccentGreenStart,
                 onClick = onNavigateToExerciseLibrary,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Tools
+        SettingsGroup(
+            title = stringResource(R.string.tools_title),
+            accentColor = AccentAmberStart,
+        ) {
+            SettingItem(
+                icon = Icons.Default.FitnessCenter,
+                label = stringResource(R.string.tools_title),
+                subtitle = stringResource(R.string.tools_subtitle),
+                iconTint = AccentAmberStart,
+                onClick = onNavigateToTools,
             )
         }
 

--- a/android/feature/src/main/java/com/gymbro/feature/tools/OneRMCalculatorScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/tools/OneRMCalculatorScreen.kt
@@ -1,0 +1,392 @@
+package com.gymbro.feature.tools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.gymbro.core.R
+import com.gymbro.core.ui.theme.AccentAmberEnd
+import com.gymbro.core.ui.theme.AccentAmberStart
+import com.gymbro.core.ui.theme.AccentCyanEnd
+import com.gymbro.core.ui.theme.AccentCyanStart
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.AccentGreenStart
+import com.gymbro.core.ui.theme.Background
+import com.gymbro.core.ui.theme.GlassBorder
+import com.gymbro.core.ui.theme.GlassOverlay
+import com.gymbro.feature.common.GlassmorphicCard
+import kotlin.math.roundToInt
+
+@Composable
+fun OneRMCalculatorRoute(
+    onNavigateBack: () -> Unit = {},
+) {
+    OneRMCalculatorScreen(
+        onNavigateBack = onNavigateBack,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun OneRMCalculatorScreen(
+    onNavigateBack: () -> Unit,
+) {
+    var weight by remember { mutableStateOf("") }
+    var reps by remember { mutableStateOf("") }
+    var useKg by remember { mutableStateOf(true) }
+
+    val oneRM by remember {
+        derivedStateOf {
+            calculateOneRM(
+                weight = weight.toDoubleOrNull() ?: 0.0,
+                reps = reps.toIntOrNull() ?: 0
+            )
+        }
+    }
+
+    val percentages = listOf(100, 95, 90, 85, 80, 75, 70, 65, 60)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.tools_one_rm_calculator),
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Background,
+                    titleContentColor = Color.White,
+                ),
+            )
+        },
+        containerColor = Background,
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Unit Toggle
+            GlassmorphicCard {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                ) {
+                    UnitButton(
+                        text = "KG",
+                        isSelected = useKg,
+                        onClick = { useKg = true },
+                    )
+                    UnitButton(
+                        text = "LBS",
+                        isSelected = !useKg,
+                        onClick = { useKg = false },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Input Section
+            GlassmorphicCard {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.tools_one_rm_weight_lifted),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = weight,
+                        onValueChange = { weight = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = {
+                            Text("100${if (useKg) "kg" else "lbs"}")
+                        },
+                        suffix = {
+                            Text(if (useKg) "kg" else "lbs")
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AccentCyanStart,
+                            unfocusedBorderColor = GlassBorder,
+                            focusedTextColor = Color.White,
+                            unfocusedTextColor = Color.White,
+                        ),
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = stringResource(R.string.tools_one_rm_reps_performed),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = reps,
+                        onValueChange = { reps = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = {
+                            Text("5")
+                        },
+                        suffix = {
+                            Text(stringResource(R.string.tools_one_rm_reps))
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AccentAmberStart,
+                            unfocusedBorderColor = GlassBorder,
+                            focusedTextColor = Color.White,
+                            unfocusedTextColor = Color.White,
+                        ),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Results Section
+            if (oneRM > 0) {
+                // 1RM Result
+                GlassmorphicCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.tools_one_rm_estimated),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = Color.White.copy(alpha = 0.7f),
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "${String.format("%.1f", oneRM)}${if (useKg) "kg" else "lbs"}",
+                            style = MaterialTheme.typography.displayMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = AccentGreenStart,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Percentage Chart
+                GlassmorphicCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.tools_one_rm_percentage_chart),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                        )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        percentages.forEach { percentage ->
+                            PercentageRow(
+                                percentage = percentage,
+                                weight = oneRM * percentage / 100.0,
+                                unit = if (useKg) "kg" else "lbs",
+                            )
+                            if (percentage != percentages.last()) {
+                                Spacer(modifier = Modifier.height(12.dp))
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun UnitButton(
+    text: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .width(100.dp)
+            .height(48.dp)
+            .background(
+                brush = if (isSelected) {
+                    Brush.linearGradient(
+                        colors = listOf(AccentCyanStart, AccentCyanEnd)
+                    )
+                } else {
+                    Brush.linearGradient(
+                        colors = listOf(GlassOverlay, GlassOverlay)
+                    )
+                },
+                shape = RoundedCornerShape(12.dp)
+            )
+            .border(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = if (isSelected) AccentCyanEnd else GlassBorder,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(8.dp)
+            .then(
+                if (!isSelected) {
+                    Modifier.clickableWithoutRipple(onClick = onClick)
+                } else {
+                    Modifier
+                }
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = if (isSelected) Color.Black else Color.White,
+        )
+    }
+}
+
+@Composable
+private fun PercentageRow(
+    percentage: Int,
+    weight: Double,
+    unit: String,
+) {
+    val color = getPercentageColor(percentage)
+    
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        color.copy(alpha = 0.3f),
+                        color.copy(alpha = 0.1f),
+                        Color.Transparent
+                    )
+                ),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .border(
+                width = 1.dp,
+                color = color.copy(alpha = 0.5f),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "$percentage%",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = color,
+        )
+        Text(
+            text = "${String.format("%.1f", weight)} $unit",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = Color.White,
+        )
+    }
+}
+
+private fun getPercentageColor(percentage: Int): Color {
+    return when {
+        percentage >= 95 -> Color(0xFFE74C3C) // Red - max intensity
+        percentage >= 85 -> Color(0xFFF39C12) // Orange - high intensity
+        percentage >= 75 -> Color(0xFFF1C40F) // Yellow - moderate-high
+        percentage >= 65 -> AccentCyanStart // Cyan - moderate
+        else -> Color(0xFF95A5A6) // Gray - light work
+    }
+}
+
+private fun calculateOneRM(weight: Double, reps: Int): Double {
+    if (weight <= 0 || reps <= 0) return 0.0
+    if (reps == 1) return weight
+    
+    // Epley formula: 1RM = weight × (1 + reps/30)
+    return weight * (1 + reps / 30.0)
+}
+
+@Composable
+private fun Modifier.clickableWithoutRipple(
+    onClick: () -> Unit,
+): Modifier {
+    return clickable(
+        onClick = onClick,
+        indication = null,
+        interactionSource = remember { MutableInteractionSource() }
+    )
+}

--- a/android/feature/src/main/java/com/gymbro/feature/tools/PlateCalculatorScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/tools/PlateCalculatorScreen.kt
@@ -1,0 +1,402 @@
+package com.gymbro.feature.tools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.gymbro.core.R
+import com.gymbro.core.ui.theme.AccentAmberEnd
+import com.gymbro.core.ui.theme.AccentAmberStart
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.AccentGreenStart
+import com.gymbro.core.ui.theme.Background
+import com.gymbro.core.ui.theme.GlassBorder
+import com.gymbro.core.ui.theme.GlassOverlay
+import com.gymbro.feature.common.GlassmorphicCard
+import kotlin.math.abs
+
+@Composable
+fun PlateCalculatorRoute(
+    onNavigateBack: () -> Unit = {},
+) {
+    PlateCalculatorScreen(
+        onNavigateBack = onNavigateBack,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun PlateCalculatorScreen(
+    onNavigateBack: () -> Unit,
+) {
+    var targetWeight by remember { mutableStateOf("") }
+    var barWeight by remember { mutableStateOf("20") }
+    var useKg by remember { mutableStateOf(true) }
+
+    val plates by remember {
+        derivedStateOf {
+            calculatePlates(
+                targetWeight = targetWeight.toDoubleOrNull() ?: 0.0,
+                barWeight = barWeight.toDoubleOrNull() ?: 20.0,
+                useKg = useKg
+            )
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.tools_plate_calculator),
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Background,
+                    titleContentColor = Color.White,
+                ),
+            )
+        },
+        containerColor = Background,
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Unit Toggle
+            GlassmorphicCard {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                ) {
+                    UnitButton(
+                        text = "KG",
+                        isSelected = useKg,
+                        onClick = { useKg = true },
+                    )
+                    UnitButton(
+                        text = "LBS",
+                        isSelected = !useKg,
+                        onClick = { useKg = false },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Input Section
+            GlassmorphicCard {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.tools_plate_target_weight),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = targetWeight,
+                        onValueChange = { targetWeight = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = {
+                            Text("100${if (useKg) "kg" else "lbs"}")
+                        },
+                        suffix = {
+                            Text(if (useKg) "kg" else "lbs")
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AccentGreenStart,
+                            unfocusedBorderColor = GlassBorder,
+                            focusedTextColor = Color.White,
+                            unfocusedTextColor = Color.White,
+                        ),
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = stringResource(R.string.tools_plate_bar_weight),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = barWeight,
+                        onValueChange = { barWeight = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = {
+                            Text("20kg / 45lbs")
+                        },
+                        suffix = {
+                            Text(if (useKg) "kg" else "lbs")
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AccentAmberStart,
+                            unfocusedBorderColor = GlassBorder,
+                            focusedTextColor = Color.White,
+                            unfocusedTextColor = Color.White,
+                        ),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Results Section
+            if (plates.isNotEmpty()) {
+                GlassmorphicCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.tools_plate_per_side),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = AccentGreenStart,
+                        )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        // Visual Plate Representation
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            plates.forEach { plate ->
+                                PlateVisual(
+                                    weight = plate,
+                                    unit = if (useKg) "kg" else "lbs",
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        // Text Summary
+                        Text(
+                            text = plates.joinToString(" + ") { "$it${if (useKg) "kg" else "lbs"}" },
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = Color.White.copy(alpha = 0.9f),
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun UnitButton(
+    text: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .width(100.dp)
+            .height(48.dp)
+            .background(
+                brush = if (isSelected) {
+                    Brush.linearGradient(
+                        colors = listOf(AccentGreenStart, AccentGreenEnd)
+                    )
+                } else {
+                    Brush.linearGradient(
+                        colors = listOf(GlassOverlay, GlassOverlay)
+                    )
+                },
+                shape = RoundedCornerShape(12.dp)
+            )
+            .border(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = if (isSelected) AccentGreenEnd else GlassBorder,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(8.dp)
+            .then(
+                if (!isSelected) {
+                    Modifier.clickableWithoutRipple(onClick = onClick)
+                } else {
+                    Modifier
+                }
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = if (isSelected) Color.Black else Color.White,
+        )
+    }
+}
+
+@Composable
+private fun PlateVisual(
+    weight: Double,
+    unit: String,
+) {
+    val color = getPlateColor(weight, unit == "kg")
+    
+    Box(
+        modifier = Modifier
+            .size(width = 100.dp, height = 60.dp)
+            .background(
+                brush = Brush.linearGradient(
+                    colors = listOf(color.copy(alpha = 0.8f), color)
+                ),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .border(
+                width = 2.dp,
+                color = color,
+                shape = RoundedCornerShape(8.dp)
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "$weight\n$unit",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            textAlign = TextAlign.Center,
+            lineHeight = 18.sp,
+        )
+    }
+}
+
+private fun getPlateColor(weight: Double, isKg: Boolean): Color {
+    return if (isKg) {
+        when (weight) {
+            25.0 -> Color(0xFFE74C3C) // Red
+            20.0 -> Color(0xFF3498DB) // Blue
+            15.0 -> Color(0xFFF39C12) // Orange
+            10.0 -> Color(0xFF2ECC71) // Green
+            5.0 -> Color(0xFFFFFFFF) // White
+            2.5 -> Color(0xFF95A5A6) // Gray
+            1.25 -> Color(0xFF34495E) // Dark Gray
+            else -> AccentGreenStart
+        }
+    } else {
+        when (weight) {
+            45.0 -> Color(0xFFE74C3C) // Red
+            35.0 -> Color(0xFF3498DB) // Blue
+            25.0 -> Color(0xFF2ECC71) // Green
+            10.0 -> Color(0xFFF39C12) // Orange
+            5.0 -> Color(0xFFFFFFFF) // White
+            2.5 -> Color(0xFF95A5A6) // Gray
+            else -> AccentGreenStart
+        }
+    }
+}
+
+private fun calculatePlates(
+    targetWeight: Double,
+    barWeight: Double,
+    useKg: Boolean,
+): List<Double> {
+    if (targetWeight <= barWeight) return emptyList()
+
+    val availablePlates = if (useKg) {
+        listOf(25.0, 20.0, 15.0, 10.0, 5.0, 2.5, 1.25)
+    } else {
+        listOf(45.0, 35.0, 25.0, 10.0, 5.0, 2.5)
+    }
+
+    val weightPerSide = (targetWeight - barWeight) / 2.0
+    val plates = mutableListOf<Double>()
+    var remaining = weightPerSide
+
+    for (plate in availablePlates) {
+        while (remaining >= plate - 0.01) { // Small tolerance for floating point
+            plates.add(plate)
+            remaining -= plate
+        }
+    }
+
+    return plates
+}
+
+@Composable
+private fun Modifier.clickableWithoutRipple(
+    onClick: () -> Unit,
+): Modifier {
+    return clickable(
+        onClick = onClick,
+        indication = null,
+        interactionSource = remember { MutableInteractionSource() }
+    )
+}

--- a/android/feature/src/main/java/com/gymbro/feature/tools/ToolsScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/tools/ToolsScreen.kt
@@ -1,0 +1,214 @@
+package com.gymbro.feature.tools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Calculate
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.gymbro.core.R
+import com.gymbro.core.ui.theme.AccentAmberEnd
+import com.gymbro.core.ui.theme.AccentAmberStart
+import com.gymbro.core.ui.theme.AccentCyanEnd
+import com.gymbro.core.ui.theme.AccentCyanStart
+import com.gymbro.core.ui.theme.AccentGreenEnd
+import com.gymbro.core.ui.theme.AccentGreenStart
+import com.gymbro.core.ui.theme.Background
+import com.gymbro.core.ui.theme.GlassBorder
+import com.gymbro.core.ui.theme.GlassOverlay
+import com.gymbro.feature.common.GlassmorphicCard
+
+@Composable
+fun ToolsRoute(
+    onNavigateToPlateCalculator: () -> Unit = {},
+    onNavigateToOneRMCalculator: () -> Unit = {},
+    onNavigateBack: () -> Unit = {},
+) {
+    ToolsScreen(
+        onNavigateToPlateCalculator = onNavigateToPlateCalculator,
+        onNavigateToOneRMCalculator = onNavigateToOneRMCalculator,
+        onNavigateBack = onNavigateBack,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ToolsScreen(
+    onNavigateToPlateCalculator: () -> Unit,
+    onNavigateToOneRMCalculator: () -> Unit,
+    onNavigateBack: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.tools_title),
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Background,
+                    titleContentColor = Color.White,
+                ),
+            )
+        },
+        containerColor = Background,
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(R.string.tools_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = Color.White.copy(alpha = 0.7f),
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Plate Calculator Card
+            ToolCard(
+                icon = Icons.Default.FitnessCenter,
+                title = stringResource(R.string.tools_plate_calculator),
+                subtitle = stringResource(R.string.tools_plate_calculator_subtitle),
+                accentColorStart = AccentGreenStart,
+                accentColorEnd = AccentGreenEnd,
+                onClick = onNavigateToPlateCalculator,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 1RM Calculator Card
+            ToolCard(
+                icon = Icons.Default.Calculate,
+                title = stringResource(R.string.tools_one_rm_calculator),
+                subtitle = stringResource(R.string.tools_one_rm_calculator_subtitle),
+                accentColorStart = AccentCyanStart,
+                accentColorEnd = AccentCyanEnd,
+                onClick = onNavigateToOneRMCalculator,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun ToolCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    accentColorStart: Color,
+    accentColorEnd: Color,
+    onClick: () -> Unit,
+) {
+    GlassmorphicCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Icon with gradient background
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .background(
+                        brush = Brush.linearGradient(
+                            colors = listOf(accentColorStart, accentColorEnd)
+                        ),
+                        shape = CircleShape
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = Color.Black,
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Text content
+            Column(
+                modifier = Modifier.weight(3f),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.7f),
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(0.5f))
+
+            // Arrow icon
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = accentColorStart,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #501, Closes #506

## Overview
Implements two workout calculator tools accessible from a new Tools section in the Profile screen.

## Features

### Plate Calculator (#501)
- **Input**: Target weight + bar weight (configurable, defaults to 20kg/45lbs)
- **Algorithm**: Greedy plate selection (subtracts bar weight, divides by 2, picks largest plates first)
- **Output**: 
  - Visual plate representation with color-coded rectangles
  - Text list showing plates per side
- **Plate sets**:
  - KG: 25, 20, 15, 10, 5, 2.5, 1.25
  - LBS: 45, 35, 25, 10, 5, 2.5
- **Unit toggle**: Switch between KG and LBS

### 1RM Calculator (#506)
- **Input**: Weight lifted + reps performed
- **Formula**: Epley formula: 1RM = weight × (1 + reps/30)
- **Output**:
  - Estimated 1RM (large, prominent display)
  - Percentage chart with 9 intensity levels (100%, 95%, 90%, 85%, 80%, 75%, 70%, 65%, 60%)
  - Color-coded by intensity (red=max, orange=high, yellow=moderate, cyan=light, gray=recovery)
  - Calculates weight for each percentage
- **Unit toggle**: Switch between KG and LBS

### Navigation
- Added **Tools** section in ProfileScreen (positioned after Exercise Library)
- New routes:
  - \	ools\ - main hub screen with calculator cards
  - \	ools/plate_calculator\
  - \	ools/one_rm_calculator\
- Each screen has TopAppBar with back button

## Technical Details

### New Files
- \PlateCalculatorScreen.kt\ - Plate calculator composable
- \OneRMCalculatorScreen.kt\ - 1RM calculator composable
- \ToolsScreen.kt\ - Tools hub with navigation cards

### Modified Files
- \ProfileScreen.kt\ - Added Tools section with accent amber styling
- \GymBroNavGraph.kt\ - Added 3 new routes + imports
- \alues/strings.xml\ - Added 17 EN strings
- \alues-es/strings.xml\ - Added 17 ES strings

### Localization
Full EN + ES support:
- Tools title/subtitle
- Plate calculator title/description
- 1RM calculator title/description
- All input labels and result labels

### Design
- Uses existing GymBro design system (GlassmorphicCard, accent colors, Background)
- Plate calculator uses green accent (matches Exercise Library)
- 1RM calculator uses cyan accent (matches Recovery)
- Tools hub uses amber accent
- Follows existing screen patterns (TopAppBar, Scaffold, scrollable content)

## Build Status
✅ Build successful (\./gradlew assembleDebug\)

## Screenshots
_Will be added after review_