### PR TITLE
fix: duration chip fixes — remove from active workout, make home interactive

### DIFF
--- a/android/core/src/main/res/values-es/strings.xml
+++ b/android/core/src/main/res/values-es/strings.xml
@@ -1006,6 +1006,8 @@
 
     <!-- Home redesign (FitBod-inspired) -->
     <string name="home_estimated_duration">~%d min</string>
+    <string name="home_target_duration" formatted="false">⏱ %dm objetivo</string>
+    <string name="home_adjusting_duration">Ajustando…</string>
     <string name="home_training_type">Tipo</string>
     <string name="home_suggested_weight">Sugerido: %s</string>
     <string name="home_start_workout">Iniciar Entrenamiento</string>

--- a/android/core/src/main/res/values/strings.xml
+++ b/android/core/src/main/res/values/strings.xml
@@ -1000,6 +1000,8 @@
 
     <!-- Home redesign (FitBod-inspired) -->
     <string name="home_estimated_duration">~%d min</string>
+    <string name="home_target_duration" formatted="false">⏱ %dm target</string>
+    <string name="home_adjusting_duration">Adjusting…</string>
     <string name="home_training_type">Training Type</string>
     <string name="home_suggested_weight">Suggested: %s</string>
     <string name="home_start_workout">Start Workout</string>

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeContract.kt
@@ -23,6 +23,8 @@ data class HomeState(
     val showMilestoneCelebration: Boolean = false,
     val milestoneCelebration: MilestoneCelebration? = null,
     val plateauAlerts: List<PlateauAlert> = emptyList(),
+    val targetDurationMinutes: Int = 60,
+    val isAdjustingDuration: Boolean = false,
 )
 
 data class MilestoneCelebration(
@@ -54,6 +56,7 @@ sealed interface HomeEvent {
     data class DismissPlateauAlert(val exerciseId: String) : HomeEvent
     data class OpenCoachForPlateau(val alert: PlateauAlert) : HomeEvent
     data object SwapDay : HomeEvent
+    data class SetTargetDuration(val minutes: Int) : HomeEvent
 }
 
 sealed interface HomeEffect {

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeScreen.kt
@@ -42,7 +42,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -212,10 +215,13 @@ fun HomeScreen(
                         )
                     }
 
-                    // Context Chips
+                    // Context Chips — tappable duration selector
                     item {
                         DurationChip(
                             exercises = state.todayWorkout.exercises,
+                            selectedMinutes = state.targetDurationMinutes,
+                            isAdjusting = state.isAdjustingDuration,
+                            onSelectDuration = { minutes -> onEvent(HomeEvent.SetTargetDuration(minutes)) },
                         )
                     }
 
@@ -356,17 +362,63 @@ private fun WorkoutHeader(
     }
 }
 
