### PR TITLE
fix: QA Batch 3 data persistence + UX bugs

### DIFF
--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -1139,6 +1139,149 @@ if highSeverityTriggers >= 2:
 else if highSeverityTriggers == 1:
     state = .overreaching  // Deload recommended
     urgency = .recommended
+
+---
+
+## 2026-04-14T10-14: Session Retrospective — Quality Gate Failure
+
+**Reporter:** Copilot (via Copilot)  
+**Date:** 2026-04-14  
+**Status:** Lesson Learned  
+
+**Issue:** Features #548-#553 were compiled and merged but NOT verified in the emulator. Quality gate failed:
+1. Superseries: UI not discoverable
+2. Home full exercise list + swap day: changes invisible
+3. i18n translations: still showing English
+4. Drag & drop: only arrow buttons, no drag gesture
+
+**Root Cause:** "Compile = Done" assumption. No verification step before merge.
+
+**Decision:** Enforce verification gate for all future features.
+- Work ONE feature at a time
+- Verify each feature visually in emulator BEFORE moving to next
+- User confirmation required before closing issue
+- No merge without visual proof
+
+**Why:** Prevent repeating this pattern. Quality is not byte-counted; it's verified.
+
+---
+
+## 2026-04-14: Exercise Selection and Validation Logic — Neo
+
+**Author:** Neo (AI/ML Engineer)  
+**Date:** 2026-04-14  
+**Issues:** #558, #560, #562  
+**PR:** #564
+
+### Exercise Suitability Filtering (#558)
+
+**Problem:** AI plan generator selected inappropriate exercises — Back Lever, Band Dislocates appeared in hypertrophy plans.
+
+**Decision:** Add generator-side denylist (`UNSUITABLE_FOR_PLANS`) instead of modifying seed data.
+
+**Rationale:**
+- Exercises ARE valid for library (users CAN manually add them)
+- Just inappropriate for AI-generated plans
+- Denylist keeps seed data clean
+- Allows future per-goal filtering
+
+**Implementation:**
+```kotlin
+private val UNSUITABLE_FOR_PLANS = setOf(
+    "Back Lever", "Front Lever", "Planche",  // Gymnastics skills
+    "Handstand Push-Up", "Muscle-Up",         // Advanced calisthenics
+    "Band Dislocate", "Band Pull-Apart"       // Warmup/mobility
+)
+```
+
+### Bodyweight Exercise Default Weight (#560)
+
+**Problem:** Users had to enter weight for Pull-Up, Push-Up, Dip.
+
+**Decision:** Check BOTH equipment tag AND exercise name pattern. Default to 0kg for true unloaded bodyweight.
+
+**Implementation:**
+```kotlin
+private fun isTrueBodyweightExercise(exercise: Exercise): Boolean {
+    val bodyweightNames = setOf(
+        "Pull-Up", "Chin-Up", "Push-Up", "Dip", 
+        "Sit-Up", "Crunch", "Plank", "Jumping Jack", 
+        "Burpee", "Mountain Climber", "Air Squat"
+    )
+    return exercise.equipment == Equipment.BODYWEIGHT 
+        && bodyweightNames.any { exercise.name.contains(it, ignoreCase = true) }
+        && !exercise.name.contains("Weighted", ignoreCase = true)
+}
+```
+
+### Weight Sanity Validation (#562)
+
+**Problem:** No plausibility check — 250kg Dumbbell Farmer's March accepted.
+
+**Decision:** Soft warning (confirmation dialog), not hard reject. Category-based limits.
+
+**Thresholds:**
+- COMPOUND: 300kg
+- ISOLATION: 100kg
+- ACCESSORY: 60kg
+- CARDIO: 40kg
+
+**Rationale:** Elite powerlifters DO squat >300kg. Category-based is more accurate than global limits.
+
+---
+
+## 2026-04-14: Localization Fixes — Trinity
+
+**Author:** Trinity (Mobile Dev)  
+**Date:** 2026-04-14  
+**Issues:** #559, #561  
+**PR:** #565
+
+### Plural Grammar (#559)
+
+**Problem:** Spanish showed "1 semanas", "1 ejercicios" (incorrect plurals).
+
+**Decision:** Use Android `<plurals>` resources for language-aware quantity handling.
+
+**Applied to:** exercises_count, weeks_count, sets_count, home_plateau_stagnation, home_plateau_regression.
+
+### Template Localization (#561)
+
+**Problem:** Workout template names/descriptions hardcoded in English in `WorkoutTemplateRepositoryImpl.kt`.
+
+**Decision:** Inject Context, use string resources for all 11 built-in templates (EN + ES).
+
+**Migration:** Existing users keep English templates. New users/cleared data get localized templates. No migration needed.
+
+---
+
+## 2026-04-14: Edit Past Workout Data — Tank
+
+**Author:** Tank (Backend Dev)  
+**Date:** 2026-04-14  
+**Issue:** #563  
+**PR:** #566
+
+### Architecture
+
+**Data Flow:**
+User taps set → EditSetDialog → User edits → onSave callback → UpdateSet intent → ViewModel.updateSet() → Repository.updateSet() → Room DB update (REPLACE) → Auto-reload → UI refreshes
+
+**Features:**
+- ✅ Offline-first (Room DB only)
+- ✅ Preserves metadata (exerciseId, workoutId, completedAt, isWarmup)
+- ✅ Updates only weight, reps, RPE
+- ✅ Respects weight unit preference
+- ⚠️ No undo (future enhancement)
+- ⚠️ No input validation (future enhancement)
+
+### Testing Checklist
+1. Edit set, verify volume recalculates
+2. Edit PRs, verify badges update
+3. Offline editing (airplane mode)
+4. kg vs lb unit preference
+5. Warmup vs working sets
+6. Cancel dialog (no changes saved)
 else if moderateTriggers > 0:
     state = .overreaching
     urgency = .recommended

