### PR TITLE
Fix Profile navigation structure (issue #526)

### DIFF
--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -440,6 +440,8 @@
     <string name="profile_sign_in_label">Iniciar sesión</string>
     <string name="profile_sign_in_subtitle_alt">Guarda tus datos en la nube</string>
     <string name="profile_preferences">Preferencias</string>
+    <string name="profile_settings">Configuración</string>
+    <string name="profile_settings_subtitle">Personaliza tus preferencias de entrenamiento</string>
     <string name="profile_rest_timer">Temporizador de descanso</string>
     <string name="profile_weight_unit_label">Unidad de peso</string>
     <string name="profile_weight_unit_lbs">lbs</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -434,6 +434,8 @@
     <string name="profile_sign_in_label">Sign in</string>
     <string name="profile_sign_in_subtitle_alt">Save your data to the cloud</string>
     <string name="profile_preferences">Preferences</string>
+    <string name="profile_settings">Settings</string>
+    <string name="profile_settings_subtitle">Customize your workout preferences</string>
     <string name="profile_rest_timer">Rest timer</string>
     <string name="profile_weight_unit_label">Weight unit</string>
     <string name="profile_weight_unit_lbs">lbs</string>

--- a/android/feature/src/main/java/com/gymbro/feature/profile/ProfileScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/profile/ProfileScreen.kt
@@ -227,40 +227,15 @@ internal fun ProfileScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Preferences Group (Cyan Accent)
+        // Settings Group (Cyan Accent)
         SettingsGroup(
-            title = stringResource(R.string.profile_preferences),
+            title = stringResource(R.string.profile_settings),
             accentColor = AccentCyanStart,
         ) {
             SettingItem(
-                icon = Icons.Default.Timer,
-                label = stringResource(R.string.profile_rest_timer),
-                subtitle = stringResource(R.string.profile_rest_timer_default),
-                iconTint = AccentCyanStart,
-                onClick = onNavigateToSettings,
-            )
-            SettingItem(
-                icon = Icons.Default.FitnessCenter,
-                label = stringResource(R.string.profile_weight_unit_label),
-                subtitle = stringResource(R.string.profile_weight_unit_lbs),
-                iconTint = AccentCyanStart,
-                onClick = onNavigateToSettings,
-            )
-            SettingItem(
-                icon = Icons.Default.LocalFireDepartment,
-                label = stringResource(R.string.profile_training_phase),
-                iconTint = AccentCyanStart,
-                onClick = onNavigateToSettings,
-            )
-            SettingItem(
-                icon = Icons.Default.Notifications,
-                label = stringResource(R.string.profile_notifications),
-                iconTint = AccentCyanStart,
-                onClick = onNavigateToSettings,
-            )
-            SettingItem(
-                icon = Icons.Default.MonitorHeart,
-                label = stringResource(R.string.profile_health_integration),
+                icon = Icons.Default.Settings,
+                label = stringResource(R.string.profile_settings),
+                subtitle = stringResource(R.string.profile_settings_subtitle),
                 iconTint = AccentCyanStart,
                 onClick = onNavigateToSettings,
             )
@@ -316,26 +291,7 @@ internal fun ProfileScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Data Group (Amber Accent)
-        SettingsGroup(
-            title = stringResource(R.string.profile_data_section),
-            accentColor = AccentAmberStart,
-        ) {
-            SettingItem(
-                icon = Icons.Default.Storage,
-                label = stringResource(R.string.profile_export_data),
-                iconTint = AccentAmberStart,
-                onClick = onNavigateToSettings,
-            )
-            SettingItem(
-                icon = Icons.Default.Delete,
-                label = stringResource(R.string.profile_clear_all_data),
-                iconTint = AccentRed,
-                onClick = onNavigateToSettings,
-            )
-        }
 
-        Spacer(modifier = Modifier.height(16.dp))
 
         // About Group (White Accent)
         SettingsGroup(


### PR DESCRIPTION
Closes #526

## Summary
Fixed confusing Profile navigation where multiple menu items all routed to the same Settings screen.

## Problem
Users reported that navigating the Profile tab was confusing — clicking on different-sounding options like 'Rest Timer', 'Weight Unit', 'Training Phase', 'Notifications', 'Health Integration', 'Export Data', and 'Clear Data' all led to the same Settings/Configuration screen.

## Solution
Consolidated 7 Settings-bound menu items into a single 'Settings' menu item with subtitle 'Customize your workout preferences'. Now each Profile menu item leads to a distinct destination:
- Talk to Coach → Coach screen
- Progress → Progress screen  
- Analytics → Analytics screen
- Exercise Library → Exercise Library screen
- Tools → Tools screen
- Recovery → Recovery screen
- Settings → Settings screen (consolidated)

The individual preference options are still accessible within the Settings screen.

## Changes
- Replaced Preferences section (5 items) and Data section (2 items) with single Settings item
- Added bilingual strings (EN/ES): profile_settings and profile_settings_subtitle
- Removed 49 lines, added 9 lines — cleaner, clearer navigation structure

## Testing
- Build verified: assembleDebug passes successfully
- No unintended file deletions
- All navigation routes properly wired in GymBroNavGraph.kt

Working as Trinity (Mobile Developer)