-// ─── DurationChip: Estimated workout time based on exercise data ───
+// ─── DurationChip: Interactive duration selector ───
 @Composable
 private fun DurationChip(
     exercises: List<PlannedExercise>,
+    selectedMinutes: Int,
+    isAdjusting: Boolean,
+    onSelectDuration: (Int) -> Unit,
 ) {
-    val estimatedMinutes = remember(exercises) { estimateWorkoutDurationMinutes(exercises) }
-    Row {
-        InfoChip(
-            label = stringResource(R.string.home_estimated_duration, estimatedMinutes),
-            color = AccentCyan,
-        )
+    val durations = listOf(30, 45, 60, 90)
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Main chip — tappable to expand options
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .background(AccentCyan.copy(alpha = 0.15f))
+                .clickable { expanded = !expanded }
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+        ) {
+            Text(
+                text = if (isAdjusting) {
+                    stringResource(R.string.home_adjusting_duration)
+                } else {
+                    stringResource(R.string.home_target_duration, selectedMinutes)
+                },
+                style = MaterialTheme.typography.labelMedium.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                color = AccentCyan,
+            )
+        }
+
+        // Expanded: show alternative duration options
+        if (expanded) {
+            durations.filter { it != selectedMinutes }.forEach { minutes ->
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .clickable {
+                            onSelectDuration(minutes)
+                            expanded = false
+                        }
+                        .padding(horizontal = 10.dp, vertical = 6.dp),
+                ) {
+                    Text(
+                        text = "${minutes}m",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/android/feature/src/main/java/com/gymbro/feature/home/HomeViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/home/HomeViewModel.kt
@@ -2,15 +2,18 @@ package com.gymbro.feature.home
 
 import com.gymbro.core.repository.WorkoutRepository
 import com.gymbro.core.repository.ExerciseRepository
+import com.gymbro.core.preferences.UserPreferences
 import com.gymbro.core.service.ActivePlanStore
 import com.gymbro.core.service.PersonalRecordService
 import com.gymbro.core.service.PlateauDetectionService
+import com.gymbro.core.service.WorkoutPlanGenerator
 import com.gymbro.feature.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import androidx.lifecycle.viewModelScope
@@ -24,6 +27,8 @@ class HomeViewModel @Inject constructor(
     private val personalRecordService: PersonalRecordService,
     private val plateauDetectionService: PlateauDetectionService,
     private val exerciseRepository: ExerciseRepository,
+    private val userPreferences: UserPreferences,
+    private val workoutPlanGenerator: WorkoutPlanGenerator,
 ) : BaseViewModel() {
 
     private val _state = MutableStateFlow(HomeState())
@@ -39,6 +44,7 @@ class HomeViewModel @Inject constructor(
         loadWorkoutStreak()
         loadRecentPR()
         loadPlateauAlerts()
+        loadTargetDuration()
     }
 
     fun onEvent(event: HomeEvent) {
@@ -131,6 +137,9 @@ class HomeViewModel @Inject constructor(
                         todayWorkout = nextWorkout,
                     )
                 }
+            }
+            is HomeEvent.SetTargetDuration -> {
+                adjustWorkoutForDuration(event.minutes)
             }
         }
     }
@@ -350,6 +359,37 @@ class HomeViewModel @Inject constructor(
             _state.update { 
                 it.copy(plateauAlerts = alerts.take(3))
             }
+        }
+    }
+
+    private fun loadTargetDuration() {
+        viewModelScope.launch {
+            val saved = userPreferences.sessionDurationMinutes.firstOrNull() ?: 60
+            _state.update { it.copy(targetDurationMinutes = saved) }
+        }
+    }
+
+    private fun adjustWorkoutForDuration(minutes: Int) {
+        val todayWorkout = _state.value.todayWorkout ?: return
+        _state.update { it.copy(targetDurationMinutes = minutes, isAdjustingDuration = true) }
+
+        safeLaunch(
+            onError = { error ->
+                _state.update { it.copy(isAdjustingDuration = false) }
+                handleError(error) { adjustWorkoutForDuration(minutes) }
+            }
+        ) {
+            userPreferences.setSessionDurationMinutes(minutes)
+
+            val adjusted = workoutPlanGenerator.adjustDayForDuration(todayWorkout, minutes)
+            _state.update {
+                it.copy(
+                    todayWorkout = adjusted,
+                    isAdjustingDuration = false,
+                )
+            }
+            // Update the pending workout day so ActiveWorkout picks up the adjusted plan
+            activePlanStore.setPendingWorkoutDay(adjusted)
         }
     }
 

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutContract.kt
@@ -129,7 +129,6 @@ sealed interface ActiveWorkoutEvent {
     data object DismissPrCelebration : ActiveWorkoutEvent
     data object ConfirmWeightWarning : ActiveWorkoutEvent
     data object DismissWeightWarning : ActiveWorkoutEvent
-    data class SetTargetDuration(val minutes: Int) : ActiveWorkoutEvent
     data class MoveExerciseUp(val exerciseIndex: Int) : ActiveWorkoutEvent
     data class MoveExerciseDown(val exerciseIndex: Int) : ActiveWorkoutEvent
     data class ReorderExercise(val fromIndex: Int, val toIndex: Int) : ActiveWorkoutEvent

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutScreen.kt
@@ -502,15 +502,6 @@ fun ActiveWorkoutScreen(
                     }
                 }
 
-                // Duration target selector (#545)
-                item {
-                    DurationTargetChips(
-                        selectedMinutes = state.targetDurationMinutes,
-                        elapsedSeconds = state.elapsedSeconds,
-                        onSelect = { minutes -> onEvent(ActiveWorkoutEvent.SetTargetDuration(minutes)) },
-                    )
-                }
-
                 // Empty workout guidance
                 if (state.exercises.isEmpty() && !state.isLoading) {
                     item {
@@ -856,108 +847,6 @@ private fun StatItem(label: String, value: String, color: Color) {
             style = MaterialTheme.typography.labelSmall,
             color = Color.White.copy(alpha = 0.6f),
         )
-    }
-}
-
-@Composable
-private fun DurationTargetChips(
-    selectedMinutes: Int,
-    elapsedSeconds: Long,
-    onSelect: (Int) -> Unit,
-) {
-    val durations = listOf(30, 45, 60, 90)
-    var isExpanded by remember { mutableStateOf(true) }
-    val elapsedMinutes = (elapsedSeconds / 60).toInt()
-    val remaining = selectedMinutes - elapsedMinutes
-    val remainingColor = when {
-        remaining <= 0 -> AccentRed
-        remaining <= 10 -> AccentAmberStart
-        else -> AccentGreenStart
-    }
-
-    // Collapsed: single chip showing selected duration + remaining
-    AnimatedVisibility(visible = !isExpanded) {
-        Box(
-            modifier = Modifier
-                .height(32.dp)
-                .clip(RoundedCornerShape(16.dp))
-                .background(AccentGreenStart.copy(alpha = 0.15f))
-                .border(1.dp, AccentGreenStart.copy(alpha = 0.4f), RoundedCornerShape(16.dp))
-                .clickable { isExpanded = true }
-                .padding(horizontal = 14.dp, vertical = 4.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            val remainingText = if (remaining > 0) {
-                stringResource(R.string.active_workout_remaining, remaining)
-            } else {
-                stringResource(R.string.active_workout_overtime)
-            }
-            Text(
-                text = "⏱ ${selectedMinutes}m · $remainingText",
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.Bold,
-                color = if (remaining > 0) AccentGreenStart else AccentRed,
-            )
-        }
-    }
-
-    // Expanded: all duration chips
-    AnimatedVisibility(visible = isExpanded) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Icon(
-                Icons.Default.PlayArrow,
-                contentDescription = null,
-                tint = remainingColor,
-                modifier = Modifier.size(18.dp),
-            )
-            durations.forEach { minutes ->
-                val isSelected = minutes == selectedMinutes
-                Box(
-                    modifier = Modifier
-                        .height(32.dp)
-                        .background(
-                            color = if (isSelected) AccentGreenStart.copy(alpha = 0.2f) else Color.Transparent,
-                            shape = RoundedCornerShape(16.dp),
-                        )
-                        .border(
-                            width = 1.dp,
-                            color = if (isSelected) AccentGreenStart else Color.White.copy(alpha = 0.2f),
-                            shape = RoundedCornerShape(16.dp),
-                        )
-                        .clickable {
-                            onSelect(minutes)
-                            isExpanded = false
-                        }
-                        .padding(horizontal = 12.dp, vertical = 4.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "${minutes}m",
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                        color = if (isSelected) AccentGreenStart else Color.White.copy(alpha = 0.6f),
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.weight(1f))
-            if (remaining > 0) {
-                Text(
-                    text = stringResource(R.string.active_workout_remaining, remaining),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = remainingColor,
-                )
-            } else {
-                Text(
-                    text = stringResource(R.string.active_workout_overtime),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = AccentRed,
-                )
-            }
-        }
     }
 }
 
@@ -1378,36 +1267,7 @@ private fun ExerciseCardContent(
                     .size(18.dp)
                     .clickable { onEvent(ActiveWorkoutEvent.ShowExerciseDetail(exerciseUi.exercise)) },
             )
-            // Voice input — auto-fills the first incomplete set
-            VoiceInputButton(
-                voiceRecognitionService = voiceRecognitionService,
-                defaultWeightUnit = defaultWeightUnit,
-                onVoiceResult = { parsed ->
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    val targetSetIndex = exerciseUi.sets.indexOfFirst { !it.isCompleted }
-                    if (targetSetIndex >= 0) {
-                        val parser = com.gymbro.core.voice.VoiceInputParser()
-                        onEvent(
-                            ActiveWorkoutEvent.VoiceInput(
-                                exerciseIndex = exerciseIndex,
-                                setIndex = targetSetIndex,
-                                weight = parsed.weight.let { w ->
-                                    if (w == w.toLong().toDouble()) w.toLong().toString() else w.toString()
-                                },
-                                reps = parsed.reps.toString(),
-                                rpe = parsed.rpe?.let { r ->
-                                    if (r == r.toLong().toDouble()) r.toLong().toString() else r.toString()
-                                } ?: "",
-                            )
-                        )
-                        voiceToast = parser.formatConfirmation(parsed)
-                    }
-                },
-                onError = { errorMsg ->
-                    voiceToast = errorMsg
-                },
-            )
-            // Superset link button — visible entry point for creating supersets
+            // Superset link button— visible entry point for creating supersets
             if (!isInSuperset) {
                 IconButton(
                     onClick = {

--- a/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
+++ b/android/feature/src/main/java/com/gymbro/feature/workout/ActiveWorkoutViewModel.kt
@@ -12,7 +12,7 @@ import com.gymbro.core.service.ActivePlanStore
 import com.gymbro.core.service.RpeTrendService
 import com.gymbro.core.service.PersonalRecordService
 import com.gymbro.core.service.SmartDefaultsService
-import com.gymbro.core.service.WorkoutPlanGenerator
+
 import com.gymbro.feature.common.BaseViewModel
 import com.gymbro.feature.common.TooltipManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -250,8 +250,7 @@ class ActiveWorkoutViewModel @Inject constructor(
             is ActiveWorkoutEvent.DismissPrCelebration -> _state.update { it.copy(prCelebration = null) }
             is ActiveWorkoutEvent.ConfirmWeightWarning -> confirmWeightWarning()
             is ActiveWorkoutEvent.DismissWeightWarning -> _state.update { it.copy(weightWarning = null) }
-            is ActiveWorkoutEvent.SetTargetDuration -> adjustExercisesForDuration(event.minutes)
-            is ActiveWorkoutEvent.MoveExerciseUp -> moveExercise(event.exerciseIndex, event.exerciseIndex - 1)
+            is ActiveWorkoutEvent.MoveExerciseUp-> moveExercise(event.exerciseIndex, event.exerciseIndex - 1)
             is ActiveWorkoutEvent.MoveExerciseDown -> moveExercise(event.exerciseIndex, event.exerciseIndex + 1)
             is ActiveWorkoutEvent.ReorderExercise -> moveExercise(event.fromIndex, event.toIndex)
         }
@@ -368,32 +367,6 @@ class ActiveWorkoutViewModel @Inject constructor(
             }
             autoSaveState()
         }
-    }
-
-    private fun adjustExercisesForDuration(minutes: Int) {
-        _state.update { current ->
-            val exercises = current.exercises
-            if (exercises.isEmpty()) return@update current.copy(targetDurationMinutes = minutes)
-
-            val budgetSeconds = WorkoutPlanGenerator.workTimeBudgetSeconds(minutes)
-            var accumulated = 0
-            var fitCount = 0
-            for (ex in exercises) {
-                val sets = ex.sets.size.coerceAtLeast(1)
-                val time = WorkoutPlanGenerator.estimateExerciseTimeSeconds(ex.exercise.category, sets)
-                if (accumulated + time > budgetSeconds && fitCount >= WorkoutPlanGenerator.MIN_EXERCISES) break
-                accumulated += time
-                fitCount++
-            }
-            fitCount = fitCount.coerceIn(WorkoutPlanGenerator.MIN_EXERCISES, exercises.size)
-
-            val trimmed = exercises.take(fitCount)
-            current.copy(
-                exercises = trimmed,
-                targetDurationMinutes = minutes,
-            )
-        }
-        autoSaveState()
     }
 
     private fun addSet(exerciseIndex: Int) {


### PR DESCRIPTION
## Changes

### 1. Removed DurationTargetChips from Active Workout
- Removed the 30m/45m/60m/90m chip selector and its confusing overtime indicators
- Removed the \SetTargetDuration\ event and \djustExercisesForDuration()\ which destructively trimmed exercises
- Removed unused \WorkoutPlanGenerator\ import from ActiveWorkoutViewModel

### 2. Removed VoiceInputButton from exercise cards
- Removed \VoiceInputButton\ usage from the exercise card header Row
- Kept the \VoiceInputButton\ composable itself for potential future use

### 3. Made Home screen duration chip interactive
- \DurationChip\ is now tappable — reveals 30/45/60/90 min options
- Selecting a duration calls \WorkoutPlanGenerator.adjustDayForDuration()\ to recalculate exercises
- Duration persists to \UserPreferences.sessionDurationMinutes\
- Added \HomeEvent.SetTargetDuration\ + ViewModel handling with loading state
- Added EN/ES string resources

**Build:** ✅ Compiles clean (only pre-existing warnings)