### PR TITLE
Fix #523 — Exercise detail sheet during workout

### DIFF
--- a/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
+++ b/android/core/src/main/java/com/gymbro/core/database/dao/WorkoutDao.kt
@@ -21,6 +21,11 @@ data class WorkoutWithSets(
     val sets: List<WorkoutSetEntity>,
 )
 
+data class WorkoutSetWithDate(
+    @Embedded val set: WorkoutSetEntity,
+    val workoutDate: Long,
+)
+
 @Dao
 interface WorkoutDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -105,4 +110,15 @@ interface WorkoutDao {
 
     @Query("SELECT COUNT(DISTINCT date(startedAt / 1000, 'unixepoch')) FROM workouts WHERE completed = 1")
     suspend fun getActiveDaysCount(): Int
+
+    @Query(
+        """
+        SELECT ws.*, w.startedAt as workoutDate FROM workout_sets ws
+        INNER JOIN workouts w ON ws.workoutId = w.id
+        WHERE ws.exerciseId = :exerciseId AND w.completed = 1 AND ws.isWarmup = 0
+        ORDER BY w.startedAt DESC
+        LIMIT :limit
+        """
+    )
+    suspend fun getExerciseHistorySets(exerciseId: String, limit: Int): List<WorkoutSetWithDate>
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
@@ -3,6 +3,12 @@ package com.gymbro.core.repository
 import com.gymbro.core.model.ExerciseSet
 import com.gymbro.core.model.Workout
 import kotlinx.coroutines.flow.Flow
+import java.time.Instant
+
+data class ExerciseHistorySession(
+    val workoutDate: Instant,
+    val sets: List<ExerciseSet>,
+)
 
 interface WorkoutRepository {
     suspend fun startWorkout(): Workout
@@ -22,4 +28,6 @@ interface WorkoutRepository {
     suspend fun getTotalCompletedWorkoutsCount(): Int
     suspend fun getActiveDaysCount(): Int
     suspend fun getCurrentStreak(): Int
+    
+    suspend fun getExerciseHistory(exerciseId: String, limit: Int = 10): List<ExerciseHistorySession>
 }

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
@@ -372,6 +372,46 @@ class WorkoutRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getExerciseHistory(exerciseId: String, limit: Int): List<ExerciseHistorySession> {
+        val result = retryWithBackoff {
+            runCatchingAsResult {
+                val setsWithDates = workoutDao.getExerciseHistorySets(exerciseId, limit * 5)
+                
+                // Group sets by workout date
+                val groupedByWorkout = setsWithDates.groupBy { it.workoutDate }
+                
+                // Convert to ExerciseHistorySession and take only the requested limit of sessions
+                groupedByWorkout.entries
+                    .sortedByDescending { it.key }
+                    .take(limit)
+                    .map { (workoutDate, setsWithDate) ->
+                        ExerciseHistorySession(
+                            workoutDate = Instant.ofEpochMilli(workoutDate),
+                            sets = setsWithDate.map { setWithDate ->
+                                ExerciseSet(
+                                    id = UUID.fromString(setWithDate.set.id),
+                                    exerciseId = UUID.fromString(setWithDate.set.exerciseId),
+                                    weightKg = setWithDate.set.weight,
+                                    reps = setWithDate.set.reps,
+                                    rpe = setWithDate.set.rpe,
+                                    rir = setWithDate.set.rir,
+                                    isWarmup = setWithDate.set.isWarmup,
+                                    completedAt = Instant.ofEpochMilli(setWithDate.set.completedAt),
+                                )
+                            }
+                        )
+                    }
+            }
+        }
+        return when (result) {
+            is AppResult.Success -> result.data
+            is AppResult.Error -> {
+                Log.e(TAG, "Failed to get exercise history: ${result.error.message}")
+                emptyList()
+            }
+        }
+    }
+
     companion object {
         private const val TAG = "WorkoutRepositoryImpl"
     }

--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -847,4 +847,15 @@
     <string name="profile_sign_out_failed">Error al cerrar sesión</string>
     <string name="home_cd_view_all_programs">Ver todos los programas</string>
     <string name="home_cd_recent_workout">Entrenamiento del %1$s, %2$d ejercicios</string>
+
+    <!-- Exercise Detail Sheet - Additional strings -->
+    <string name="exercise_detail_sheet_title">Detalles del Ejercicio</string>
+    <string name="exercise_detail_history_title">Sesiones Recientes</string>
+    <string name="exercise_detail_history_empty">Sin historial aún para este ejercicio</string>
+    <string name="exercise_detail_history_loading">Cargando historial…</string>
+    <string name="exercise_detail_setup">Preparación</string>
+    <string name="exercise_detail_execution">Ejecución</string>
+    <string name="exercise_detail_tips">Consejos</string>
+    <string name="exercise_detail_set_format">%1$d × %2$.1f kg</string>
+    <string name="exercise_detail_set_format_with_rpe">%1$d × %2$.1f kg @ RPE %3$.1f</string>
 </resources>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -841,4 +841,15 @@
     <string name="profile_sign_out_failed">Sign-out failed</string>
     <string name="home_cd_view_all_programs">View all programs</string>
     <string name="home_cd_recent_workout">Workout on %1$s, %2$d exercises</string>
+
+    <!-- Exercise Detail Sheet - Additional strings -->
+    <string name="exercise_detail_sheet_title">Exercise Details</string>
+    <string name="exercise_detail_history_title">Recent Sessions</string>
+    <string name="exercise_detail_history_empty">No history yet for this exercise</string>
+    <string name="exercise_detail_history_loading">Loading history…</string>
+    <string name="exercise_detail_setup">Setup</string>
+    <string name="exercise_detail_execution">Execution</string>
+    <string name="exercise_detail_tips">Tips</string>
+    <string name="exercise_detail_set_format">%1$d × %2$.1f kg</string>
+    <string name="exercise_detail_set_format_with_rpe">%1$d × %2$.1f kg @ RPE %3$.1f</string>
 </resources>

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -20,6 +20,24 @@ data class ActiveWorkoutState(
     val fatigueWarnings: List<FatigueWarningUi> = emptyList(),
     val supersetGroups: Map<String, List<Int>> = emptyMap(),
     val selectedExercises: Set<Int> = emptySet(),
+    val exerciseDetailSheet: ExerciseDetailSheetState? = null,
+)
+
+data class ExerciseDetailSheetState(
+    val exercise: Exercise,
+    val history: List<ExerciseHistorySessionUi> = emptyList(),
+    val isLoadingHistory: Boolean = true,
+)
+
+data class ExerciseHistorySessionUi(
+    val date: String,
+    val sets: List<ExerciseHistorySetUi>,
+)
+
+data class ExerciseHistorySetUi(
+    val weight: Double,
+    val reps: Int,
+    val rpe: Double?,
 )
 
 data class FatigueWarningUi(
@@ -79,6 +97,8 @@ sealed interface ActiveWorkoutEvent {
     data class ToggleExerciseSelection(val exerciseIndex: Int) : ActiveWorkoutEvent
     data object CreateSuperset : ActiveWorkoutEvent
     data class UnlinkSuperset(val groupId: String) : ActiveWorkoutEvent
+    data class ShowExerciseDetail(val exercise: Exercise) : ActiveWorkoutEvent
+    data object DismissExerciseDetail : ActiveWorkoutEvent
 }
 
 sealed interface ActiveWorkoutEffect {

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -39,6 +41,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material3.AlertDialog
@@ -48,6 +51,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -56,6 +60,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -521,6 +526,15 @@ fun ActiveWorkoutScreen(
                 onDismiss = onTooltipDismissed
             )
         }
+
+        // Exercise Detail Bottom Sheet
+        state.exerciseDetailSheet?.let { detailState ->
+            ExerciseDetailBottomSheet(
+                detailState = detailState,
+                onDismiss = { onEvent(ActiveWorkoutEvent.DismissExerciseDetail) },
+                defaultWeightUnit = defaultWeightUnit,
+            )
+        }
     }
 }
 
@@ -793,7 +807,12 @@ private fun ExerciseCardContent(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = Color.White,
-                modifier = Modifier.weight(1f).semantics { heading() },
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(
+                        onClick = { onEvent(ActiveWorkoutEvent.ShowExerciseDetail(exerciseUi.exercise)) }
+                    )
+                    .semantics { heading() },
             )
             // Voice input — auto-fills the first incomplete set
             VoiceInputButton(
@@ -1515,3 +1534,252 @@ private fun formatDuration(totalSeconds: Long): String {
         "%d:%02d".format(minutes, seconds)
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ExerciseDetailBottomSheet(
+    detailState: ExerciseDetailSheetState,
+    onDismiss: () -> Unit,
+    defaultWeightUnit: UserPreferences.WeightUnit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = Color(0xFF1C1C1E),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+        ) {
+            // Exercise Name Header
+            Text(
+                text = detailState.exercise.name,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                modifier = Modifier.padding(bottom = 16.dp),
+            )
+            
+            // Exercise Metadata
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 24.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                ExerciseMetadataChip(
+                    label = stringResource(R.string.exercise_detail_equipment),
+                    value = detailState.exercise.equipment.name.lowercase().replaceFirstChar { it.uppercase() },
+                )
+                ExerciseMetadataChip(
+                    label = stringResource(R.string.exercise_detail_muscle_group),
+                    value = detailState.exercise.muscleGroup.displayName,
+                )
+            }
+            
+            // Description with structured sections
+            if (detailState.exercise.description.isNotBlank()) {
+                Text(
+                    text = stringResource(R.string.exercise_detail_description),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+                
+                val sections = parseExerciseDescription(detailState.exercise.description)
+                sections.forEach { (sectionName, content) ->
+                    if (content.isNotBlank()) {
+                        Text(
+                            text = when (sectionName) {
+                                "SETUP" -> stringResource(R.string.exercise_detail_setup)
+                                "EXECUTION" -> stringResource(R.string.exercise_detail_execution)
+                                "TIPS" -> stringResource(R.string.exercise_detail_tips)
+                                else -> sectionName
+                            },
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = AccentCyanStart,
+                            modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+                        )
+                        Text(
+                            text = content.trim(),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White.copy(alpha = 0.85f),
+                        )
+                    }
+                }
+                
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            
+            // YouTube Video Link
+            detailState.exercise.youtubeUrl?.let { url ->
+                val context = androidx.compose.ui.platform.LocalContext.current
+                OutlinedButton(
+                    onClick = {
+                        // Open YouTube URL
+                        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
+                        context.startActivity(intent)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = AccentCyanStart,
+                    ),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.PlayArrow,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.exercise_detail_watch_video))
+                }
+            }
+            
+            // History Section
+            Text(
+                text = stringResource(R.string.exercise_detail_history_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+            
+            when {
+                detailState.isLoadingHistory -> {
+                    Text(
+                        text = stringResource(R.string.exercise_detail_history_loading),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White.copy(alpha = 0.6f),
+                        modifier = Modifier.padding(vertical = 16.dp),
+                    )
+                }
+                detailState.history.isEmpty() -> {
+                    Text(
+                        text = stringResource(R.string.exercise_detail_history_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White.copy(alpha = 0.6f),
+                        modifier = Modifier.padding(vertical = 16.dp),
+                    )
+                }
+                else -> {
+                    detailState.history.forEach { session ->
+                        HistorySessionCard(
+                            session = session,
+                            weightUnit = defaultWeightUnit,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                    }
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun ExerciseMetadataChip(label: String, value: String) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White.copy(alpha = 0.6f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = Color.White,
+        )
+    }
+}
+
+@Composable
+private fun HistorySessionCard(
+    session: ExerciseHistorySessionUi,
+    weightUnit: UserPreferences.WeightUnit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = Color.White.copy(alpha = 0.05f),
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Text(
+            text = session.date,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = AccentGreenStart,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+        
+        session.sets.forEachIndexed { index, set ->
+            val weight = if (weightUnit == UserPreferences.WeightUnit.LBS) {
+                set.weight * 2.20462
+            } else {
+                set.weight
+            }
+            
+            val setInfo = if (set.rpe != null) {
+                stringResource(
+                    R.string.exercise_detail_set_format_with_rpe,
+                    set.reps,
+                    weight,
+                    set.rpe
+                )
+            } else {
+                stringResource(
+                    R.string.exercise_detail_set_format,
+                    set.reps,
+                    weight
+                )
+            }
+            
+            Text(
+                text = "Set ${index + 1}: $setInfo",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.White.copy(alpha = 0.85f),
+                modifier = Modifier.padding(vertical = 2.dp),
+            )
+        }
+    }
+}
+
+private fun parseExerciseDescription(description: String): List<Pair<String, String>> {
+    val sections = mutableListOf<Pair<String, String>>()
+    val sectionPattern = "##(\\w+)##".toRegex()
+    
+    val matches = sectionPattern.findAll(description).toList()
+    
+    if (matches.isEmpty()) {
+        // No structured format, return the whole description as-is
+        return listOf("" to description)
+    }
+    
+    matches.forEachIndexed { index, match ->
+        val sectionName = match.groupValues[1]
+        val startIndex = match.range.last + 1
+        val endIndex = if (index < matches.size - 1) {
+            matches[index + 1].range.first
+        } else {
+            description.length
+        }
+        
+        val content = description.substring(startIndex, endIndex).trim()
+        sections.add(sectionName to content)
+    }
+    
+    return sections
+}
+

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -222,6 +222,8 @@ class ActiveWorkoutViewModel @Inject constructor(
             is ActiveWorkoutEvent.ToggleExerciseSelection -> toggleExerciseSelection(event.exerciseIndex)
             is ActiveWorkoutEvent.CreateSuperset -> createSuperset()
             is ActiveWorkoutEvent.UnlinkSuperset -> unlinkSuperset(event.groupId)
+            is ActiveWorkoutEvent.ShowExerciseDetail -> showExerciseDetail(event.exercise)
+            is ActiveWorkoutEvent.DismissExerciseDetail -> _state.update { it.copy(exerciseDetailSheet = null) }
         }
     }
     
@@ -258,6 +260,37 @@ class ActiveWorkoutViewModel @Inject constructor(
             val newGroups = current.supersetGroups.toMutableMap()
             newGroups.remove(groupId)
             current.copy(supersetGroups = newGroups)
+        }
+    }
+
+    private fun showExerciseDetail(exercise: Exercise) {
+        safeLaunch {
+            _state.update { it.copy(exerciseDetailSheet = ExerciseDetailSheetState(exercise = exercise, isLoadingHistory = true)) }
+            
+            val history = workoutRepository.getExerciseHistory(exercise.id.toString(), limit = 10)
+            
+            val historyUi = history.map { session ->
+                val formatter = java.time.format.DateTimeFormatter.ofPattern("MMM d, yyyy")
+                ExerciseHistorySessionUi(
+                    date = session.workoutDate.atZone(java.time.ZoneId.systemDefault()).format(formatter),
+                    sets = session.sets.map { set ->
+                        ExerciseHistorySetUi(
+                            weight = set.weightKg,
+                            reps = set.reps,
+                            rpe = set.rpe,
+                        )
+                    }
+                )
+            }
+            
+            _state.update { 
+                it.copy(
+                    exerciseDetailSheet = it.exerciseDetailSheet?.copy(
+                        history = historyUi,
+                        isLoadingHistory = false,
+                    )
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## What
During active workout, tapping an exercise name opens a bottom sheet showing:
1. Exercise description/instructions (parsed with ##SETUP##/##EXECUTION##/##TIPS## sections)
2. Equipment needed
3. Historical weight progression (last 5-10 sessions)
4. YouTube link button if video available

## Why
Users need to check form cues mid-workout AND see what they lifted last time. This is fundamental gym app UX — 'what did I lift last time?'

## Changes
- Made exercise name clickable in ActiveWorkoutScreen
- Added ModalBottomSheet with scrollable content
- Added repository query for exercise history
- Bilingual strings (EN + ES)
- Touch targets 56dp minimum

## Testing
- ✅ Build passes: \.\gradlew.bat :app:assembleDebug\
- Manually test: tap exercise name during workout → bottom sheet appears
- Verify: history shows previous weights, description sections render correctly
- Verify: YouTube button opens video if URL present