### PR TITLE
fix: wire up weight sanity check dialog (BUG-005)

### DIFF
--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -1139,6 +1139,149 @@ if highSeverityTriggers >= 2:
 else if highSeverityTriggers == 1:
     state = .overreaching  // Deload recommended
     urgency = .recommended
+
+---
+
+## 2026-04-14T10-14: Session Retrospective — Quality Gate Failure
+
+**Reporter:** Copilot (via Copilot)  
+**Date:** 2026-04-14  
+**Status:** Lesson Learned  
+
+**Issue:** Features #548-#553 were compiled and merged but NOT verified in the emulator. Quality gate failed:
+1. Superseries: UI not discoverable
+2. Home full exercise list + swap day: changes invisible
+3. i18n translations: still showing English
+4. Drag & drop: only arrow buttons, no drag gesture
+
+**Root Cause:** "Compile = Done" assumption. No verification step before merge.
+
+**Decision:** Enforce verification gate for all future features.
+- Work ONE feature at a time
+- Verify each feature visually in emulator BEFORE moving to next
+- User confirmation required before closing issue
+- No merge without visual proof
+
+**Why:** Prevent repeating this pattern. Quality is not byte-counted; it's verified.
+
+---
+
+## 2026-04-14: Exercise Selection and Validation Logic — Neo
+
+**Author:** Neo (AI/ML Engineer)  
+**Date:** 2026-04-14  
+**Issues:** #558, #560, #562  
+**PR:** #564
+
+### Exercise Suitability Filtering (#558)
+
+**Problem:** AI plan generator selected inappropriate exercises — Back Lever, Band Dislocates appeared in hypertrophy plans.
+
+**Decision:** Add generator-side denylist (`UNSUITABLE_FOR_PLANS`) instead of modifying seed data.
+
+**Rationale:**
+- Exercises ARE valid for library (users CAN manually add them)
+- Just inappropriate for AI-generated plans
+- Denylist keeps seed data clean
+- Allows future per-goal filtering
+
+**Implementation:**
+```kotlin
+private val UNSUITABLE_FOR_PLANS = setOf(
+    "Back Lever", "Front Lever", "Planche",  // Gymnastics skills
+    "Handstand Push-Up", "Muscle-Up",         // Advanced calisthenics
+    "Band Dislocate", "Band Pull-Apart"       // Warmup/mobility
+)
+```
+
+### Bodyweight Exercise Default Weight (#560)
+
+**Problem:** Users had to enter weight for Pull-Up, Push-Up, Dip.
+
+**Decision:** Check BOTH equipment tag AND exercise name pattern. Default to 0kg for true unloaded bodyweight.
+
+**Implementation:**
+```kotlin
+private fun isTrueBodyweightExercise(exercise: Exercise): Boolean {
+    val bodyweightNames = setOf(
+        "Pull-Up", "Chin-Up", "Push-Up", "Dip", 
+        "Sit-Up", "Crunch", "Plank", "Jumping Jack", 
+        "Burpee", "Mountain Climber", "Air Squat"
+    )
+    return exercise.equipment == Equipment.BODYWEIGHT 
+        && bodyweightNames.any { exercise.name.contains(it, ignoreCase = true) }
+        && !exercise.name.contains("Weighted", ignoreCase = true)
+}
+```
+
+### Weight Sanity Validation (#562)
+
+**Problem:** No plausibility check — 250kg Dumbbell Farmer's March accepted.
+
+**Decision:** Soft warning (confirmation dialog), not hard reject. Category-based limits.
+
+**Thresholds:**
+- COMPOUND: 300kg
+- ISOLATION: 100kg
+- ACCESSORY: 60kg
+- CARDIO: 40kg
+
+**Rationale:** Elite powerlifters DO squat >300kg. Category-based is more accurate than global limits.
+
+---
+
+## 2026-04-14: Localization Fixes — Trinity
+
+**Author:** Trinity (Mobile Dev)  
+**Date:** 2026-04-14  
+**Issues:** #559, #561  
+**PR:** #565
+
+### Plural Grammar (#559)
+
+**Problem:** Spanish showed "1 semanas", "1 ejercicios" (incorrect plurals).
+
+**Decision:** Use Android `<plurals>` resources for language-aware quantity handling.
+
+**Applied to:** exercises_count, weeks_count, sets_count, home_plateau_stagnation, home_plateau_regression.
+
+### Template Localization (#561)
+
+**Problem:** Workout template names/descriptions hardcoded in English in `WorkoutTemplateRepositoryImpl.kt`.
+
+**Decision:** Inject Context, use string resources for all 11 built-in templates (EN + ES).
+
+**Migration:** Existing users keep English templates. New users/cleared data get localized templates. No migration needed.
+
+---
+
+## 2026-04-14: Edit Past Workout Data — Tank
+
+**Author:** Tank (Backend Dev)  
+**Date:** 2026-04-14  
+**Issue:** #563  
+**PR:** #566
+
+### Architecture
+
+**Data Flow:**
+User taps set → EditSetDialog → User edits → onSave callback → UpdateSet intent → ViewModel.updateSet() → Repository.updateSet() → Room DB update (REPLACE) → Auto-reload → UI refreshes
+
+**Features:**
+- ✅ Offline-first (Room DB only)
+- ✅ Preserves metadata (exerciseId, workoutId, completedAt, isWarmup)
+- ✅ Updates only weight, reps, RPE
+- ✅ Respects weight unit preference
+- ⚠️ No undo (future enhancement)
+- ⚠️ No input validation (future enhancement)
+
+### Testing Checklist
+1. Edit set, verify volume recalculates
+2. Edit PRs, verify badges update
+3. Offline editing (airplane mode)
+4. kg vs lb unit preference
+5. Warmup vs working sets
+6. Cancel dialog (no changes saved)
 else if moderateTriggers > 0:
     state = .overreaching
     urgency = .recommended

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -26,6 +26,7 @@ data class ActiveWorkoutState(
     val prCelebration: PrCelebrationUi? = null,
     val replacingExerciseIndex: Int? = null,
     val targetDurationMinutes: Int = 60,
+    val weightWarning: WeightWarningState? = null,
 )
 
 data class ExerciseDetailSheetState(
@@ -75,6 +76,14 @@ data class PrCelebrationUi(
     val previousValue: String?,
 )
 
+data class WeightWarningState(
+    val exerciseIndex: Int,
+    val setIndex: Int,
+    val weight: Double,
+    val exerciseName: String,
+    val maxPlausible: Int,
+)
+
 data class WorkoutSetUi(
     val id: String,
     val setNumber: Int,
@@ -116,6 +125,8 @@ sealed interface ActiveWorkoutEvent {
     data class ShowExerciseDetail(val exercise: Exercise) : ActiveWorkoutEvent
     data object DismissExerciseDetail : ActiveWorkoutEvent
     data object DismissPrCelebration : ActiveWorkoutEvent
+    data object ConfirmWeightWarning : ActiveWorkoutEvent
+    data object DismissWeightWarning : ActiveWorkoutEvent
     data class SetTargetDuration(val minutes: Int) : ActiveWorkoutEvent
     data class MoveExerciseUp(val exerciseIndex: Int) : ActiveWorkoutEvent
     data class MoveExerciseDown(val exerciseIndex: Int) : ActiveWorkoutEvent

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -363,6 +363,31 @@ fun ActiveWorkoutScreen(
                 },
             )
         }
+
+        // Issue #562: Weight sanity check confirmation dialog
+        val weightWarning = state.weightWarning
+        if (weightWarning != null) {
+            AlertDialog(
+                onDismissRequest = { onEvent(ActiveWorkoutEvent.DismissWeightWarning) },
+                title = { Text("⚠️ Peso inusual") },
+                text = {
+                    Text(
+                        "El peso ingresado (${weightWarning.weight.toInt()}kg) parece inusual para ${weightWarning.exerciseName}. " +
+                        "Máximo típico: ${weightWarning.maxPlausible}kg. ¿Continuar?"
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = { onEvent(ActiveWorkoutEvent.ConfirmWeightWarning) }) {
+                        Text("Sí")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { onEvent(ActiveWorkoutEvent.DismissWeightWarning) }) {
+                        Text("No")
+                    }
+                },
+            )
+        }
         
         Scaffold(
         topBar = {

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -254,6 +254,8 @@ class ActiveWorkoutViewModel @Inject constructor(
             is ActiveWorkoutEvent.ShowExerciseDetail -> showExerciseDetail(event.exercise)
             is ActiveWorkoutEvent.DismissExerciseDetail -> _state.update { it.copy(exerciseDetailSheet = null) }
             is ActiveWorkoutEvent.DismissPrCelebration -> _state.update { it.copy(prCelebration = null) }
+            is ActiveWorkoutEvent.ConfirmWeightWarning -> confirmWeightWarning()
+            is ActiveWorkoutEvent.DismissWeightWarning -> _state.update { it.copy(weightWarning = null) }
             is ActiveWorkoutEvent.SetTargetDuration -> adjustExercisesForDuration(event.minutes)
             is ActiveWorkoutEvent.MoveExerciseUp -> moveExercise(event.exerciseIndex, event.exerciseIndex - 1)
             is ActiveWorkoutEvent.MoveExerciseDown -> moveExercise(event.exerciseIndex, event.exerciseIndex + 1)
@@ -491,14 +493,63 @@ class ActiveWorkoutViewModel @Inject constructor(
         }
 
         // Issue #562: Soft validation warning for implausible weights
-        // Don't reject, just warn — user may legitimately be logging exceptional lifts
+        // Show confirmation dialog — user may legitimately be logging exceptional lifts
         val maxPlausible = getPlausibleMaxWeight(exerciseUi.exercise.category)
         if (weightKg > maxPlausible && !setUi.isWarmup) {
-            _state.update { 
-                it.copy(errorMessage = "⚠️ ${weightKg}kg seems high for ${exerciseUi.exercise.name} (${exerciseUi.exercise.category.displayName}). Typical max: ${maxPlausible.toInt()}kg. Double-check before continuing.")
+            _state.update {
+                it.copy(weightWarning = WeightWarningState(
+                    exerciseIndex = exerciseIndex,
+                    setIndex = setIndex,
+                    weight = weightKg,
+                    exerciseName = exerciseUi.exercise.name,
+                    maxPlausible = maxPlausible.toInt(),
+                ))
             }
             return
         }
+
+        saveCompletedSet(exerciseIndex, setIndex, weightKg, reps, weightInput)
+    }
+
+    /**
+     * Issue #562: Confirms a weight warning and proceeds to save the set.
+     */
+    private fun confirmWeightWarning() {
+        val warning = _state.value.weightWarning ?: return
+        _state.update { it.copy(weightWarning = null) }
+
+        val currentState = _state.value
+        val exercises = currentState.exercises
+        if (warning.exerciseIndex !in exercises.indices) return
+        val exerciseUi = exercises[warning.exerciseIndex]
+        if (warning.setIndex !in exerciseUi.sets.indices) return
+        val setUi = exerciseUi.sets[warning.setIndex]
+        if (setUi.isCompleted) return
+
+        val weightInput = setUi.weight.ifBlank { warning.weight.toString() }
+        val reps = setUi.reps.toIntOrNull() ?: return
+
+        saveCompletedSet(warning.exerciseIndex, warning.setIndex, warning.weight, reps, weightInput)
+    }
+
+    /**
+     * Persists a completed set to the repository and triggers post-save actions
+     * (carry-forward, PR check, auto-add, rest timer).
+     */
+    private fun saveCompletedSet(
+        exerciseIndex: Int,
+        setIndex: Int,
+        weightKg: Double,
+        reps: Int,
+        weightInput: String,
+    ) {
+        val currentState = _state.value
+        val workoutId = currentState.workoutId ?: return
+        val exercises = currentState.exercises
+        if (exerciseIndex !in exercises.indices) return
+        val exerciseUi = exercises[exerciseIndex]
+        if (setIndex !in exerciseUi.sets.indices) return
+        val setUi = exerciseUi.sets[setIndex]
 
         safeLaunch(
             onError = { error ->


### PR DESCRIPTION
## BUG-005: Weight warning from PR #564 not working

**Root Cause:** PR #564 added weight category limits and set \rrorMessage\ in the ViewModel, but \ActiveWorkoutScreen\ never consumed \state.errorMessage\ — the warning was dead code. Additionally, the check did a hard \eturn\ with no way for the user to override and save anyway.

**Fix:**
- Added \WeightWarningState\ data class and \weightWarning\ field to \ActiveWorkoutState\
- Added \ConfirmWeightWarning\ / \DismissWeightWarning\ events
- Replaced the dead \rrorMessage\ + \eturn\ with a proper confirmation dialog
- Dialog: *El peso ingresado ({weight}kg) parece inusual para {exercise}. ¿Continuar?* with Sí/No
- Confirming saves the set normally; dismissing keeps the set open for correction
- Extracted \saveCompletedSet()\ so both normal and force-confirmed paths share save logic

**Limits preserved:** compound >300kg, isolation >100kg, accessory >60kg, cardio >40kg

Closes BUG-005