--- a/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
+++ b/android/core/src/main/java/com/gymbro/core/preferences/UserPreferences.kt
@@ -40,6 +40,7 @@ class UserPreferences @Inject constructor(
         val MANUAL_MUSCLE_SORENESS = intPreferencesKey("manual_muscle_soreness")
         val MANUAL_ENERGY_LEVEL = intPreferencesKey("manual_energy_level")
         val THEME_PREFERENCE = stringPreferencesKey("theme_preference")
+        val ACTIVE_PLAN_JSON = stringPreferencesKey("active_plan_json")
     }
 
     enum class WeightUnit {
@@ -199,6 +200,20 @@ class UserPreferences @Inject constructor(
     suspend fun setThemePreference(theme: ThemePreference) {
         dataStore.edit { preferences ->
             preferences[THEME_PREFERENCE] = theme.name
+        }
+    }
+
+    val activePlanJson: Flow<String?> = dataStore.data.map { preferences ->
+        preferences[ACTIVE_PLAN_JSON]
+    }
+
+    suspend fun setActivePlanJson(json: String?) {
+        dataStore.edit { preferences ->
+            if (json != null) {
+                preferences[ACTIVE_PLAN_JSON] = json
+            } else {
+                preferences.remove(ACTIVE_PLAN_JSON)
+            }
         }
     }
 

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepository.kt
@@ -25,6 +25,7 @@ interface WorkoutRepository {
     suspend fun saveInProgressWorkout(inProgressWorkout: com.gymbro.core.model.InProgressWorkout)
     suspend fun getInProgressWorkout(): com.gymbro.core.model.InProgressWorkout?
     suspend fun clearInProgressWorkout(workoutId: String)
+    suspend fun clearAllInProgressWorkouts()
     
     suspend fun getTotalCompletedWorkoutsCount(): Int
     suspend fun getActiveDaysCount(): Int

--- a/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
+++ b/android/core/src/main/java/com/gymbro/core/repository/WorkoutRepositoryImpl.kt
@@ -327,6 +327,18 @@ class WorkoutRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun clearAllInProgressWorkouts() {
+        val result = retryWithBackoff {
+            runCatchingAsResult { workoutDao.clearAllInProgressWorkouts() }
+        }
+        when (result) {
+            is AppResult.Success -> Unit
+            is AppResult.Error -> {
+                Log.e(TAG, "Failed to clear all in-progress workouts: ${result.error.message}")
+            }
+        }
+    }
+
     override suspend fun getTotalCompletedWorkoutsCount(): Int {
         val result = retryWithBackoff {
             runCatchingAsResult { workoutDao.getTotalCompletedWorkoutsCount() }

--- a/android/core/src/main/java/com/gymbro/core/service/ActivePlanStore.kt
+++ b/android/core/src/main/java/com/gymbro/core/service/ActivePlanStore.kt
@@ -1,20 +1,34 @@
 package com.gymbro.core.service
 
+import android.util.Log
+import com.google.gson.Gson
 import com.gymbro.core.model.WorkoutDay
 import com.gymbro.core.model.WorkoutPlan
+import com.gymbro.core.preferences.UserPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * In-memory store for the currently active workout plan.
+ * Store for the currently active workout plan.
+ * Persisted to DataStore so the plan survives app restarts (BUG-001 fix).
  * Shared between ProgramsViewModel (writes) and PlanDayDetailViewModel (reads)
  * so plan data survives navigation between composable destinations.
  */
 @Singleton
-class ActivePlanStore @Inject constructor() {
+class ActivePlanStore @Inject constructor(
+    private val userPreferences: UserPreferences,
+    private val gson: Gson,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val _activePlan = MutableStateFlow<WorkoutPlan?>(null)
     val activePlan: StateFlow<WorkoutPlan?> = _activePlan.asStateFlow()
@@ -25,13 +39,29 @@ class ActivePlanStore @Inject constructor() {
     private val _pendingWorkoutDay = MutableStateFlow<WorkoutDay?>(null)
     val pendingWorkoutDay: StateFlow<WorkoutDay?> = _pendingWorkoutDay.asStateFlow()
 
+    init {
+        scope.launch {
+            try {
+                val json = userPreferences.activePlanJson.firstOrNull()
+                if (json != null) {
+                    val plan = gson.fromJson(json, WorkoutPlan::class.java)
+                    _activePlan.value = plan
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to restore active plan from DataStore", e)
+            }
+        }
+    }
+
     fun setPlan(plan: WorkoutPlan?) {
         _activePlan.value = plan
+        persistPlan(plan)
     }
 
     fun setPlanFromOnboarding(plan: WorkoutPlan) {
         _activePlan.value = plan
         _isFromOnboarding.value = true
+        persistPlan(plan)
     }
 
     fun clearOnboardingFlag() {
@@ -48,5 +78,20 @@ class ActivePlanStore @Inject constructor() {
         val day = _pendingWorkoutDay.value
         _pendingWorkoutDay.value = null
         return day
+    }
+
+    private fun persistPlan(plan: WorkoutPlan?) {
+        scope.launch {
+            try {
+                val json = if (plan != null) gson.toJson(plan) else null
+                userPreferences.setActivePlanJson(json)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to persist active plan to DataStore", e)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "ActivePlanStore"
     }
 }

--- a/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/common/GradientButton.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.gymbro.core.ui.theme.AccentGreenEnd
@@ -34,6 +35,7 @@ fun GradientButton(
     modifier: Modifier = Modifier,
     gradientColors: List<Color> = listOf(AccentGreenStart, AccentGreenEnd),
     enabled: Boolean = true,
+    testTag: String? = null,
 ) {
     val haptic = LocalHapticFeedback.current
     var isPressed by remember { mutableStateOf(false) }
@@ -62,7 +64,7 @@ fun GradientButton(
                 haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                 onClick()
             },
-            modifier = Modifier,
+            modifier = if (testTag != null) Modifier.testTag(testTag) else Modifier,
             enabled = enabled,
             shape = RoundedCornerShape(12.dp),
             colors = ButtonDefaults.buttonColors(

--- a/android/feature/src/main/java/com/gymbro/feature/history/HistoryListScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/history/HistoryListScreen.kt
@@ -97,6 +97,18 @@ fun HistoryListRoute(
     }
     val weightUnit = userPreferences.weightUnit.collectAsStateWithLifecycle(initialValue = UserPreferences.WeightUnit.KG)
 
+    // BUG-003 fix: Reload history when screen regains focus (e.g., after completing a workout)
+    val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                viewModel.onIntent(HistoryListIntent.LoadHistory)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(

--- a/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/onboarding/OnboardingScreen.kt
@@ -426,8 +426,8 @@ private fun GetStartedPage(
             enabled = !isGeneratingPlan,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp)
-                .testTag("onboarding_start"),
+                .height(56.dp),
+            testTag = "onboarding_start",
         )
     }
 }

--- a/android/feature/src/main/java/com/gymbro/feature/profile/ProfileContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/profile/ProfileContract.kt
@@ -20,6 +20,7 @@ sealed interface ProfileEvent {
     data object SignIn : ProfileEvent
     data object SignOut : ProfileEvent
     data object SyncNow : ProfileEvent
+    data object Refresh : ProfileEvent
     data class ToggleAutoSync(val enabled: Boolean) : ProfileEvent
 }
 

--- a/android/feature/src/main/java/com/gymbro/feature/profile/ProfileScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/profile/ProfileScreen.kt
@@ -97,6 +97,18 @@ fun ProfileRoute(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    // BUG-003 fix: Reload stats when profile tab regains focus
+    val lifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                viewModel.onEvent(ProfileEvent.Refresh)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.effects.collect { effect ->
             when (effect) {

--- a/android/feature/src/main/java/com/gymbro/feature/profile/ProfileViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/profile/ProfileViewModel.kt
@@ -45,6 +45,7 @@ class ProfileViewModel @Inject constructor(
             is ProfileEvent.SignOut -> signOut()
             is ProfileEvent.SyncNow -> syncNow()
             is ProfileEvent.ToggleAutoSync -> toggleAutoSync(event.enabled)
+            is ProfileEvent.Refresh -> loadWorkoutStats()
         }
     }
 

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -169,18 +169,10 @@ class ActiveWorkoutViewModel @Inject constructor(
                     )
                 }
             }
-            // Auto-create superset groups from plan's supersetGroupId
-            val supersetMap = mutableMapOf<String, MutableList<Int>>()
-            pendingDay.exercises.forEachIndexed { index, planned ->
-                val groupId = planned.supersetGroupId ?: return@forEachIndexed
-                supersetMap.getOrPut(groupId) { mutableListOf() }.add(index)
-            }
-            val validGroups = supersetMap.filter { it.value.size >= 2 }
-            if (validGroups.isNotEmpty()) {
-                _state.update { current ->
-                    current.copy(supersetGroups = validGroups)
-                }
-            }
+            // BUG-007 fix: Don't auto-create superset groups from plan data.
+            // Users should manually group exercises during the workout via the
+            // superset selection UI. Auto-grouping was confusing because it showed
+            // "Superserie" labels on exercises users never explicitly grouped.
         }
     }
 
@@ -868,10 +860,8 @@ class ActiveWorkoutViewModel @Inject constructor(
                 }
             }
         ) {
-            val inProgress = workoutRepository.getInProgressWorkout()
-            if (inProgress != null) {
-                workoutRepository.clearInProgressWorkout(inProgress.workoutId)
-            }
+            // BUG-004 fix: Clear ALL stale in-progress data, not just one entry
+            workoutRepository.clearAllInProgressWorkouts()
             startWorkout()
         }
     }


### PR DESCRIPTION
Fixes 5 bugs from QA Batch 3 (Carlos persona). Build passes, zero new dependencies.

BUG-001 (P0): Plan persists across restarts via DataStore JSON.
BUG-003 (P1): History/Profile reload on ON_RESUME.
BUG-002 (P1): testTag moved to clickable Button in GradientButton.
BUG-004 (P2): clearAllInProgressWorkouts wipes stale entries.
BUG-007 (P3): Auto-superset grouping removed.

11 files changed. Needs QA retest.
